### PR TITLE
Add Claude provider tests

### DIFF
--- a/packages/core/src/services/chat/providers/claude/ClaudeChatService.ts
+++ b/packages/core/src/services/chat/providers/claude/ClaudeChatService.ts
@@ -40,6 +40,7 @@ export class ClaudeChatService implements ChatService {
    * @param model Name of the model to use
    * @param visionModel Name of the vision model
    * @param tools Array of tool definitions
+   * @throws Error if the vision model doesn't support vision capabilities
    */
   constructor(
     apiKey: string,
@@ -51,6 +52,13 @@ export class ClaudeChatService implements ChatService {
     this.model = model || MODEL_CLAUDE_3_HAIKU;
     this.visionModel = visionModel || MODEL_CLAUDE_3_HAIKU;
     this.tools = tools;
+
+    // Validate vision model supports vision capabilities
+    if (!CLAUDE_VISION_SUPPORTED_MODELS.includes(this.visionModel)) {
+      throw new Error(
+        `Model ${this.visionModel} does not support vision capabilities.`,
+      );
+    }
   }
 
   /**
@@ -115,19 +123,12 @@ export class ClaudeChatService implements ChatService {
    * @param messages Array of messages to send (including images)
    * @param onPartialResponse Callback to receive each part of streaming response
    * @param onCompleteResponse Callback to execute when response is complete
-   * @throws Error if the selected model doesn't support vision
    */
   async processVisionChat(
     messages: MessageWithVision[],
     onPartialResponse: (text: string) => void,
     onCompleteResponse: (text: string) => Promise<void>,
   ): Promise<void> {
-    if (!CLAUDE_VISION_SUPPORTED_MODELS.includes(this.visionModel)) {
-      throw new Error(
-        `Model ${this.visionModel} does not support vision capabilities.`,
-      );
-    }
-
     /* same branch logic for vision */
     if (this.tools.length === 0) {
       const res = await this.callClaude(messages, this.visionModel, true);

--- a/packages/core/src/services/chat/providers/gemini/GeminiChatService.ts
+++ b/packages/core/src/services/chat/providers/gemini/GeminiChatService.ts
@@ -161,12 +161,6 @@ export class GeminiChatService implements ChatService {
     onCompleteResponse: (text: string) => Promise<void>,
   ): Promise<void> {
     try {
-      if (!GEMINI_VISION_SUPPORTED_MODELS.includes(this.visionModel)) {
-        throw new Error(
-          `Model ${this.visionModel} does not support vision capabilities.`,
-        );
-      }
-
       if (this.tools.length === 0) {
         const res = await this.callGemini(messages, this.visionModel, true);
         const { blocks } = await this.parseStream(res, onPartialResponse);

--- a/packages/core/src/services/chat/providers/openai/OpenAIChatService.ts
+++ b/packages/core/src/services/chat/providers/openai/OpenAIChatService.ts
@@ -117,13 +117,6 @@ export class OpenAIChatService implements ChatService {
     onCompleteResponse: (text: string) => Promise<void>,
   ): Promise<void> {
     try {
-      // Check if the vision model supports vision capabilities
-      if (!VISION_SUPPORTED_MODELS.includes(this.visionModel)) {
-        throw new Error(
-          `Model ${this.visionModel} does not support vision capabilities.`,
-        );
-      }
-
       // not use tools
       if (this.tools.length === 0) {
         const res = await this.callOpenAI(messages, this.visionModel, true);

--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
@@ -50,3 +50,138 @@ describe('ClaudeChatService parse functions', () => {
     });
   });
 });
+
+import { vi } from 'vitest';
+import { Message, MessageWithVision } from '../../../../../src/types';
+import {
+  ENDPOINT_CLAUDE_API,
+  MODEL_CLAUDE_3_HAIKU,
+  CLAUDE_VISION_SUPPORTED_MODELS,
+} from '../../../../../src/constants';
+
+describe('ClaudeChatService', () => {
+  const TEST_API_KEY = 'test-api-key';
+  let service: ClaudeChatService;
+
+  function mockFetch(responseData: any, ok = true, statusText = 'OK') {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 400,
+      statusText,
+      json: async () => responseData,
+      body: { getReader: () => ({ read: vi.fn().mockResolvedValueOnce({ done: true }) }) },
+    });
+  }
+
+  beforeEach(() => {
+    service = new ClaudeChatService(TEST_API_KEY);
+    vi.resetAllMocks();
+  });
+
+  it('should return the default model if none is specified', () => {
+    expect(service.getModel()).toBe(MODEL_CLAUDE_3_HAIKU);
+  });
+
+  it('should return the model passed into constructor', () => {
+    const customModel = 'custom-claude-model';
+    const customService = new ClaudeChatService(TEST_API_KEY, customModel);
+    expect(customService.getModel()).toBe(customModel);
+  });
+
+  it('should call Claude API with correct endpoint and body in processChat', async () => {
+    mockFetch({ content: [{ text: 'Hello from Claude!' }] });
+    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce('Hello from Claude!');
+
+    const messages: Message[] = [{ role: 'user', content: 'Hello' }];
+
+    const onPartialResponse = vi.fn();
+    const onCompleteResponse = vi.fn();
+
+    await service.processChat(messages, onPartialResponse, onCompleteResponse);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(global.fetch).mock.calls[0];
+    const url = callArgs[0];
+    const requestOptions = callArgs[1];
+
+    expect(url).toBe(ENDPOINT_CLAUDE_API);
+    expect(requestOptions?.method).toBe('POST');
+    expect(requestOptions?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-api-key': TEST_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    });
+
+    const bodyObj = JSON.parse(requestOptions?.body as string);
+    expect(bodyObj.model).toBe(MODEL_CLAUDE_3_HAIKU);
+    expect(bodyObj.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+    expect(bodyObj.stream).toBe(true);
+
+    expect(onCompleteResponse).toHaveBeenCalledWith('Hello from Claude!');
+  });
+
+  it('should throw an error when Claude API returns a non-200 status', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => JSON.stringify({ error: { message: 'Unauthorized' } }),
+    });
+
+    const messages: Message[] = [{ role: 'user', content: 'Hi' }];
+
+    await expect(service.processChat(messages, vi.fn(), vi.fn())).rejects.toThrow();
+  });
+
+  it('should process vision chat with a vision-supported model', async () => {
+    const visionModel = CLAUDE_VISION_SUPPORTED_MODELS[0];
+    service = new ClaudeChatService(TEST_API_KEY, MODEL_CLAUDE_3_HAIKU, visionModel);
+
+    mockFetch({ content: [{ text: 'Vision response' }] });
+    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce('Vision response');
+
+    const messages: MessageWithVision[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check image' },
+          { type: 'image_url', image_url: { url: 'http://example.com/image.jpg' } },
+        ],
+      },
+    ];
+
+    const onPartialResponse = vi.fn();
+    const onCompleteResponse = vi.fn();
+
+    await service.processVisionChat(messages, onPartialResponse, onCompleteResponse);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(global.fetch).mock.calls[0];
+    const bodyObj = JSON.parse(callArgs[1]?.body as string);
+    expect(bodyObj.model).toBe(visionModel);
+    expect(bodyObj.stream).toBe(true);
+
+    expect(onCompleteResponse).toHaveBeenCalledWith('Vision response');
+  });
+
+  it('should throw error if vision model does not support vision', async () => {
+    expect(() => new ClaudeChatService(TEST_API_KEY, MODEL_CLAUDE_3_HAIKU, 'non-vision')).toThrow();
+  });
+
+  it('should call chatOnce directly and return tool chat completion', async () => {
+    mockFetch({ content: [{ text: 'Direct response' }] });
+    vi.spyOn(service as any, 'parseStream').mockResolvedValueOnce({
+      blocks: [{ type: 'text', text: 'Direct response' }],
+      stop_reason: 'end',
+    });
+
+    const messages: Message[] = [{ role: 'user', content: 'Hello' }];
+    const result = await service.chatOnce(messages, true, vi.fn());
+
+    expect(result).toEqual({
+      blocks: [{ type: 'text', text: 'Direct response' }],
+      stop_reason: 'end',
+    });
+  });
+});

--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatService.test.ts
@@ -69,7 +69,11 @@ describe('ClaudeChatService', () => {
       status: ok ? 200 : 400,
       statusText,
       json: async () => responseData,
-      body: { getReader: () => ({ read: vi.fn().mockResolvedValueOnce({ done: true }) }) },
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockResolvedValueOnce({ done: true }),
+        }),
+      },
     });
   }
 
@@ -90,7 +94,9 @@ describe('ClaudeChatService', () => {
 
   it('should call Claude API with correct endpoint and body in processChat', async () => {
     mockFetch({ content: [{ text: 'Hello from Claude!' }] });
-    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce('Hello from Claude!');
+    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce(
+      'Hello from Claude!',
+    );
 
     const messages: Message[] = [{ role: 'user', content: 'Hello' }];
 
@@ -131,22 +137,33 @@ describe('ClaudeChatService', () => {
 
     const messages: Message[] = [{ role: 'user', content: 'Hi' }];
 
-    await expect(service.processChat(messages, vi.fn(), vi.fn())).rejects.toThrow();
+    await expect(
+      service.processChat(messages, vi.fn(), vi.fn()),
+    ).rejects.toThrow();
   });
 
   it('should process vision chat with a vision-supported model', async () => {
     const visionModel = CLAUDE_VISION_SUPPORTED_MODELS[0];
-    service = new ClaudeChatService(TEST_API_KEY, MODEL_CLAUDE_3_HAIKU, visionModel);
+    service = new ClaudeChatService(
+      TEST_API_KEY,
+      MODEL_CLAUDE_3_HAIKU,
+      visionModel,
+    );
 
     mockFetch({ content: [{ text: 'Vision response' }] });
-    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce('Vision response');
+    vi.spyOn(service as any, 'parsePureStream').mockResolvedValueOnce(
+      'Vision response',
+    );
 
     const messages: MessageWithVision[] = [
       {
         role: 'user',
         content: [
           { type: 'text', text: 'Check image' },
-          { type: 'image_url', image_url: { url: 'http://example.com/image.jpg' } },
+          {
+            type: 'image_url',
+            image_url: { url: 'http://example.com/image.jpg' },
+          },
         ],
       },
     ];
@@ -154,7 +171,11 @@ describe('ClaudeChatService', () => {
     const onPartialResponse = vi.fn();
     const onCompleteResponse = vi.fn();
 
-    await service.processVisionChat(messages, onPartialResponse, onCompleteResponse);
+    await service.processVisionChat(
+      messages,
+      onPartialResponse,
+      onCompleteResponse,
+    );
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const callArgs = vi.mocked(global.fetch).mock.calls[0];
@@ -166,7 +187,10 @@ describe('ClaudeChatService', () => {
   });
 
   it('should throw error if vision model does not support vision', async () => {
-    expect(() => new ClaudeChatService(TEST_API_KEY, MODEL_CLAUDE_3_HAIKU, 'non-vision')).toThrow();
+    expect(
+      () =>
+        new ClaudeChatService(TEST_API_KEY, MODEL_CLAUDE_3_HAIKU, 'non-vision'),
+    ).toThrow();
   });
 
   it('should call chatOnce directly and return tool chat completion', async () => {

--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatServiceProvider.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatServiceProvider.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ClaudeChatServiceProvider } from '../../../../../src/services/chat/providers/claude/ClaudeChatServiceProvider.ts';
+import { ClaudeChatService } from '../../../../../src/services/chat/providers/claude/ClaudeChatService.ts';
+import {
+  MODEL_CLAUDE_3_HAIKU,
+  MODEL_CLAUDE_3_5_HAIKU,
+  CLAUDE_VISION_SUPPORTED_MODELS,
+} from '../../../../../src/constants';
+import { ChatServiceOptions } from '../../../../../src/services/chat/providers/ChatServiceProvider.ts';
+
+describe('ClaudeChatServiceProvider', () => {
+  let provider: ClaudeChatServiceProvider;
+
+  beforeEach(() => {
+    provider = new ClaudeChatServiceProvider();
+  });
+
+  it('should return "claude" as provider name', () => {
+    expect(provider.getProviderName()).toBe('claude');
+  });
+
+  it('should return default model', () => {
+    expect(provider.getDefaultModel()).toBe(MODEL_CLAUDE_3_HAIKU);
+  });
+
+  it('should create ClaudeChatService with given apiKey and model', () => {
+    const options: ChatServiceOptions = {
+      apiKey: 'test-key',
+      model: MODEL_CLAUDE_3_5_HAIKU,
+    };
+    const chatService = provider.createChatService(options);
+
+    expect(chatService).toBeInstanceOf(ClaudeChatService);
+    expect(chatService.getModel()).toBe(MODEL_CLAUDE_3_5_HAIKU);
+  });
+
+  it('should fall back to default model if none is provided', () => {
+    const options: ChatServiceOptions = {
+      apiKey: 'test-key',
+    };
+    const chatService = provider.createChatService(options);
+    expect(chatService.getModel()).toBe(MODEL_CLAUDE_3_HAIKU);
+  });
+
+  it('should use visionModel if provided', () => {
+    const visionModel = CLAUDE_VISION_SUPPORTED_MODELS[0];
+    const options: ChatServiceOptions = {
+      apiKey: 'test-key',
+      model: MODEL_CLAUDE_3_HAIKU,
+      visionModel,
+    };
+    const chatService = provider.createChatService(options);
+
+    expect(chatService).toBeInstanceOf(ClaudeChatService);
+  });
+
+  it('should check if a model supports vision', () => {
+    expect(provider.supportsVisionForModel(CLAUDE_VISION_SUPPORTED_MODELS[0])).toBe(true);
+    expect(provider.supportsVisionForModel('unsupported-model')).toBe(false);
+  });
+});

--- a/packages/core/tests/services/chat/providers/claude/ClaudeChatServiceProvider.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeChatServiceProvider.test.ts
@@ -55,7 +55,9 @@ describe('ClaudeChatServiceProvider', () => {
   });
 
   it('should check if a model supports vision', () => {
-    expect(provider.supportsVisionForModel(CLAUDE_VISION_SUPPORTED_MODELS[0])).toBe(true);
+    expect(
+      provider.supportsVisionForModel(CLAUDE_VISION_SUPPORTED_MODELS[0]),
+    ).toBe(true);
     expect(provider.supportsVisionForModel('unsupported-model')).toBe(false);
   });
 });

--- a/packages/core/tests/services/chat/providers/claude/ClaudeSummarizer.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeSummarizer.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ClaudeSummarizer } from '../../../../../src/services/chat/providers/claude/ClaudeSummarizer.ts';
 import { Message } from '../../../../../src/types';
-import { ENDPOINT_CLAUDE_API, MODEL_CLAUDE_3_HAIKU } from '../../../../../src/constants';
+import {
+  ENDPOINT_CLAUDE_API,
+  MODEL_CLAUDE_3_HAIKU,
+} from '../../../../../src/constants';
 import { DEFAULT_SUMMARY_PROMPT_TEMPLATE } from '../../../../../src/constants';
 import { AITuberOnAirCore } from '../../../../../src/core/AITuberOnAirCore';
 import { ChatServiceFactory } from '../../../../../src/services/chat/ChatServiceFactory';
@@ -138,7 +141,9 @@ describe('ClaudeSummarizer', () => {
     };
 
     const originalCreateChatService = ChatServiceFactory.createChatService;
-    ChatServiceFactory.createChatService = vi.fn().mockReturnValue(mockChatService);
+    ChatServiceFactory.createChatService = vi
+      .fn()
+      .mockReturnValue(mockChatService);
 
     try {
       const core = new AITuberOnAirCore({

--- a/packages/core/tests/services/chat/providers/claude/ClaudeSummarizer.test.ts
+++ b/packages/core/tests/services/chat/providers/claude/ClaudeSummarizer.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ClaudeSummarizer } from '../../../../../src/services/chat/providers/claude/ClaudeSummarizer.ts';
+import { Message } from '../../../../../src/types';
+import { ENDPOINT_CLAUDE_API, MODEL_CLAUDE_3_HAIKU } from '../../../../../src/constants';
+import { DEFAULT_SUMMARY_PROMPT_TEMPLATE } from '../../../../../src/constants';
+import { AITuberOnAirCore } from '../../../../../src/core/AITuberOnAirCore';
+import { ChatServiceFactory } from '../../../../../src/services/chat/ChatServiceFactory';
+
+describe('ClaudeSummarizer', () => {
+  const TEST_API_KEY = 'test-api-key';
+  let summarizer: ClaudeSummarizer;
+
+  function mockFetch(responseData: any, ok = true, statusText = 'OK') {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 400,
+      statusText,
+      json: async () => responseData,
+    });
+  }
+
+  beforeEach(() => {
+    summarizer = new ClaudeSummarizer(TEST_API_KEY);
+    vi.resetAllMocks();
+  });
+
+  it('should initialize with default model', () => {
+    const defaultSummarizer = new ClaudeSummarizer(TEST_API_KEY);
+    const model = (defaultSummarizer as any).model;
+    expect(model).toBe(MODEL_CLAUDE_3_HAIKU);
+  });
+
+  it('should initialize with custom model and prompt template', () => {
+    const customModel = 'custom-claude-model';
+    const customTemplate = 'Custom prompt {maxLength} characters';
+    const customSummarizer = new ClaudeSummarizer(
+      TEST_API_KEY,
+      customModel,
+      customTemplate,
+    );
+
+    const model = (customSummarizer as any).model;
+    const template = (customSummarizer as any).defaultPromptTemplate;
+
+    expect(model).toBe(customModel);
+    expect(template).toBe(customTemplate);
+  });
+
+  it('should generate summary successfully', async () => {
+    const mockApiResponse = {
+      content: [{ text: 'Summary of the conversation.' }],
+    };
+    mockFetch(mockApiResponse);
+
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'How are you?' },
+      { role: 'user', content: 'I am fine!' },
+    ];
+
+    const summary = await summarizer.summarize(messages);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(global.fetch).mock.calls[0];
+    const url = callArgs[0];
+    const requestOptions = callArgs[1];
+
+    expect(url).toBe(ENDPOINT_CLAUDE_API);
+
+    expect(requestOptions?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-api-key': TEST_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    });
+
+    const bodyObj = JSON.parse(requestOptions?.body as string);
+    expect(bodyObj.model).toBe(MODEL_CLAUDE_3_HAIKU);
+    expect(bodyObj.messages).toHaveLength(1);
+    expect(bodyObj.messages[0].content).toContain(
+      DEFAULT_SUMMARY_PROMPT_TEMPLATE.replace('{maxLength}', '256'),
+    );
+    expect(bodyObj.max_tokens).toBe(256);
+
+    expect(summary).toBe('Summary of the conversation.');
+  });
+
+  it('should apply maxLength parameter correctly', async () => {
+    const mockApiResponse = { content: [{ text: 'Short summary' }] };
+    mockFetch(mockApiResponse);
+
+    const messages: Message[] = [{ role: 'user', content: 'Test' }];
+
+    const maxLength = 100;
+    await summarizer.summarize(messages, maxLength);
+
+    const callArgs = vi.mocked(global.fetch).mock.calls[0];
+    const bodyObj = JSON.parse(callArgs[1]?.body as string);
+
+    expect(bodyObj.messages[0].content).toContain('100');
+    expect(bodyObj.max_tokens).toBe(100);
+  });
+
+  it('should return fallback summary on API error', async () => {
+    mockFetch(
+      { error: { message: 'Authentication error' } },
+      false,
+      'Authentication error',
+    );
+
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi!' },
+    ];
+
+    const summary = await summarizer.summarize(messages);
+
+    expect(summary).toContain('2 messages');
+    expect(summary).toContain('Latest topic:');
+  });
+
+  it('should handle empty response correctly', async () => {
+    const mockApiResponse = { content: [] };
+    mockFetch(mockApiResponse);
+
+    const messages: Message[] = [{ role: 'user', content: 'Test' }];
+
+    const summary = await summarizer.summarize(messages);
+    expect(summary).toBe('');
+  });
+
+  it('should be selected automatically when using Claude chat provider', () => {
+    const mockChatService = {
+      provider: 'claude',
+      getModel: () => MODEL_CLAUDE_3_HAIKU,
+      processChat: vi.fn(),
+      processVisionChat: vi.fn(),
+    };
+
+    const originalCreateChatService = ChatServiceFactory.createChatService;
+    ChatServiceFactory.createChatService = vi.fn().mockReturnValue(mockChatService);
+
+    try {
+      const core = new AITuberOnAirCore({
+        chatProvider: 'claude',
+        apiKey: TEST_API_KEY,
+        chatOptions: { systemPrompt: 'Test prompt' },
+        memoryOptions: {
+          enableSummarization: true,
+          maxMessagesBeforeSummarization: 10,
+          shortTermDuration: 60 * 1000,
+          midTermDuration: 5 * 60 * 1000,
+          longTermDuration: 10 * 60 * 1000,
+        },
+      });
+
+      expect(core.isMemoryEnabled()).toBe(true);
+      expect(ChatServiceFactory.createChatService).toHaveBeenCalledWith(
+        'claude',
+        expect.objectContaining({ apiKey: TEST_API_KEY }),
+      );
+
+      const providerInfo = core.getProviderInfo();
+      expect(providerInfo.name).toBe('claude');
+    } finally {
+      ChatServiceFactory.createChatService = originalCreateChatService;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- cover ClaudeChatService with provider and summarizer tests
- extend ClaudeChatService tests for API usage and vision logic
- unify vision model validation in constructor across providers

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*