### PR TITLE
Update release workflow to build packages in dependency order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
-        run: npm install --workspaces --ignore-scripts --no-audit --no-fund
+        run: npm ci
+
+      - name: Build packages in dependency order
+        run: |
+          npm -w @aituber-onair/voice run build
+          npm -w @aituber-onair/core run build
 
       - name: Run Tests
-        run: npm run test
-
-      - name: Build Packages
-        run: npm run build
+        run: npm run test --workspaces
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
fix: update release workflow to build packages in dependency order

Applied same fix as CI workflow:
- Use npm ci for deterministic installs
- Build voice package first, then core package
- This ensures core can find voice type declarations
- Moved tests after build to ensure build artifacts exist

🤖 Generated with [Claude Code](https://claude.ai/code)