### PR TITLE
feat(chat): low-latency reasoning defaults and normalization for GPT-5 models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6502,7 +6502,7 @@
         },
         "packages/chat": {
             "name": "@aituber-onair/chat",
-            "version": "0.37.0",
+            "version": "0.38.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -6860,7 +6860,7 @@
             "version": "0.26.0",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.37.0",
+                "@aituber-onair/chat": "^0.38.0",
                 "@aituber-onair/voice": "^0.17.0"
             },
             "devDependencies": {
@@ -7420,7 +7420,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.37.0"
+                "@aituber-onair/chat": "^0.38.0"
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @aituber-onair/chat
 
+## 0.38.0
+
+### Minor Changes
+
+- Changed the default `reasoning_effort` for GPT-5.4 Mini and GPT-5.4 Nano
+  from `medium` to `none`, so every model that supports `none` now defaults
+  to the low-latency setting.
+- Changed `reasoning_effort` normalization to round unsupported values to
+  the nearest supported level instead of resetting to the model default.
+  This fixes the `casual` preset escalating to `medium` reasoning on
+  GPT-5.4 Mini/Nano and `xhigh` dropping to `none` on GPT-5.1.
+- Documented GPT-5 presets, default/normalization rules, and recommended
+  low-latency settings for real-time character chat (AITuber-style) in the
+  English/Japanese README.
+
 ## 0.37.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -449,11 +449,55 @@ const compatibleService = ChatServiceFactory.createChatService(
 
 `reasoning_effort` の選択肢はモデルによって異なります。
 - `gpt-5.4-pro`: `'medium' | 'high' | 'xhigh'`（Responses API 専用）
-- `gpt-5.5`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`（このパッケージでは高速なチャット応答を優先してデフォルトは `'none'`）
+- `gpt-5.5`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.4`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.4-mini` / `gpt-5.4-nano`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.1`: `'none' | 'low' | 'medium' | 'high'`
 - `gpt-5` / `gpt-5-mini` / `gpt-5-nano`: `'minimal' | 'low' | 'medium' | 'high'`
+
+このパッケージでのデフォルト値と正規化:
+- `'none'` に対応するモデル（`gpt-5.1`, `gpt-5.4`, `gpt-5.4-mini`,
+  `gpt-5.4-nano`, `gpt-5.5`）は、高速なチャット応答を優先してデフォルトが
+  `'none'` になります。OpenAI 公式のデフォルトが `'medium'` のモデルも
+  ありますが、このパッケージでは意図的に低遅延を優先しています。
+- それ以外の GPT-5 系モデルのデフォルトは `'medium'` です。
+- モデルが対応していない値はリセットされず、最も近い対応値に丸められます
+  （例: `gpt-5.4-nano` の `'minimal'` は `'none'` に、`gpt-5-nano` の
+  `'none'` は `'minimal'` に、`gpt-5.1` の `'xhigh'` は `'high'` に
+  解決されます）。
+
+##### GPT-5 プリセットと低遅延チャット（AITuber 向け）
+
+モデルごとに `reasoning_effort` と `verbosity` を調整する代わりに、
+`gpt5Preset` を指定できます。
+
+- `casual` – 最速の応答（`reasoning_effort: 'minimal'`,
+  `verbosity: 'low'`）。`'minimal'` 非対応モデルでは、そのモデルで使える
+  最小の effort に解決されます（GPT-5.1 / 5.4 / 5.5 系では `'none'`、
+  `gpt-5.4-pro` では `'medium'`）。
+- `balanced` – `reasoning_effort: 'medium'`, `verbosity: 'medium'`。
+- `expert` – `reasoning_effort: 'high'`, `verbosity: 'high'`。
+
+深い推論よりも最初の応答までの速さが重要なリアルタイムのキャラクター
+チャット(AITuber 向け)には、次の設定を推奨します。
+
+```typescript
+const aituberChatService = ChatServiceFactory.createChatService('openai', {
+  apiKey: process.env.OPENAI_API_KEY,
+  model: 'gpt-5.4-nano',
+  gpt5Preset: 'casual', // このモデルでは reasoning_effort 'none' に解決
+  responseLength: 'veryShort', // 少し長めの応答なら 'short'
+});
+```
+
+注意点:
+- 低い reasoning effort は、速度と引き換えに複雑な質問への回答品質が
+  低下する可能性があります。ツール/関数呼び出しや MCP を多用する場合は
+  `balanced` 以上を推奨します。
+- 一部の GPT-5.4 系モデルでは、Chat Completions API で function tools と
+  `reasoning_effort` の併用がサポートされていません。ツールと reasoning
+  設定を併用する場合は `gpt5EndpointPreference: 'responses'` を指定して
+  ください。
 
 **GPT-5ファミリーの概要**
 

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -467,11 +467,54 @@ Notes:
 
 `reasoning_effort` options differ per model:
 - `gpt-5.4-pro`: `'medium' | 'high' | 'xhigh'` (Responses API only)
-- `gpt-5.5`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'` (defaults to `'none'` in this package for fast chat responses)
+- `gpt-5.5`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.4`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.4-mini` / `gpt-5.4-nano`: `'none' | 'low' | 'medium' | 'high' | 'xhigh'`
 - `gpt-5.1`: `'none' | 'low' | 'medium' | 'high'`
 - `gpt-5` / `gpt-5-mini` / `gpt-5-nano`: `'minimal' | 'low' | 'medium' | 'high'`
+
+Defaults and normalization in this package:
+- Models that support `'none'` (`gpt-5.1`, `gpt-5.4`, `gpt-5.4-mini`,
+  `gpt-5.4-nano`, `gpt-5.5`) default to `'none'` for fast chat responses.
+  Note that OpenAI's own default for some of these models is `'medium'`;
+  this package intentionally prioritizes low latency.
+- Other GPT-5 models default to `'medium'`.
+- Values a model does not support are rounded to the nearest supported
+  level instead of being reset (e.g. `'minimal'` on `gpt-5.4-nano`
+  resolves to `'none'`, `'none'` on `gpt-5-nano` resolves to `'minimal'`,
+  and `'xhigh'` on `gpt-5.1` resolves to `'high'`).
+
+##### GPT-5 Presets and Low-Latency Chat (AITuber-style)
+
+Instead of tuning `reasoning_effort` and `verbosity` per model, you can set
+`gpt5Preset`:
+
+- `casual` – fastest responses (`reasoning_effort: 'minimal'`,
+  `verbosity: 'low'`). On models without `'minimal'` this resolves to the
+  lowest supported effort (`'none'` on the GPT-5.1/5.4/5.5 family,
+  `'medium'` on `gpt-5.4-pro`).
+- `balanced` – `reasoning_effort: 'medium'`, `verbosity: 'medium'`.
+- `expert` – `reasoning_effort: 'high'`, `verbosity: 'high'`.
+
+Recommended settings for real-time character chat (AITuber-style), where
+time-to-first-token matters more than deep reasoning:
+
+```typescript
+const aituberChatService = ChatServiceFactory.createChatService('openai', {
+  apiKey: process.env.OPENAI_API_KEY,
+  model: 'gpt-5.4-nano',
+  gpt5Preset: 'casual', // resolves to reasoning_effort 'none' on this model
+  responseLength: 'veryShort', // or 'short' for slightly longer replies
+});
+```
+
+Caveats:
+- Low reasoning effort trades answer quality on complex questions for
+  speed. For tool/function calling or MCP-heavy flows, prefer `balanced`
+  or higher.
+- OpenAI does not support function tools combined with `reasoning_effort`
+  on the Chat Completions API for some GPT-5.4 models. When you use tools
+  with reasoning settings, set `gpt5EndpointPreference: 'responses'`.
 
 **Meet the GPT-5 family**
 

--- a/packages/chat/examples/react-basic/src/App.tsx
+++ b/packages/chat/examples/react-basic/src/App.tsx
@@ -66,25 +66,31 @@ const normalizeReasoningEffortForModel = (
     return effort;
   }
 
-  const defaultEffort = getDefaultReasoningEffortForGPT5Model(modelId);
   if (!effort) {
-    return defaultEffort;
+    return getDefaultReasoningEffortForGPT5Model(modelId);
   }
 
-  if (effort === 'none' && !allowsReasoningNone(modelId)) {
-    return defaultEffort;
-  }
-
-  if (effort === 'minimal' && !allowsReasoningMinimal(modelId)) {
-    return defaultEffort;
+  // Round unsupported values to the nearest supported level, matching the
+  // normalization performed by the chat package.
+  if (
+    (effort === 'none' && !allowsReasoningNone(modelId)) ||
+    (effort === 'minimal' && !allowsReasoningMinimal(modelId))
+  ) {
+    if (effort === 'minimal' && allowsReasoningNone(modelId)) {
+      return 'none';
+    }
+    if (effort === 'none' && allowsReasoningMinimal(modelId)) {
+      return 'minimal';
+    }
+    return allowsReasoningLow(modelId) ? 'low' : 'medium';
   }
 
   if (effort === 'low' && !allowsReasoningLow(modelId)) {
-    return defaultEffort;
+    return 'medium';
   }
 
   if (effort === 'xhigh' && !allowsReasoningXHigh(modelId)) {
-    return defaultEffort;
+    return 'high';
   }
 
   return effort;

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -1192,21 +1192,28 @@ export default function ProviderSelector({
       return reasoning_effort;
     }
 
-    const fallback = getDefaultReasoningEffortForGPT5Model(selectedModel);
     if (!reasoning_effort) {
-      return fallback;
+      return getDefaultReasoningEffortForGPT5Model(selectedModel);
     }
-    if (reasoning_effort === 'none' && !allowsNone) {
-      return fallback;
-    }
-    if (reasoning_effort === 'minimal' && !allowsMinimal) {
-      return fallback;
+    // Round unsupported values to the nearest supported level, matching the
+    // normalization performed by the chat package.
+    if (
+      (reasoning_effort === 'none' && !allowsNone) ||
+      (reasoning_effort === 'minimal' && !allowsMinimal)
+    ) {
+      if (reasoning_effort === 'minimal' && allowsNone) {
+        return 'none';
+      }
+      if (reasoning_effort === 'none' && allowsMinimal) {
+        return 'minimal';
+      }
+      return allowsLow ? 'low' : 'medium';
     }
     if (reasoning_effort === 'low' && !allowsLow) {
-      return fallback;
+      return 'medium';
     }
     if (reasoning_effort === 'xhigh' && !allowsXHigh) {
-      return fallback;
+      return 'high';
     }
     return reasoning_effort;
   })();

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -1531,7 +1531,7 @@ export default function ProviderSelector({
                 >
                   <option value="">Custom Settings</option>
                   <option value="casual">
-                    Casual (fast, minimal reasoning)
+                    Casual (fastest, lowest reasoning for the model)
                   </option>
                   <option value="balanced">Balanced (medium reasoning)</option>
                   <option value="expert">Expert (deep reasoning)</option>

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/chat",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Chat and LLM API integration library for AITuber OnAir",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/chat/src/constants/openai.ts
+++ b/packages/chat/src/constants/openai.ts
@@ -133,17 +133,14 @@ export function allowsReasoningLow(model: string): boolean {
 
 /**
  * Get default reasoning effort by GPT-5 model family
- * - GPT-5.1 / GPT-5.4 / GPT-5.5: none
+ * - Models that support reasoning_effort 'none'
+ *   (GPT-5.1 / GPT-5.4 / GPT-5.5 family, except Pro): none
  * - GPT-5.4 Pro and earlier GPT-5 variants: medium
  */
 export function getDefaultReasoningEffortForGPT5Model(
   model: string,
 ): 'none' | 'medium' {
-  if (
-    model === MODEL_GPT_5_1 ||
-    model === MODEL_GPT_5_4 ||
-    model === MODEL_GPT_5_5
-  ) {
+  if (allowsReasoningNone(model)) {
     return 'none';
   }
   return 'medium';

--- a/packages/chat/src/services/providers/openai/OpenAIChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/openai/OpenAIChatServiceProvider.ts
@@ -216,6 +216,12 @@ export class OpenAIChatServiceProvider
 
   /**
    * Normalize reasoning effort to a model-supported value
+   *
+   * Unsupported values are rounded to the nearest supported level instead of
+   * resetting to the model default, so a low-latency request stays low
+   * (e.g. 'minimal' on GPT-5.4 resolves to 'none', not 'medium') and a
+   * high-effort request stays high (e.g. 'xhigh' on GPT-5.1 resolves to
+   * 'high', not 'none').
    */
   private normalizeReasoningEffort(
     modelName: string,
@@ -225,20 +231,25 @@ export class OpenAIChatServiceProvider
       return undefined;
     }
 
-    if (effort === 'none' && !allowsReasoningNone(modelName)) {
-      return getDefaultReasoningEffortForGPT5Model(modelName);
-    }
-
-    if (effort === 'minimal' && !allowsReasoningMinimal(modelName)) {
-      return getDefaultReasoningEffortForGPT5Model(modelName);
+    if (
+      (effort === 'none' && !allowsReasoningNone(modelName)) ||
+      (effort === 'minimal' && !allowsReasoningMinimal(modelName))
+    ) {
+      if (effort === 'minimal' && allowsReasoningNone(modelName)) {
+        return 'none';
+      }
+      if (effort === 'none' && allowsReasoningMinimal(modelName)) {
+        return 'minimal';
+      }
+      return allowsReasoningLow(modelName) ? 'low' : 'medium';
     }
 
     if (effort === 'low' && !allowsReasoningLow(modelName)) {
-      return getDefaultReasoningEffortForGPT5Model(modelName);
+      return 'medium';
     }
 
     if (effort === 'xhigh' && !allowsReasoningXHigh(modelName)) {
-      return getDefaultReasoningEffortForGPT5Model(modelName);
+      return 'high';
     }
 
     return effort;

--- a/packages/chat/tests/constants/openai.test.ts
+++ b/packages/chat/tests/constants/openai.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MODEL_GPT_5,
+  MODEL_GPT_5_1,
+  MODEL_GPT_5_4,
+  MODEL_GPT_5_4_MINI,
+  MODEL_GPT_5_4_NANO,
+  MODEL_GPT_5_4_PRO,
+  MODEL_GPT_5_5,
+  MODEL_GPT_5_MINI,
+  MODEL_GPT_5_NANO,
+  getDefaultReasoningEffortForGPT5Model,
+} from '../../src/constants/openai';
+
+describe('getDefaultReasoningEffortForGPT5Model', () => {
+  it('returns none for all models that support reasoning_effort none', () => {
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_1)).toBe('none');
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_4)).toBe('none');
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_5)).toBe('none');
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_4_MINI)).toBe(
+      'none',
+    );
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_4_NANO)).toBe(
+      'none',
+    );
+  });
+
+  it('returns medium for models without reasoning_effort none support', () => {
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5)).toBe('medium');
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_MINI)).toBe(
+      'medium',
+    );
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_NANO)).toBe(
+      'medium',
+    );
+    expect(getDefaultReasoningEffortForGPT5Model(MODEL_GPT_5_4_PRO)).toBe(
+      'medium',
+    );
+  });
+});

--- a/packages/chat/tests/providers/OpenAIChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/OpenAIChatServiceProvider.test.ts
@@ -764,15 +764,18 @@ describe('OpenAIChatServiceProvider', () => {
     });
 
     it('should create services for all GPT-5 models correctly', () => {
-      const gpt5Models = [
-        MODEL_GPT_5_NANO,
-        MODEL_GPT_5_MINI,
-        MODEL_GPT_5,
-        MODEL_GPT_5_4_MINI,
-        MODEL_GPT_5_4_NANO,
+      const gpt5Models: Array<{
+        model: string;
+        defaultEffort: 'none' | 'medium';
+      }> = [
+        { model: MODEL_GPT_5_NANO, defaultEffort: 'medium' },
+        { model: MODEL_GPT_5_MINI, defaultEffort: 'medium' },
+        { model: MODEL_GPT_5, defaultEffort: 'medium' },
+        { model: MODEL_GPT_5_4_MINI, defaultEffort: 'none' },
+        { model: MODEL_GPT_5_4_NANO, defaultEffort: 'none' },
       ];
 
-      gpt5Models.forEach((model) => {
+      gpt5Models.forEach(({ model, defaultEffort }) => {
         // Clear previous calls
         vi.clearAllMocks();
 
@@ -793,7 +796,7 @@ describe('OpenAIChatServiceProvider', () => {
           [],
           undefined,
           undefined,
-          'medium', // default reasoning_effort for GPT-5
+          defaultEffort,
           undefined,
           'openai',
         );

--- a/packages/chat/tests/providers/OpenAIChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/OpenAIChatServiceProvider.test.ts
@@ -359,7 +359,7 @@ describe('OpenAIChatServiceProvider', () => {
       );
     });
 
-    it('should fallback reasoning effort to default when none is not supported', () => {
+    it('should round none up to minimal when none is not supported', () => {
       const options: OpenAIChatServiceOptions = {
         apiKey: 'test-api-key',
         model: MODEL_GPT_5,
@@ -377,7 +377,7 @@ describe('OpenAIChatServiceProvider', () => {
         [],
         undefined,
         undefined,
-        'medium',
+        'minimal',
         undefined,
         'openai',
       );
@@ -426,6 +426,102 @@ describe('OpenAIChatServiceProvider', () => {
         undefined,
         undefined,
         'none',
+        undefined,
+        'openai',
+      );
+    });
+
+    it('should round xhigh down to high when xhigh is not supported', () => {
+      const options: OpenAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GPT_5_1,
+        reasoning_effort: 'xhigh',
+      };
+
+      provider.createChatService(options);
+
+      expect(OpenAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GPT_5_1,
+        MODEL_GPT_5_1,
+        undefined,
+        ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+        [],
+        undefined,
+        undefined,
+        'high',
+        undefined,
+        'openai',
+      );
+    });
+
+    it('should resolve casual preset to none for GPT-5.4 Nano', () => {
+      const options: OpenAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GPT_5_4_NANO,
+        gpt5Preset: 'casual',
+      };
+
+      provider.createChatService(options);
+
+      expect(OpenAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GPT_5_4_NANO,
+        MODEL_GPT_5_4_NANO,
+        undefined,
+        ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+        [],
+        undefined,
+        'low',
+        'none',
+        undefined,
+        'openai',
+      );
+    });
+
+    it('should resolve casual preset to minimal for GPT-5 Nano', () => {
+      const options: OpenAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GPT_5_NANO,
+        gpt5Preset: 'casual',
+      };
+
+      provider.createChatService(options);
+
+      expect(OpenAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GPT_5_NANO,
+        MODEL_GPT_5_NANO,
+        undefined,
+        ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+        [],
+        undefined,
+        'low',
+        'minimal',
+        undefined,
+        'openai',
+      );
+    });
+
+    it('should resolve casual preset to medium for GPT-5.4 Pro', () => {
+      const options: OpenAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GPT_5_4_PRO,
+        gpt5Preset: 'casual',
+      };
+
+      provider.createChatService(options);
+
+      expect(OpenAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GPT_5_4_PRO,
+        MODEL_GPT_5_4_PRO,
+        undefined,
+        ENDPOINT_OPENAI_RESPONSES_API,
+        [],
+        undefined,
+        'low',
+        'medium',
         undefined,
         'openai',
       );

--- a/packages/chat/tests/providers/openaiRequestBuilder.test.ts
+++ b/packages/chat/tests/providers/openaiRequestBuilder.test.ts
@@ -5,6 +5,7 @@ import {
   ENDPOINT_OPENAI_RESPONSES_API,
   MODEL_GPT_5_4,
   MODEL_GPT_5_4_MINI,
+  MODEL_GPT_5_4_NANO,
 } from '../../src/constants';
 import { buildOpenAIRequestBody } from '../../src/services/providers/openai/openaiRequestBuilder';
 import type {
@@ -46,6 +47,24 @@ describe('buildOpenAIRequestBody', () => {
     });
 
     expect(body.max_output_tokens).toBe(4000);
+  });
+
+  it('uses the none reasoning minimum for GPT-5.4-nano when effort is unspecified', () => {
+    const body = buildOpenAIRequestBody({
+      provider: 'openai',
+      endpoint: ENDPOINT_OPENAI_RESPONSES_API,
+      messages,
+      model: MODEL_GPT_5_4_NANO,
+      stream: false,
+      tools: [],
+      mcpServers: [],
+      responseLength: CHAT_RESPONSE_LENGTH.MEDIUM,
+    });
+
+    // Default effort resolves to 'none' (min 1200), so the medium
+    // response-length floor (2000) wins instead of the 'medium' effort
+    // floor (4000).
+    expect(body.max_output_tokens).toBe(2000);
   });
 
   it('keeps explicit maxTokens unchanged', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   "author": "shinshin86 (https://github.com/shinshin86)",
   "license": "MIT",
   "dependencies": {
-    "@aituber-onair/chat": "^0.37.0",
+    "@aituber-onair/chat": "^0.38.0",
     "@aituber-onair/voice": "^0.17.0"
   },
   "peerDependencies": {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -52,7 +52,7 @@
     "directory": "packages/noise"
   },
   "dependencies": {
-    "@aituber-onair/chat": "^0.37.0"
+    "@aituber-onair/chat": "^0.38.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary

Optimizes GPT-5 reasoning effort handling for low-latency, real-time character chat (AITuber-style) use cases.

- **Default effort fix**: every model that supports `reasoning_effort: 'none'` (GPT-5.1 / 5.4 / 5.4-mini / 5.4-nano / 5.5) now defaults to `'none'`. Previously `gpt-5.4-mini` / `gpt-5.4-nano` fell back to `'medium'`.
- **Normalization fix**: unsupported effort values are now rounded to the nearest supported level instead of being reset to the model default.
  - Fixes the `casual` preset (`minimal`) **escalating** to `medium` reasoning on `gpt-5.4-mini` / `gpt-5.4-nano` (now resolves to `none`).
  - Fixes `xhigh` **dropping** to `none` on `gpt-5.1` (now resolves to `high`).
- **Docs**: added a GPT-5 presets section to the README (en/ja) covering default/normalization rules, recommended low-latency settings (`gpt-5.4-nano` + `gpt5Preset: 'casual'` + `responseLength: 'veryShort'`), and a caveat about combining tools with reasoning settings on the Chat Completions API.
- **Examples**: aligned the react-basic example's duplicated effort normalization helpers with the new nearest-level rounding so the UI no longer overrides the package behavior.
- **Release**: chat 0.38.0 (minor), updated the workspace dependency ranges in core and noise to `^0.38.0`, regenerated `package-lock.json` (validated with `npm ci`).

## Effort resolution matrix (after this PR)

| Model | default | `none` | `minimal` (casual) | `xhigh` |
|---|---|---|---|---|
| gpt-5 / 5-mini / 5-nano | `medium` | → `minimal` | `minimal` | → `high` |
| gpt-5.1 | `none` | `none` | → `none` | → `high` |
| gpt-5.4 / 5.5 | `none` | `none` | → `none` | `xhigh` |
| gpt-5.4-mini / 5.4-nano | `none` (was `medium`) | `none` | → `none` (was `medium`) | `xhigh` |
| gpt-5.4-pro | `medium` | → `medium` | → `medium` | `xhigh` |

## Test plan

- [x] New: `tests/constants/openai.test.ts` (per-model default effort verification)
- [x] New: 5 provider tests for preset resolution and rounding direction
- [x] New: regression test pinning the `none` default on the Responses API path
- [x] Updated existing expectations (e.g. `gpt-5` + `none` → `minimal`)
- [x] DoD: `npm run fmt` / `lint` / `test` (all 8 workspaces pass) / `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)