### PR TITLE
Update changesets/action from v2 to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
           publish: npm run changeset:publish
           version: npm run changeset:version


### PR DESCRIPTION
fix: update changesets/action from v2 to v1

GitHub Actions was failing with "Unable to resolve action changesets/action@v2" because v2 doesn't exist. Updated to use the latest stable v1 version.

🤖 Generated with [Claude Code](https://claude.ai/code)