### PR TITLE
Remove duplicate ToolResultBlock

### DIFF
--- a/packages/core/src/types/toolChat.ts
+++ b/packages/core/src/types/toolChat.ts
@@ -45,9 +45,3 @@ export type ToolDefinition<P = any> = {
   };
   config?: { timeoutMs?: number };
 };
-
-export interface ToolResultBlock {
-  type: 'tool_result';
-  tool_use_id: string;
-  content: string;
-}


### PR DESCRIPTION
## Summary
- remove duplicate `ToolResultBlock` definition in `toolChat.ts`

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node' and 'vitest')*