### PR TITLE
Enable OpenAI Remote MCP support

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -681,6 +681,42 @@ const aituberOptions: AITuberOnAirCoreOptions = {
 const newAITuber = new AITuberOnAirCore(aituberOptions);
 ```
 
+## Using OpenAI Remote MCP
+
+OpenAI's Responses API allows connecting to remote MCP servers. Specify the
+`endpoint` as `responses` and provide MCP server configurations via the
+`mcpServers` option when initializing **AITuberOnAirCore**.
+
+```typescript
+import {
+  AITuberOnAirCore,
+  AITuberOnAirCoreOptions,
+  MCPServerConfig,
+} from '@aituber-onair/core';
+
+const mcpServers: MCPServerConfig[] = [
+  {
+    type: 'url',
+    url: 'https://mcp-server.example.com/',
+    name: 'example-mcp',
+    tool_configuration: { allowed_tools: ['example_tool'] },
+    authorization_token: 'YOUR_TOKEN',
+  },
+];
+
+const options: AITuberOnAirCoreOptions = {
+  chatProvider: 'openai',
+  apiKey: 'your-openai-api-key',
+  model: 'gpt-4.1',
+  providerOptions: {
+    endpoint: 'responses',
+  },
+  mcpServers,
+};
+
+const aituber = new AITuberOnAirCore(options);
+```
+
 ## Using Claude MCP Connector
 
 AITuber OnAir Core supports Claude's Model Context Protocol (MCP) connector feature, allowing you to connect to remote MCP servers directly from the Messages API without a separate MCP client.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -692,6 +692,7 @@ import {
   AITuberOnAirCore,
   AITuberOnAirCoreOptions,
   MCPServerConfig,
+  ENDPOINT_OPENAI_RESPONSES_API,
 } from '@aituber-onair/core';
 
 const mcpServers: MCPServerConfig[] = [
@@ -709,7 +710,7 @@ const options: AITuberOnAirCoreOptions = {
   apiKey: 'your-openai-api-key',
   model: 'gpt-4.1',
   providerOptions: {
-    endpoint: 'responses',
+    endpoint: ENDPOINT_OPENAI_RESPONSES_API,
   },
   mcpServers,
 };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,6 +19,7 @@ It specializes in generating response text and audio from text or image inputs, 
 - [Tool System](#tool-system)
 - [Function Calling Differences](#function-calling-differences)
 - [Using MCP](#using-mcp)
+- [Using OpenAI Remote MCP](#using-openai-remote-mcp)
 - [Using Claude MCP Connector](#using-claude-mcp-connector)
 - [Architecture](#architecture)
 - [Main Components](#main-components)
@@ -683,16 +684,15 @@ const newAITuber = new AITuberOnAirCore(aituberOptions);
 
 ## Using OpenAI Remote MCP
 
-OpenAI's Responses API allows connecting to remote MCP servers. Specify the
-`endpoint` as `responses` and provide MCP server configurations via the
-`mcpServers` option when initializing **AITuberOnAirCore**.
+OpenAI's Responses API allows connecting to remote MCP servers. When you specify 
+MCP server configurations via the `mcpServers` option, **AITuberOnAirCore** 
+automatically switches to the Responses API endpoint for OpenAI.
 
 ```typescript
 import {
   AITuberOnAirCore,
   AITuberOnAirCoreOptions,
   MCPServerConfig,
-  ENDPOINT_OPENAI_RESPONSES_API,
 } from '@aituber-onair/core';
 
 const mcpServers: MCPServerConfig[] = [
@@ -709,14 +709,15 @@ const options: AITuberOnAirCoreOptions = {
   chatProvider: 'openai',
   apiKey: 'your-openai-api-key',
   model: 'gpt-4.1',
-  providerOptions: {
-    endpoint: ENDPOINT_OPENAI_RESPONSES_API,
-  },
-  mcpServers,
+  mcpServers, // Automatically switches to Responses API when MCP servers are configured
 };
 
 const aituber = new AITuberOnAirCore(options);
 ```
+
+**Note**: The `endpoint` configuration is OpenAI-specific and is automatically managed 
+based on MCP server configuration. Other providers (Claude, Gemini) use their own 
+fixed endpoints.
 
 ## Using Claude MCP Connector
 

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -683,6 +683,7 @@ import {
   AITuberOnAirCore,
   AITuberOnAirCoreOptions,
   MCPServerConfig,
+  ENDPOINT_OPENAI_RESPONSES_API,
 } from '@aituber-onair/core';
 
 const mcpServers: MCPServerConfig[] = [
@@ -700,7 +701,7 @@ const options: AITuberOnAirCoreOptions = {
   apiKey: 'your-openai-api-key',
   model: 'gpt-4.1',
   providerOptions: {
-    endpoint: 'responses',
+    endpoint: ENDPOINT_OPENAI_RESPONSES_API,
   },
   mcpServers,
 };

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -673,6 +673,41 @@ const aituberOptions: AITuberOnAirCoreOptions = {
 const newAITuber = new AITuberOnAirCore(aituberOptions);
 ```
 
+## OpenAI Remote MCPの利用
+
+OpenAIのResponses APIを使用すると、リモートMCPサーバーに接続できます。
+`endpoint` に `responses` を指定し、`mcpServers` オプションでサーバー情報を渡します。
+
+```typescript
+import {
+  AITuberOnAirCore,
+  AITuberOnAirCoreOptions,
+  MCPServerConfig,
+} from '@aituber-onair/core';
+
+const mcpServers: MCPServerConfig[] = [
+  {
+    type: 'url',
+    url: 'https://mcp-server.example.com/',
+    name: 'example-mcp',
+    tool_configuration: { allowed_tools: ['example_tool'] },
+    authorization_token: 'YOUR_TOKEN',
+  },
+];
+
+const options: AITuberOnAirCoreOptions = {
+  chatProvider: 'openai',
+  apiKey: 'your-openai-api-key',
+  model: 'gpt-4.1',
+  providerOptions: {
+    endpoint: 'responses',
+  },
+  mcpServers,
+};
+
+const aituber = new AITuberOnAirCore(options);
+```
+
 ## Claude MCP Connectorの使用方法
 
 AITuber OnAir Coreは、ClaudeのModel Context Protocol (MCP) connector機能をサポートしており、別のMCPクライアントを使用せずにMessages APIからリモートMCPサーバーに直接接続できます。

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -18,6 +18,7 @@
 - [基本的な使用方法](#基本的な使用方法)
 - [ツールシステム (Function calling)](#ツールシステム)
 - [MCPの利用方法](#MCPの利用方法)
+- [OpenAI Remote MCPの利用](#OpenAI-Remote-MCPの利用)
 - [Claude MCP Connectorの使用方法](#Claude-MCP-Connectorの使用方法)
 - [アーキテクチャ](#アーキテクチャ)
 - [主要コンポーネント](#主要コンポーネント)
@@ -676,14 +677,14 @@ const newAITuber = new AITuberOnAirCore(aituberOptions);
 ## OpenAI Remote MCPの利用
 
 OpenAIのResponses APIを使用すると、リモートMCPサーバーに接続できます。
-`endpoint` に `responses` を指定し、`mcpServers` オプションでサーバー情報を渡します。
+`mcpServers`オプションでMCPサーバー設定を指定すると、**AITuberOnAirCore**が
+自動的にOpenAI用のResponses APIエンドポイントに切り替わります。
 
 ```typescript
 import {
   AITuberOnAirCore,
   AITuberOnAirCoreOptions,
   MCPServerConfig,
-  ENDPOINT_OPENAI_RESPONSES_API,
 } from '@aituber-onair/core';
 
 const mcpServers: MCPServerConfig[] = [
@@ -700,14 +701,14 @@ const options: AITuberOnAirCoreOptions = {
   chatProvider: 'openai',
   apiKey: 'your-openai-api-key',
   model: 'gpt-4.1',
-  providerOptions: {
-    endpoint: ENDPOINT_OPENAI_RESPONSES_API,
-  },
-  mcpServers,
+  mcpServers, // MCPサーバー設定時に自動的にResponses APIに切り替わります
 };
 
 const aituber = new AITuberOnAirCore(options);
 ```
+
+**注意**: `endpoint`設定はOpenAI専用の機能で、MCP設定に基づいて自動的に管理されます。
+他のプロバイダー（Claude、Gemini）は独自の固定エンドポイントを使用します。
 
 ## Claude MCP Connectorの使用方法
 

--- a/packages/core/biome.json
+++ b/packages/core/biome.json
@@ -23,7 +23,8 @@
         "noInferrableTypes": "off",
         "noNonNullAssertion": "off",
         "useTemplate": "off",
-        "noUselessElse": "off"
+        "noUselessElse": "off",
+        "noUnusedTemplateLiteral": "off"
       }
     }
   },

--- a/packages/core/src/constants/openai.ts
+++ b/packages/core/src/constants/openai.ts
@@ -1,5 +1,7 @@
 export const ENDPOINT_OPENAI_CHAT_COMPLETIONS_API =
   'https://api.openai.com/v1/chat/completions';
+export const ENDPOINT_OPENAI_RESPONSES_API =
+  'https://api.openai.com/v1/responses';
 
 // gpt model
 export const MODEL_GPT_4_1 = 'gpt-4.1';

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -49,7 +49,7 @@ export interface AITuberOnAirCoreOptions {
     definition: ToolDefinition;
     handler: (input: any) => Promise<any>;
   }[];
-  /** MCP servers configuration (Claude only) */
+  /** MCP servers configuration (OpenAI and Claude only) */
   mcpServers?: MCPServerConfig[];
 }
 

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -129,8 +129,11 @@ export class AITuberOnAirCore extends EventEmitter {
       tools: this.toolExecutor.listDefinitions(),
     };
 
-    // Add MCP servers for Claude provider
-    if (providerName === 'claude' && options.mcpServers) {
+    // Add MCP servers for providers that support remote MCP
+    if (
+      (providerName === 'claude' || providerName === 'openai') &&
+      options.mcpServers
+    ) {
       (chatServiceOptions as any).mcpServers = options.mcpServers;
     }
 

--- a/packages/core/src/services/chat/providers/ChatServiceProvider.ts
+++ b/packages/core/src/services/chat/providers/ChatServiceProvider.ts
@@ -10,7 +10,7 @@ export interface ChatServiceOptions {
   model?: string;
   /** Vision model name (for image processing) */
   visionModel?: string;
-  /** API endpoint type (chat/completions or responses) */
+  /** API endpoint type (chat/completions or responses (OpenAI only)) */
   endpoint?: string;
   /** Additional provider-specific options */
   [key: string]: any;

--- a/packages/core/src/services/chat/providers/ChatServiceProvider.ts
+++ b/packages/core/src/services/chat/providers/ChatServiceProvider.ts
@@ -10,6 +10,8 @@ export interface ChatServiceOptions {
   model?: string;
   /** Vision model name (for image processing) */
   visionModel?: string;
+  /** API endpoint type (chat/completions or responses) */
+  endpoint?: string;
   /** Additional provider-specific options */
   [key: string]: any;
 }

--- a/packages/core/src/services/chat/providers/openai/OpenAIChatService.ts
+++ b/packages/core/src/services/chat/providers/openai/OpenAIChatService.ts
@@ -2,6 +2,7 @@ import { ChatService } from '../../ChatService';
 import { Message, MessageWithVision } from '../../../../types';
 import {
   ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+  ENDPOINT_OPENAI_RESPONSES_API,
   MODEL_GPT_4O_MINI,
   VISION_SUPPORTED_MODELS,
 } from '../../../../constants';
@@ -161,8 +162,10 @@ export class OpenAIChatService implements ChatService {
   }
 
   /**
-   * Process chat messages with tools
+   * Process chat messages with tools (text only)
    * @param messages Array of messages to send
+   * @param stream Whether to use streaming
+   * @param onPartialResponse Callback for partial responses
    * @returns Tool chat completion
    */
   async chatOnce(
@@ -171,17 +174,14 @@ export class OpenAIChatService implements ChatService {
     onPartialResponse: (text: string) => void = () => {},
   ): Promise<ToolChatCompletion> {
     const res = await this.callOpenAI(messages, this.model, stream);
-
-    if (stream) {
-      return this.parseStream(res, onPartialResponse);
-    }
-
-    return this.parseOneShot(await res.json());
+    return this.parseResponse(res, stream, onPartialResponse);
   }
 
   /**
    * Process vision chat messages with tools
    * @param messages Array of messages to send (including images)
+   * @param stream Whether to use streaming
+   * @param onPartialResponse Callback for partial responses
    * @returns Tool chat completion
    */
   async visionChatOnce(
@@ -190,6 +190,25 @@ export class OpenAIChatService implements ChatService {
     onPartialResponse: (text: string) => void = () => {},
   ): Promise<ToolChatCompletion> {
     const res = await this.callOpenAI(messages, this.visionModel, stream);
+    return this.parseResponse(res, stream, onPartialResponse);
+  }
+
+  /**
+   * Parse response based on endpoint type
+   */
+  private async parseResponse(
+    res: Response,
+    stream: boolean,
+    onPartialResponse: (text: string) => void,
+  ): Promise<ToolChatCompletion> {
+    const isResponsesAPI = this.endpoint === ENDPOINT_OPENAI_RESPONSES_API;
+
+    if (isResponsesAPI) {
+      return stream
+        ? this.parseResponsesStream(res, onPartialResponse)
+        : this.parseResponsesOneShot(await res.json());
+    }
+
     return stream
       ? this.parseStream(res, onPartialResponse)
       : this.parseOneShot(await res.json());
@@ -200,49 +219,7 @@ export class OpenAIChatService implements ChatService {
     model: string,
     stream: boolean = false,
   ): Promise<Response> {
-    const body: any = {
-      model,
-      messages,
-      stream,
-    };
-
-    const toolDefs: any[] = [];
-    if (this.tools.length) {
-      toolDefs.push(
-        ...this.tools.map((t) => ({
-          type: 'function',
-          function: {
-            name: t.name,
-            description: t.description,
-            parameters: t.parameters,
-          },
-        })),
-      );
-    }
-
-    if (this.mcpServers.length) {
-      this.mcpServers.forEach((s) => {
-        const mcpDef: any = {
-          type: 'mcp',
-          server_label: s.name,
-          server_url: s.url,
-        };
-        if (s.tool_configuration?.allowed_tools) {
-          mcpDef.allowed_tools = s.tool_configuration.allowed_tools;
-        }
-        if (s.authorization_token) {
-          mcpDef.headers = {
-            Authorization: `Bearer ${s.authorization_token}`,
-          };
-        }
-        toolDefs.push(mcpDef);
-      });
-    }
-
-    if (toolDefs.length) {
-      body.tools = toolDefs;
-      body.tool_choice = 'auto';
-    }
+    const body = this.buildRequestBody(messages, model, stream);
 
     const res = await fetch(this.endpoint, {
       method: 'POST',
@@ -259,6 +236,155 @@ export class OpenAIChatService implements ChatService {
     }
 
     return res;
+  }
+
+  /**
+   * Build request body based on the endpoint type
+   */
+  private buildRequestBody(
+    messages: (Message | MessageWithVision)[],
+    model: string,
+    stream: boolean,
+  ): any {
+    const isResponsesAPI = this.endpoint === ENDPOINT_OPENAI_RESPONSES_API;
+
+    // Validate MCP servers compatibility
+    this.validateMCPCompatibility();
+
+    const body: any = {
+      model,
+      stream,
+    };
+
+    // Handle messages format based on endpoint
+    if (isResponsesAPI && this.mcpServers.length > 0) {
+      body.input = this.cleanMessagesForResponsesAPI(messages);
+    } else {
+      body.messages = messages;
+    }
+
+    // Add tools if available
+    const tools = this.buildToolsDefinition();
+    if (tools.length > 0) {
+      body.tools = tools;
+
+      // Only Chat Completions API requires tool_choice
+      if (!isResponsesAPI) {
+        body.tool_choice = 'auto';
+      }
+    }
+
+    return body;
+  }
+
+  /**
+   * Validate MCP servers compatibility with the current endpoint
+   */
+  private validateMCPCompatibility(): void {
+    if (
+      this.mcpServers.length > 0 &&
+      this.endpoint === ENDPOINT_OPENAI_CHAT_COMPLETIONS_API
+    ) {
+      throw new Error(
+        `MCP servers are not supported with Chat Completions API. ` +
+          `Current endpoint: ${this.endpoint}. ` +
+          `Please use OpenAI Responses API endpoint: ${ENDPOINT_OPENAI_RESPONSES_API}. ` +
+          `MCP tools are only available in the Responses API endpoint.`,
+      );
+    }
+  }
+
+  /**
+   * Clean messages for Responses API (remove timestamp and other extra properties)
+   */
+  private cleanMessagesForResponsesAPI(
+    messages: (Message | MessageWithVision)[],
+  ): any[] {
+    return messages.map((msg) => {
+      const cleanMsg: any = {
+        role: msg.role,
+      };
+
+      // Handle content (text or vision)
+      if (typeof msg.content === 'string') {
+        cleanMsg.content = msg.content;
+      } else if (Array.isArray(msg.content)) {
+        // Vision message case
+        cleanMsg.content = msg.content;
+      } else {
+        cleanMsg.content = msg.content;
+      }
+
+      return cleanMsg;
+    });
+  }
+
+  /**
+   * Build tools definition based on the endpoint type
+   */
+  private buildToolsDefinition(): any[] {
+    const isResponsesAPI = this.endpoint === ENDPOINT_OPENAI_RESPONSES_API;
+    const toolDefs: any[] = [];
+
+    // Add function tools
+    if (this.tools.length > 0) {
+      if (isResponsesAPI) {
+        // Responses API format (flattened function properties)
+        toolDefs.push(
+          ...this.tools.map((t) => ({
+            type: 'function',
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          })),
+        );
+      } else {
+        // Chat Completions API format (nested function properties)
+        toolDefs.push(
+          ...this.tools.map((t) => ({
+            type: 'function',
+            function: {
+              name: t.name,
+              description: t.description,
+              parameters: t.parameters,
+            },
+          })),
+        );
+      }
+    }
+
+    // Add MCP tools (only for Responses API)
+    if (this.mcpServers.length > 0 && isResponsesAPI) {
+      toolDefs.push(...this.buildMCPToolsDefinition());
+    }
+
+    return toolDefs;
+  }
+
+  /**
+   * Build MCP tools definition for Responses API
+   */
+  private buildMCPToolsDefinition(): any[] {
+    return this.mcpServers.map((server) => {
+      const mcpDef: any = {
+        type: 'mcp',
+        server_label: server.name,
+        server_url: server.url,
+        require_approval: 'never',
+      };
+
+      if (server.tool_configuration?.allowed_tools) {
+        mcpDef.allowed_tools = server.tool_configuration.allowed_tools;
+      }
+
+      if (server.authorization_token) {
+        mcpDef.headers = {
+          Authorization: `Bearer ${server.authorization_token}`,
+        };
+      }
+
+      return mcpDef;
+    });
   }
 
   private async handleStream(res: Response, onPartial: (t: string) => void) {
@@ -386,6 +512,201 @@ export class OpenAIChatService implements ChatService {
     return {
       blocks,
       stop_reason: choice.finish_reason === 'tool_calls' ? 'tool_use' : 'end',
+    };
+  }
+
+  /**
+   * Parse streaming response from Responses API (SSE format)
+   */
+  private async parseResponsesStream(
+    res: Response,
+    onPartial: (t: string) => void,
+  ): Promise<ToolChatCompletion> {
+    const reader = res.body!.getReader();
+    const dec = new TextDecoder();
+
+    const textBlocks: ToolChatBlock[] = [];
+    const toolCallsMap = new Map<string, any>();
+
+    let buf = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+
+      // Parse SSE format: process event: and data: combinations
+      let eventType = '';
+      let eventData = '';
+
+      const lines = buf.split('\n');
+      buf = lines.pop() || ''; // Keep the last incomplete line
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+
+        if (line.startsWith('event:')) {
+          eventType = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          eventData = line.slice(5).trim();
+        } else if (line === '' && eventType && eventData) {
+          // Process event separated by empty line
+          try {
+            const json = JSON.parse(eventData);
+            this.handleResponsesSSEEvent(
+              eventType,
+              json,
+              onPartial,
+              textBlocks,
+              toolCallsMap,
+            );
+          } catch (e) {
+            console.warn('Failed to parse SSE data:', eventData);
+          }
+          eventType = '';
+          eventData = '';
+        }
+      }
+    }
+
+    // Convert tool calls to blocks
+    const toolBlocks: ToolChatBlock[] = Array.from(toolCallsMap.values()).map(
+      (tool) => ({
+        type: 'tool_use',
+        id: tool.id,
+        name: tool.name,
+        input: tool.input || {},
+      }),
+    );
+
+    const blocks = [...textBlocks, ...toolBlocks];
+
+    return {
+      blocks,
+      stop_reason: toolBlocks.length ? 'tool_use' : 'end',
+    };
+  }
+
+  /**
+   * Handle specific SSE events from Responses API
+   */
+  private handleResponsesSSEEvent(
+    eventType: string,
+    data: any,
+    onPartial: (t: string) => void,
+    textBlocks: ToolChatBlock[],
+    toolCallsMap: Map<string, any>,
+  ): void {
+    // Helper to append text to the last text block or create a new one
+    const appendText = (txt: string) => {
+      if (!txt) return;
+      if (
+        textBlocks.length &&
+        textBlocks[textBlocks.length - 1].type === 'text'
+      ) {
+        (textBlocks[textBlocks.length - 1] as any).text += txt;
+      } else {
+        textBlocks.push({ type: 'text', text: txt });
+      }
+    };
+
+    switch (eventType) {
+      // Item addition events
+      case 'response.output_item.added':
+        if (data.item?.type === 'message' && Array.isArray(data.item.content)) {
+          data.item.content.forEach((c: any) => {
+            if (c.type === 'output_text' && c.text) {
+              onPartial(c.text);
+              appendText(c.text);
+            }
+          });
+        } else if (data.item?.type === 'function_call') {
+          toolCallsMap.set(data.item.id, {
+            id: data.item.id,
+            name: data.item.name,
+            input: data.item.arguments ? JSON.parse(data.item.arguments) : {},
+          });
+        }
+        break;
+
+      // Initial content part events
+      case 'response.content_part.added':
+        if (
+          data.part?.type === 'output_text' &&
+          typeof data.part.text === 'string'
+        ) {
+          onPartial(data.part.text);
+          appendText(data.part.text);
+        }
+        break;
+
+      // Text delta events
+      case 'response.output_text.delta':
+      case 'response.content_part.delta': // Also handle this event type just in case
+        {
+          const deltaText =
+            typeof data.delta === 'string'
+              ? data.delta
+              : (data.delta?.text ?? '');
+          if (deltaText) {
+            onPartial(deltaText);
+            appendText(deltaText);
+          }
+        }
+        break;
+
+      // Text completion events
+      case 'response.output_text.done':
+      case 'response.content_part.done':
+        if (typeof data.text === 'string' && data.text) {
+          appendText(data.text);
+        }
+        break;
+
+      // Response completion events
+      case 'response.completed':
+        break;
+
+      default:
+        // Ignore other events
+        break;
+    }
+  }
+
+  /**
+   * Parse non-streaming response from Responses API
+   */
+  private parseResponsesOneShot(data: any): ToolChatCompletion {
+    const blocks: ToolChatBlock[] = [];
+
+    // Process Responses API format: data.output array
+    if (data.output && Array.isArray(data.output)) {
+      data.output.forEach((outputItem: any) => {
+        if (outputItem.type === 'message' && outputItem.content) {
+          outputItem.content.forEach((content: any) => {
+            if (content.type === 'output_text' && content.text) {
+              blocks.push({ type: 'text', text: content.text });
+            }
+          });
+        }
+
+        // Handle function call items
+        if (outputItem.type === 'function_call') {
+          blocks.push({
+            type: 'tool_use',
+            id: outputItem.id,
+            name: outputItem.name,
+            input: outputItem.arguments ? JSON.parse(outputItem.arguments) : {},
+          });
+        }
+      });
+    }
+
+    return {
+      blocks,
+      stop_reason: blocks.some((b) => b.type === 'tool_use')
+        ? 'tool_use'
+        : 'end',
     };
   }
 }

--- a/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
+++ b/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
@@ -1,5 +1,6 @@
 import {
   ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+  ENDPOINT_OPENAI_RESPONSES_API,
   MODEL_GPT_4O_MINI,
   MODEL_GPT_4O,
   MODEL_O3_MINI,
@@ -33,13 +34,22 @@ export class OpenAIChatServiceProvider implements ChatServiceProvider {
     // tools definition
     const tools: ToolDefinition[] | undefined = options.tools;
 
+    // MCPサーバが設定されている場合は自動的にResponses APIを使用
+    const mcpServers = (options as any).mcpServers ?? [];
+    const shouldUseResponsesAPI = mcpServers.length > 0;
+    const endpoint =
+      options.endpoint ||
+      (shouldUseResponsesAPI
+        ? ENDPOINT_OPENAI_RESPONSES_API
+        : ENDPOINT_OPENAI_CHAT_COMPLETIONS_API);
+
     return new OpenAIChatService(
       options.apiKey,
       options.model || this.getDefaultModel(),
       visionModel,
       tools,
-      options.endpoint || ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
-      (options as any).mcpServers ?? [],
+      endpoint,
+      mcpServers,
     );
   }
 

--- a/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
+++ b/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
@@ -1,4 +1,5 @@
 import {
+  ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
   MODEL_GPT_4O_MINI,
   MODEL_GPT_4O,
   MODEL_O3_MINI,
@@ -37,6 +38,8 @@ export class OpenAIChatServiceProvider implements ChatServiceProvider {
       options.model || this.getDefaultModel(),
       visionModel,
       tools,
+      options.endpoint || ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+      (options as any).mcpServers ?? [],
     );
   }
 

--- a/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
+++ b/packages/core/src/services/chat/providers/openai/OpenAIChatServiceProvider.ts
@@ -34,7 +34,7 @@ export class OpenAIChatServiceProvider implements ChatServiceProvider {
     // tools definition
     const tools: ToolDefinition[] | undefined = options.tools;
 
-    // MCPサーバが設定されている場合は自動的にResponses APIを使用
+    // if MCP servers are set, automatically use Responses API
     const mcpServers = (options as any).mcpServers ?? [];
     const shouldUseResponsesAPI = mcpServers.length > 0;
     const endpoint =


### PR DESCRIPTION
## Summary
- add new OpenAI responses endpoint constant
- allow specifying endpoint in `ChatServiceOptions`
- support remote MCP servers for OpenAI provider
- pass MCP server configs from `AITuberOnAirCore` for OpenAI
- document OpenAI remote MCP usage in README (EN/JA)

## Testing
- `npm run fmt` *(fails: biome not installed)*
- `npm test` *(fails: missing type definitions)*