### PR TITLE
Add tool parsing tests

### DIFF
--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ClaudeChatService } from '../../../../../src/services/chat/providers/claude/ClaudeChatService.ts';
+
+describe('ClaudeChatService parse functions', () => {
+  const API_KEY = 'dummy-key';
+  let service: ClaudeChatService;
+
+  beforeEach(() => {
+    service = new ClaudeChatService(API_KEY);
+  });
+
+  it('parseOneShot should handle tool use and result', () => {
+    const json = {
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'tool_use', id: '1', name: 'my_tool', input: { foo: 1 } },
+        { type: 'tool_result', tool_use_id: '1', content: 'ok' },
+      ],
+    };
+
+    const result = (service as any).parseOneShot(json);
+    expect(result).toEqual({
+      blocks: [
+        { type: 'text', text: 'hello' },
+        { type: 'tool_use', id: '1', name: 'my_tool', input: { foo: 1 } },
+        { type: 'tool_result', tool_use_id: '1', content: 'ok' },
+      ],
+      stop_reason: 'tool_use',
+    });
+  });
+
+  it('parseStream should handle SSE events for tool use and result', async () => {
+    const sse =
+      'data: {"type":"content_block_delta","index":1,"delta":{"text":"hi"}}\n' +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"1","name":"my_tool"}}\n' +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"foo\\":1"}}\n' +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}\n' +
+      'data: {"type":"content_block_stop","index":0}\n' +
+      'data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_result","tool_use_id":"1","content":"ok"}}\n' +
+      'data: [DONE]\n';
+    const res = new Response(sse);
+    const result = await (service as any).parseStream(res, () => {});
+    expect(result).toEqual({
+      blocks: [
+        { type: 'text', text: 'hi' },
+        { type: 'tool_use', id: '1', name: 'my_tool', input: { foo: 1 } },
+        { type: 'tool_result', tool_use_id: '1', content: 'ok' },
+      ],
+      stop_reason: 'tool_use',
+    });
+  });
+});

--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ClaudeChatService } from '../../../../../src/services/chat/providers/claude/ClaudeChatService.ts';
 
 describe('ClaudeChatService parse functions', () => {
-  const API_KEY = 'dummy-key';
+  const TEST_API_KEY = 'test-api-key';
   let service: ClaudeChatService;
 
   beforeEach(() => {
-    service = new ClaudeChatService(API_KEY);
+    service = new ClaudeChatService(TEST_API_KEY);
   });
 
   it('parseOneShot should handle tool use and result', () => {

--- a/packages/core/tests/services/chat/providers/gemini/GeminiChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/gemini/GeminiChatService.test.ts
@@ -348,6 +348,13 @@ describe('GeminiChatService', () => {
 });
 
 describe('GeminiChatService parse helpers', () => {
+  const TEST_API_KEY = 'test-api-key';
+  let service: GeminiChatService;
+
+  beforeEach(() => {
+    service = new GeminiChatService(TEST_API_KEY);
+  });
+
   it('parseOneShot should handle tool use and result', () => {
     const data = {
       candidates: [

--- a/packages/core/tests/services/chat/providers/openai/OpenAIChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/openai/OpenAIChatService.test.ts
@@ -224,7 +224,13 @@ describe('OpenAIChatService', () => {
   });
 });
 
-describe("OpenAIChatService parse helpers", () => {
+describe('OpenAIChatService parse helpers', () => {
+  const TEST_API_KEY = 'test-api-key';
+  let service: OpenAIChatService;
+
+  beforeEach(() => {
+    service = new OpenAIChatService(TEST_API_KEY);
+  });
 
   it('parseOneShot should extract tool calls', () => {
     const data = {


### PR DESCRIPTION
## Summary
- verify ClaudeChatService parsing for one-shot and streaming tool calls
- check OpenAIChatService parsing of tool call results
- test GeminiChatService parsing functions for tool calls and results

## Testing
- `npm test --workspace packages/core --silent` *(fails: Cannot find type definition file for 'node')*
- `npx --yes vitest run -c packages/core/vitest.config.ts` *(fails: request to https://registry.npmjs.org/vitest failed)*