### PR TITLE
Fix core example OpenAI default setting

### DIFF
--- a/packages/core/examples/react-basic/src/App.tsx
+++ b/packages/core/examples/react-basic/src/App.tsx
@@ -82,7 +82,7 @@ const App: React.FC = () => {
     CHAT_RESPONSE_LENGTH.MEDIUM,
   );
   const [gpt5Preset, setGpt5Preset] = useState<GPT5PresetKey | 'custom'>(
-    'balanced',
+    'casual',
   );
   const [verbosity, setVerbosity] = useState<'low' | 'medium' | 'high'>(
     'medium',

--- a/packages/core/examples/react-basic/src/constants/openai.ts
+++ b/packages/core/examples/react-basic/src/constants/openai.ts
@@ -14,13 +14,13 @@ import {
 
 // OpenAI models list
 export const openaiModels = [
+  MODEL_GPT_4_1_NANO,
+  MODEL_GPT_4_1_MINI,
+  MODEL_GPT_4_1,
   MODEL_GPT_5_NANO,
   MODEL_GPT_5_MINI,
   MODEL_GPT_5,
   MODEL_GPT_5_CHAT_LATEST,
-  MODEL_GPT_4_1_NANO,
-  MODEL_GPT_4_1_MINI,
-  MODEL_GPT_4_1,
   MODEL_O3_MINI,
   MODEL_GPT_4O_MINI,
   MODEL_GPT_4O,


### PR DESCRIPTION
Change core example OpenAI settings:

* default OpenAI model: `gpt-4.1-nano`
* default gpt5Preset: `casual`