### PR TITLE
Add history content generation example

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -754,6 +754,7 @@ This is the overall integration class, responsible for initializing and coordina
 - `clearChatHistory()` – Clear chat history
 - `updateVoiceService(options)` – Update speech settings
 - `isMemoryEnabled()` – Check if memory functionality is enabled
+- `generateContentFromHistory(prompt)` – Generate new text from the current chat history
 - `offAll()` – Remove all event listeners
 
 ### ChatProcessor
@@ -1255,7 +1256,23 @@ const aiTuberCore = new AITuberOnAirCore({
     // Other memory settings
     summaryPromptTemplate: 'Please summarize the following conversation in under {maxLength} characters, highlighting the key points.',
   },
-});
+  });
+```
+
+### Generating Content from Chat History
+
+```typescript
+// Prepare chat history (if not already recorded)
+aituber.setChatHistory([
+  { role: 'user', content: 'How was the show?' },
+  { role: 'assistant', content: 'It went great!' },
+]);
+
+// Generate new text based on the conversation so far
+const blog = await aituber.generateContentFromHistory(
+  'Write a short blog post summarizing the conversation.'
+);
+console.log(blog);
 ```
 
 ### Synchronized Speech Playback

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -754,7 +754,7 @@ This is the overall integration class, responsible for initializing and coordina
 - `clearChatHistory()` – Clear chat history
 - `updateVoiceService(options)` – Update speech settings
 - `isMemoryEnabled()` – Check if memory functionality is enabled
-- `generateContentFromHistory(prompt)` – Generate new text from the current chat history
+- `generateContentFromHistory(prompt)` – Generate new text from the system prompt and the current chat history
 - `offAll()` – Remove all event listeners
 
 ### ChatProcessor

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -754,7 +754,7 @@ This is the overall integration class, responsible for initializing and coordina
 - `clearChatHistory()` – Clear chat history
 - `updateVoiceService(options)` – Update speech settings
 - `isMemoryEnabled()` – Check if memory functionality is enabled
-- `generateContentFromHistory(prompt)` – Generate new text from the system prompt and the current chat history
+- `generateOneShotContentFromHistory(prompt, messageHistory)` – Generate new content from a system prompt and provided message history (one-shot, no impact on internal chat history)
 - `offAll()` – Remove all event listeners
 
 ### ChatProcessor
@@ -1259,21 +1259,46 @@ const aiTuberCore = new AITuberOnAirCore({
   });
 ```
 
-### Generating Content from Chat History
+### Generating One-Shot Content from Chat History
+
+The `generateOneShotContentFromHistory` method allows you to generate standalone content based on a provided message history without affecting the internal chat history. This is perfect for creating blog posts, reports, summaries, or other content derived from existing conversations.
 
 ```typescript
-// Prepare chat history (if not already recorded)
-aituber.setChatHistory([
-  { role: 'user', content: 'How was the show?' },
-  { role: 'assistant', content: 'It went great!' },
-]);
+// Define the conversation history you want to use
+const conversationHistory: Message[] = [
+  { role: 'user', content: 'How was the show today?', timestamp: Date.now() },
+  { role: 'assistant', content: 'It went fantastic! We had over 1000 viewers.', timestamp: Date.now() },
+  { role: 'user', content: 'What was the most popular segment?', timestamp: Date.now() },
+  { role: 'assistant', content: 'The cooking segment got the most engagement!', timestamp: Date.now() },
+];
 
-// Generate new text based on the conversation so far
-const blog = await aituber.generateContentFromHistory(
-  'Write a short blog post summarizing the conversation.'
+// Generate a blog post from the conversation
+const blogPost = await aituber.generateOneShotContentFromHistory(
+  'Write a short blog post summarizing this conversation about a live streaming show.',
+  conversationHistory
 );
-console.log(blog);
+console.log(blogPost);
+
+// Generate a summary report
+const summary = await aituber.generateOneShotContentFromHistory(
+  'Create a brief summary report highlighting the key points from this conversation.',
+  conversationHistory
+);
+console.log(summary);
+
+// Generate social media content
+const snsPost = await aituber.generateOneShotContentFromHistory(
+  'Create a social media content celebrating the success of today\'s show based on this conversation.',
+  conversationHistory
+);
+console.log(snsPost);
 ```
+
+**Key Benefits:**
+- **Isolated Operation**: Does not modify or interfere with the current chat session
+- **Flexible Input**: Works with any message history array
+- **Multiple Use Cases**: Blog posts, reports, summaries, social media content, etc.
+- **Reusable**: Can be called multiple times with different prompts and histories
 
 ### Synchronized Speech Playback
 

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -745,6 +745,7 @@ src/
 - `clearChatHistory()` - チャット履歴のクリア
 - `updateVoiceService(options)` - 音声設定の更新
 - `isMemoryEnabled()` - メモリ機能が有効かどうかの確認
+- `generateContentFromHistory(prompt)` - チャット履歴を基に新しいテキストを生成
 - `offAll()` - すべてのイベントリスナーの削除
 
 ### ChatProcessor
@@ -1263,7 +1264,23 @@ const aiTuberCore = new AITuberOnAirCore({
     // その他のメモリ設定
     summaryPromptTemplate: '以下の会話を{maxLength}文字以内で要約し、重要なポイントを強調してください。',
   },
-});
+  });
+```
+
+### チャット履歴からコンテンツ生成
+
+```typescript
+// （未設定の場合）チャット履歴をセット
+aituber.setChatHistory([
+  { role: 'user', content: '配信どうだった？' },
+  { role: 'assistant', content: '大成功だったよ！' },
+]);
+
+// これまでの会話をもとにブログ記事を生成
+const blog = await aituber.generateContentFromHistory(
+  '会話内容を要約してブログ記事を書いてください。'
+);
+console.log(blog);
 ```
 
 ### 音声再生の同期処理

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -745,7 +745,7 @@ src/
 - `clearChatHistory()` - チャット履歴のクリア
 - `updateVoiceService(options)` - 音声設定の更新
 - `isMemoryEnabled()` - メモリ機能が有効かどうかの確認
-- `generateContentFromHistory(prompt)` - プロンプトとチャット履歴を渡すことで新しいテキストを生成
+- `generateOneShotContentFromHistory(prompt, messageHistory)` - システムプロンプトと提供されたメッセージ履歴から新しいコンテンツを生成（一度限り、内部チャット履歴に影響しない）
 - `offAll()` - すべてのイベントリスナーの削除
 
 ### ChatProcessor
@@ -1267,21 +1267,46 @@ const aiTuberCore = new AITuberOnAirCore({
   });
 ```
 
-### チャット履歴からコンテンツ生成
+### チャット履歴から一度限りのコンテンツ生成
+
+`generateOneShotContentFromHistory`メソッドを使用すると、提供されたメッセージ履歴に基づいて独立したコンテンツを生成できます。内部のチャット履歴には影響せず、ブログ記事、レポート、要約、その他の既存の会話から派生したコンテンツの作成に最適です。
 
 ```typescript
-// （未設定の場合）チャット履歴をセット
-aituber.setChatHistory([
-  { role: 'user', content: '配信どうだった？' },
-  { role: 'assistant', content: '大成功だったよ！' },
-]);
+// 使用したい会話履歴を定義
+const conversationHistory: Message[] = [
+  { role: 'user', content: '今日の配信はどうでしたか？', timestamp: Date.now() },
+  { role: 'assistant', content: '最高でした！1000人以上の視聴者がいました。', timestamp: Date.now() },
+  { role: 'user', content: '一番人気だったコーナーは何ですか？', timestamp: Date.now() },
+  { role: 'assistant', content: '料理コーナーが最も盛り上がりました！', timestamp: Date.now() },
+];
 
-// これまでの会話をもとにブログ記事を生成
-const blog = await aituber.generateContentFromHistory(
-  '会話内容を要約してブログ記事を書いてください。'
+// 会話からブログ記事を生成
+const blogPost = await aituber.generateOneShotContentFromHistory(
+  'このライブ配信についての会話を要約して、短いブログ記事を書いてください。',
+  conversationHistory
 );
-console.log(blog);
+console.log(blogPost);
+
+// サマリーレポートを生成
+const summary = await aituber.generateOneShotContentFromHistory(
+  'この会話から重要なポイントを抜き出して、簡潔な要約レポートを作成してください。',
+  conversationHistory
+);
+console.log(summary);
+
+// SNS用コンテンツを生成
+const snsPost = await aituber.generateOneShotContentFromHistory(
+  'この会話を基に、今日の配信の成功を祝うSNS用の投稿を作成してください。',
+  conversationHistory
+);
+console.log(snsPost);
 ```
+
+**主な利点：**
+- **独立した動作**: 現在のチャットセッションを変更したり干渉したりしません
+- **柔軟な入力**: 任意のメッセージ履歴配列で動作します
+- **多用途**: ブログ記事、レポート、要約、SNSコンテンツなどに対応
+- **再利用可能**: 異なるプロンプトと履歴で何度でも呼び出せます
 
 ### 音声再生の同期処理
 

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -745,7 +745,7 @@ src/
 - `clearChatHistory()` - チャット履歴のクリア
 - `updateVoiceService(options)` - 音声設定の更新
 - `isMemoryEnabled()` - メモリ機能が有効かどうかの確認
-- `generateContentFromHistory(prompt)` - チャット履歴を基に新しいテキストを生成
+- `generateContentFromHistory(prompt)` - プロンプトとチャット履歴を渡すことで新しいテキストを生成
 - `offAll()` - すべてのイベントリスナーの削除
 
 ### ChatProcessor

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -453,21 +453,19 @@ export class AITuberOnAirCore extends EventEmitter {
   }
 
   /**
-   * チャット履歴を基に新しいコンテンツを生成する
-   * @param prompt 生成内容を指示するシステムプロンプト
-   * @returns 生成されたテキスト
+   * Generate new content based on the system prompt and the provided message history.
+   * The message history is treated as a one-time use.
+   *
+   * @param prompt The system prompt to guide the content generation
+   * @param messageHistory The message history to use as context
+   * @returns The generated content as a string
    */
-  async generateContentFromHistory(prompt: string): Promise<string> {
+  async generateContentFromHistory(
+    prompt: string,
+    messageHistory: Message[],
+  ): Promise<string> {
     const messages: Message[] = [{ role: 'system', content: prompt }];
-
-    if (this.memoryManager) {
-      const memory = this.memoryManager.getMemoryForPrompt();
-      if (memory) {
-        messages.push({ role: 'system', content: memory });
-      }
-    }
-
-    messages.push(...this.chatProcessor.getChatLog());
+    messages.push(...messageHistory);
 
     const result = await this.chatService.chatOnce(messages, false, () => {});
     return result.blocks

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -453,14 +453,15 @@ export class AITuberOnAirCore extends EventEmitter {
   }
 
   /**
-   * Generate new content based on the system prompt and the provided message history.
-   * The message history is treated as a one-time use.
+   * Generate new content based on the system prompt and the provided message history (one-shot).
+   * The provided message history is used only for this generation and does not affect the internal chat history.
+   * This is ideal for generating standalone content like blog posts, reports, or summaries from existing conversations.
    *
    * @param prompt The system prompt to guide the content generation
    * @param messageHistory The message history to use as context
    * @returns The generated content as a string
    */
-  async generateContentFromHistory(
+  async generateOneShotContentFromHistory(
     prompt: string,
     messageHistory: Message[],
   ): Promise<string> {

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -453,6 +453,30 @@ export class AITuberOnAirCore extends EventEmitter {
   }
 
   /**
+   * チャット履歴を基に新しいコンテンツを生成する
+   * @param prompt 生成内容を指示するシステムプロンプト
+   * @returns 生成されたテキスト
+   */
+  async generateContentFromHistory(prompt: string): Promise<string> {
+    const messages: Message[] = [{ role: 'system', content: prompt }];
+
+    if (this.memoryManager) {
+      const memory = this.memoryManager.getMemoryForPrompt();
+      if (memory) {
+        messages.push({ role: 'system', content: memory });
+      }
+    }
+
+    messages.push(...this.chatProcessor.getChatLog());
+
+    const result = await this.chatService.chatOnce(messages, false, () => {});
+    return result.blocks
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+  }
+
+  /**
    * Check if memory functionality is enabled
    */
   isMemoryEnabled(): boolean {

--- a/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
+++ b/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../src/services/voice/VoiceEngineAdapter', () => {
   };
 });
 
-describe('AITuberOnAirCore generateContentFromHistory', () => {
+describe('AITuberOnAirCore generateOneShotContentFromHistory', () => {
   let core: AITuberOnAirCore;
 
   beforeEach(() => {
@@ -57,7 +57,7 @@ describe('AITuberOnAirCore generateContentFromHistory', () => {
       { role: 'assistant', content: 'B', timestamp: 2 },
     ];
 
-    await core.generateContentFromHistory('Write a blog post', history);
+    await core.generateOneShotContentFromHistory('Write a blog post', history);
 
     expect(mockChatService.chatOnce).toHaveBeenCalledTimes(1);
     const args = mockChatService.chatOnce.mock.calls[0];
@@ -75,7 +75,10 @@ describe('AITuberOnAirCore generateContentFromHistory', () => {
   it('should work with empty message history', async () => {
     const emptyHistory: Message[] = [];
 
-    await core.generateContentFromHistory('Create a summary', emptyHistory);
+    await core.generateOneShotContentFromHistory(
+      'Create a summary',
+      emptyHistory,
+    );
 
     const messages = mockChatService.chatOnce.mock.calls[0][0] as Message[];
     expect(messages).toHaveLength(1);
@@ -99,7 +102,7 @@ describe('AITuberOnAirCore generateContentFromHistory', () => {
       stop_reason: 'end',
     });
 
-    const result = await core.generateContentFromHistory(
+    const result = await core.generateOneShotContentFromHistory(
       'Write something',
       history,
     );

--- a/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
+++ b/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AITuberOnAirCore, AITuberOnAirCoreOptions } from '../../src/core/AITuberOnAirCore';
+import {
+  AITuberOnAirCore,
+  AITuberOnAirCoreOptions,
+} from '../../src/core/AITuberOnAirCore';
 import { Message } from '../../src/types';
 
 // Mock OpenAIChatService

--- a/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
+++ b/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AITuberOnAirCore, AITuberOnAirCoreOptions } from '../../src/core/AITuberOnAirCore';
+import { Message } from '../../src/types';
+
+// Mock OpenAIChatService
+vi.mock('../../services/chat/OpenAIChatService', () => {
+  return {
+    OpenAIChatService: vi.fn().mockImplementation(() => ({
+      chatOnce: vi.fn().mockResolvedValue({
+        blocks: [{ type: 'text', text: 'generated' }],
+        stop_reason: 'end',
+      }),
+      visionChatOnce: vi.fn(),
+      getModel: vi.fn(),
+      getVisionModel: vi.fn(),
+    })),
+  };
+});
+
+// Skip voice
+vi.mock('../../services/voice/VoiceEngineAdapter', () => {
+  return {
+    VoiceEngineAdapter: vi.fn().mockImplementation(() => ({
+      speakText: vi.fn(),
+      speak: vi.fn(),
+      stop: vi.fn(),
+      updateOptions: vi.fn(),
+    })),
+  };
+});
+
+describe('AITuberOnAirCore generateContentFromHistory', () => {
+  let core: AITuberOnAirCore;
+  let chatServiceMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const options: AITuberOnAirCoreOptions = {
+      apiKey: 'test',
+      chatOptions: { systemPrompt: 'system' },
+    };
+    core = new AITuberOnAirCore(options);
+    chatServiceMock = (core as any).chatService;
+  });
+
+  it('should send system prompt and chat log to chatOnce', async () => {
+    const history: Message[] = [
+      { role: 'user', content: 'A', timestamp: 1 },
+      { role: 'assistant', content: 'B', timestamp: 2 },
+    ];
+    core.setChatHistory(history);
+
+    await core.generateContentFromHistory('ブログを書いて');
+
+    expect(chatServiceMock.chatOnce).toHaveBeenCalledTimes(1);
+    const args = chatServiceMock.chatOnce.mock.calls[0];
+    const messages = args[0] as Message[];
+    const stream = args[1];
+
+    expect(stream).toBe(false);
+    expect(messages[0]).toEqual({ role: 'system', content: 'ブログを書いて' });
+    expect(messages.slice(1)).toEqual(history);
+  });
+
+  it('should include memory when available', async () => {
+    (core as any).memoryManager = {
+      getMemoryForPrompt: vi.fn().mockReturnValue('MEMORY'),
+    };
+    core.setChatHistory([{ role: 'user', content: 'C', timestamp: 3 }]);
+
+    await core.generateContentFromHistory('指示');
+
+    const messages = chatServiceMock.chatOnce.mock.calls[0][0] as Message[];
+    expect(messages[1]).toEqual({ role: 'system', content: 'MEMORY' });
+  });
+});

--- a/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
+++ b/packages/core/tests/core/AITuberOnAirCore.generateContent.test.ts
@@ -5,23 +5,30 @@ import {
 } from '../../src/core/AITuberOnAirCore';
 import { Message } from '../../src/types';
 
-// Mock OpenAIChatService
-vi.mock('../../services/chat/OpenAIChatService', () => {
+// Create a mock chat service using vi.hoisted
+const mockChatService = vi.hoisted(() => ({
+  chatOnce: vi.fn().mockResolvedValue({
+    blocks: [{ type: 'text', text: 'generated' }],
+    stop_reason: 'end',
+  }),
+  visionChatOnce: vi.fn(),
+  getModel: vi.fn(),
+  getVisionModel: vi.fn(),
+}));
+
+// Mock ChatServiceFactory
+vi.mock('../../src/services/chat/ChatServiceFactory', () => {
   return {
-    OpenAIChatService: vi.fn().mockImplementation(() => ({
-      chatOnce: vi.fn().mockResolvedValue({
-        blocks: [{ type: 'text', text: 'generated' }],
-        stop_reason: 'end',
-      }),
-      visionChatOnce: vi.fn(),
-      getModel: vi.fn(),
-      getVisionModel: vi.fn(),
-    })),
+    ChatServiceFactory: {
+      createChatService: vi.fn().mockReturnValue(mockChatService),
+      getAvailableProviders: vi.fn().mockReturnValue(['openai']),
+      getSupportedModels: vi.fn().mockReturnValue(['gpt-4o-mini']),
+    },
   };
 });
 
 // Skip voice
-vi.mock('../../services/voice/VoiceEngineAdapter', () => {
+vi.mock('../../src/services/voice/VoiceEngineAdapter', () => {
   return {
     VoiceEngineAdapter: vi.fn().mockImplementation(() => ({
       speakText: vi.fn(),
@@ -34,7 +41,6 @@ vi.mock('../../services/voice/VoiceEngineAdapter', () => {
 
 describe('AITuberOnAirCore generateContentFromHistory', () => {
   let core: AITuberOnAirCore;
-  let chatServiceMock: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -43,37 +49,61 @@ describe('AITuberOnAirCore generateContentFromHistory', () => {
       chatOptions: { systemPrompt: 'system' },
     };
     core = new AITuberOnAirCore(options);
-    chatServiceMock = (core as any).chatService;
   });
 
-  it('should send system prompt and chat log to chatOnce', async () => {
+  it('should send system prompt and provided message history to chatOnce', async () => {
     const history: Message[] = [
       { role: 'user', content: 'A', timestamp: 1 },
       { role: 'assistant', content: 'B', timestamp: 2 },
     ];
-    core.setChatHistory(history);
 
-    await core.generateContentFromHistory('ブログを書いて');
+    await core.generateContentFromHistory('Write a blog post', history);
 
-    expect(chatServiceMock.chatOnce).toHaveBeenCalledTimes(1);
-    const args = chatServiceMock.chatOnce.mock.calls[0];
+    expect(mockChatService.chatOnce).toHaveBeenCalledTimes(1);
+    const args = mockChatService.chatOnce.mock.calls[0];
     const messages = args[0] as Message[];
     const stream = args[1];
 
     expect(stream).toBe(false);
-    expect(messages[0]).toEqual({ role: 'system', content: 'ブログを書いて' });
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: 'Write a blog post',
+    });
     expect(messages.slice(1)).toEqual(history);
   });
 
-  it('should include memory when available', async () => {
-    (core as any).memoryManager = {
-      getMemoryForPrompt: vi.fn().mockReturnValue('MEMORY'),
-    };
-    core.setChatHistory([{ role: 'user', content: 'C', timestamp: 3 }]);
+  it('should work with empty message history', async () => {
+    const emptyHistory: Message[] = [];
 
-    await core.generateContentFromHistory('指示');
+    await core.generateContentFromHistory('Create a summary', emptyHistory);
 
-    const messages = chatServiceMock.chatOnce.mock.calls[0][0] as Message[];
-    expect(messages[1]).toEqual({ role: 'system', content: 'MEMORY' });
+    const messages = mockChatService.chatOnce.mock.calls[0][0] as Message[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: 'Create a summary',
+    });
+  });
+
+  it('should return generated text from chatOnce response', async () => {
+    const history: Message[] = [
+      { role: 'user', content: 'test message', timestamp: 1 },
+    ];
+
+    mockChatService.chatOnce.mockResolvedValue({
+      blocks: [
+        { type: 'text', text: 'generated' },
+        { type: 'text', text: 'content' },
+        { type: 'other', content: 'ignored' },
+      ],
+      stop_reason: 'end',
+    });
+
+    const result = await core.generateContentFromHistory(
+      'Write something',
+      history,
+    );
+
+    expect(result).toBe('generatedcontent');
   });
 });

--- a/packages/core/tests/core/ChatProcessor.test.ts
+++ b/packages/core/tests/core/ChatProcessor.test.ts
@@ -743,7 +743,8 @@ describe('ChatProcessor', () => {
       // Assert - Check if error is emitted instead of thrown
       const errorEmit = emitSpy.mock.calls.find(
         (call) =>
-          call[0] === 'error' && call[1].message === 'Tool callback missing',
+          call[0] === 'error' &&
+          (call[1] as Error).message === 'Tool callback missing',
       );
       expect(errorEmit).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- add new function of `generateOneShotContentFromHistory`
- document `generateOneShotContentFromHistory` usage in the examples section
- mention new method in the main method list

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node' and 'vitest')*