### PR TITLE
Remove unused category field from TopicInfo interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5790,7 +5790,7 @@
         },
         "packages/manneri": {
             "name": "@aituber-onair/manneri",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/manneri/CHANGELOG.md
+++ b/packages/manneri/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @aituber-onair/manneri
 
+## 0.2.0
+
+### Major Changes
+
+- **BREAKING**: Removed unused `category` field from `TopicInfo` interface
+  - The `category` field was not being used in intervention logic
+  - Intervention decisions are based solely on `confidence` scores
+  - This simplifies the API and reduces unnecessary code complexity
+  - Migration: Remove any references to `topic.category` from your code
+
+### Improvements
+
+- Cleaner and more maintainable codebase
+- Reduced bundle size by removing unused categorization logic
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/manneri/package.json
+++ b/packages/manneri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/manneri",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A lightweight conversation pattern detection library to prevent repetitive AI responses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/manneri/src/analyzers/KeywordExtractor.ts
+++ b/packages/manneri/src/analyzers/KeywordExtractor.ts
@@ -193,7 +193,6 @@ export class KeywordExtractor {
     return clusters.map((cluster) => ({
       keywords: cluster.keywords,
       score: cluster.score,
-      category: this.categorizeKeywords(cluster.keywords),
       confidence: Math.min(cluster.score / 10, 1.0),
     }));
   }
@@ -304,44 +303,6 @@ export class KeywordExtractor {
       messageCount *
       (1 + Math.min(1, timeSpan / (60 * 60 * 1000)))
     );
-  }
-
-  private categorizeKeywords(keywords: string[]): string {
-    const categories = {
-      技術: [
-        '技術',
-        'プログラミング',
-        'コード',
-        'システム',
-        'API',
-        'データベース',
-        'サーバー',
-      ],
-      エンターテイメント: [
-        'ゲーム',
-        '音楽',
-        '映画',
-        'アニメ',
-        'TV',
-        'スポーツ',
-      ],
-      日常: ['食事', '天気', '仕事', '家族', '友達', '学校'],
-      その他: [],
-    };
-
-    for (const [category, categoryKeywords] of Object.entries(categories)) {
-      if (category === 'その他') continue;
-
-      const matchCount = keywords.filter((k) =>
-        categoryKeywords.some((ck) => k.includes(ck) || ck.includes(k))
-      ).length;
-
-      if (matchCount > 0) {
-        return category;
-      }
-    }
-
-    return 'その他';
   }
 
   private calculateKeywordDensity(

--- a/packages/manneri/src/types/index.ts
+++ b/packages/manneri/src/types/index.ts
@@ -43,7 +43,6 @@ export interface ConversationPattern {
 export interface TopicInfo {
   keywords: string[];
   score: number;
-  category: string;
   confidence: number;
 }
 

--- a/packages/manneri/tests/KeywordExtractor.test.ts
+++ b/packages/manneri/tests/KeywordExtractor.test.ts
@@ -264,7 +264,7 @@ describe('KeywordExtractor', () => {
   });
 
   describe('getTopicInfo', () => {
-    it('should get topic information with categories', () => {
+    it('should get topic information', () => {
       const topicInfo = extractor.getTopicInfo(mockMessages);
 
       expect(topicInfo).toBeInstanceOf(Array);
@@ -273,31 +273,13 @@ describe('KeywordExtractor', () => {
       for (const topic of topicInfo) {
         expect(topic).toHaveProperty('keywords');
         expect(topic).toHaveProperty('score');
-        expect(topic).toHaveProperty('category');
         expect(topic).toHaveProperty('confidence');
 
         expect(topic.keywords).toBeInstanceOf(Array);
         expect(topic.score).toBeGreaterThan(0);
         expect(topic.confidence).toBeGreaterThanOrEqual(0);
         expect(topic.confidence).toBeLessThanOrEqual(1);
-        expect(['技術', 'エンターテイメント', '日常', 'その他']).toContain(
-          topic.category
-        );
       }
-    });
-
-    it('should categorize programming topics correctly', () => {
-      const programmingMessages: Message[] = [
-        { role: 'user', content: 'プログラミング技術について話しましょう' },
-        { role: 'assistant', content: 'コードの最適化が重要です' },
-      ];
-
-      const topicInfo = extractor.getTopicInfo(programmingMessages);
-
-      expect(topicInfo.length).toBeGreaterThan(0);
-      // Should categorize as technical topic
-      const technicalTopics = topicInfo.filter((t) => t.category === '技術');
-      expect(technicalTopics.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
Remove the category field from TopicInfo interface and categorizeKeywords method as they were not being used in the actual intervention logic. The intervention decisions are based solely on confidence scores, making the category classification unnecessary dead code.

BREAKING CHANGE: TopicInfo interface no longer includes category field. Remove any references to topic.category from your code.

## Related issue
https://github.com/shinshin86/aituber-onair/issues/55