### PR TITLE
chore(voice): prepare @aituber-onair/voice v0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6747,7 +6747,7 @@
             "license": "MIT",
             "dependencies": {
                 "@aituber-onair/chat": "^0.25.0",
-                "@aituber-onair/voice": "^0.11.0"
+                "@aituber-onair/voice": "^0.12.0"
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -7284,7 +7284,7 @@
         },
         "packages/voice": {
             "name": "@aituber-onair/voice",
-            "version": "0.11.0",
+            "version": "0.12.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@aituber-onair/chat": "^0.25.0",
-    "@aituber-onair/voice": "^0.11.0"
+    "@aituber-onair/voice": "^0.12.0"
   },
   "peerDependencies": {
     "@pixiv/three-vrm": "^1.0.9"

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @aituber-onair/voice
 
+## 0.12.0
+
+### Minor Changes
+
+- Added piper-plus browser WASM TTS engine via `engineType: 'piperPlus'`.
+  - Introduce `PiperPlusEngine` using ONNX Runtime Web and OpenJTalk WASM for
+    fully on-device Japanese speech synthesis in the browser.
+  - Support `piperPlusModelPath`, `piperPlusSpeed`, `piperPlusNoiseScale`,
+    `piperPlusNoiseW`, and `piperPlusLengthScale` options.
+  - Register piper-plus in the voice engine factory, public exports, internal
+    engine handlers, React example with asset detection UI and setup guide, and
+    tests.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/voice",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Voice synthesis library for AITuber OnAir",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Bump voice package to 0.12.0 for the piper-plus browser WASM TTS engine release and update core dependency range accordingly.