### PR TITLE
fix(deps): update Vitest past critical audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,11 +157,14 @@
             }
         },
         "node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@biomejs/biome": {
             "version": "1.9.4",
@@ -328,13 +331,13 @@
             }
         },
         "node_modules/@changesets/apply-release-plan": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.12.tgz",
-            "integrity": "sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+            "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@changesets/config": "^3.1.1",
+                "@changesets/config": "^3.1.4",
                 "@changesets/get-version-range-type": "^0.4.0",
                 "@changesets/git": "^3.0.4",
                 "@changesets/should-skip-package": "^0.1.2",
@@ -350,14 +353,14 @@
             }
         },
         "node_modules/@changesets/assemble-release-plan": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
-            "integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+            "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@changesets/errors": "^0.2.0",
-                "@changesets/get-dependents-graph": "^2.1.3",
+                "@changesets/get-dependents-graph": "^2.1.4",
                 "@changesets/should-skip-package": "^0.1.2",
                 "@changesets/types": "^6.1.0",
                 "@manypkg/get-packages": "^1.1.3",
@@ -387,34 +390,32 @@
             }
         },
         "node_modules/@changesets/cli": {
-            "version": "2.29.5",
-            "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.5.tgz",
-            "integrity": "sha512-0j0cPq3fgxt2dPdFsg4XvO+6L66RC0pZybT9F4dG5TBrLA3jA/1pNkdTXH9IBBVHkgsKrNKenI3n1mPyPlIydg==",
+            "version": "2.31.0",
+            "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+            "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@changesets/apply-release-plan": "^7.0.12",
-                "@changesets/assemble-release-plan": "^6.0.9",
+                "@changesets/apply-release-plan": "^7.1.1",
+                "@changesets/assemble-release-plan": "^6.0.10",
                 "@changesets/changelog-git": "^0.2.1",
-                "@changesets/config": "^3.1.1",
+                "@changesets/config": "^3.1.4",
                 "@changesets/errors": "^0.2.0",
-                "@changesets/get-dependents-graph": "^2.1.3",
-                "@changesets/get-release-plan": "^4.0.13",
+                "@changesets/get-dependents-graph": "^2.1.4",
+                "@changesets/get-release-plan": "^4.0.16",
                 "@changesets/git": "^3.0.4",
                 "@changesets/logger": "^0.1.1",
                 "@changesets/pre": "^2.0.2",
-                "@changesets/read": "^0.6.5",
+                "@changesets/read": "^0.6.7",
                 "@changesets/should-skip-package": "^0.1.2",
                 "@changesets/types": "^6.1.0",
                 "@changesets/write": "^0.4.0",
+                "@inquirer/external-editor": "^1.0.2",
                 "@manypkg/get-packages": "^1.1.3",
                 "ansi-colors": "^4.1.3",
-                "ci-info": "^3.7.0",
                 "enquirer": "^2.4.1",
-                "external-editor": "^3.1.0",
                 "fs-extra": "^7.0.1",
                 "mri": "^1.2.0",
-                "p-limit": "^2.2.0",
                 "package-manager-detector": "^0.2.0",
                 "picocolors": "^1.1.0",
                 "resolve-from": "^5.0.0",
@@ -427,15 +428,16 @@
             }
         },
         "node_modules/@changesets/config": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.1.tgz",
-            "integrity": "sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+            "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@changesets/errors": "^0.2.0",
-                "@changesets/get-dependents-graph": "^2.1.3",
+                "@changesets/get-dependents-graph": "^2.1.4",
                 "@changesets/logger": "^0.1.1",
+                "@changesets/should-skip-package": "^0.1.2",
                 "@changesets/types": "^6.1.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "fs-extra": "^7.0.1",
@@ -453,9 +455,9 @@
             }
         },
         "node_modules/@changesets/get-dependents-graph": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
-            "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+            "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -477,16 +479,16 @@
             }
         },
         "node_modules/@changesets/get-release-plan": {
-            "version": "4.0.13",
-            "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.13.tgz",
-            "integrity": "sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+            "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@changesets/assemble-release-plan": "^6.0.9",
-                "@changesets/config": "^3.1.1",
+                "@changesets/assemble-release-plan": "^6.0.10",
+                "@changesets/config": "^3.1.4",
                 "@changesets/pre": "^2.0.2",
-                "@changesets/read": "^0.6.5",
+                "@changesets/read": "^0.6.7",
                 "@changesets/types": "^6.1.0",
                 "@manypkg/get-packages": "^1.1.3"
             }
@@ -523,14 +525,14 @@
             }
         },
         "node_modules/@changesets/parse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.1.tgz",
-            "integrity": "sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+            "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@changesets/types": "^6.1.0",
-                "js-yaml": "^3.13.1"
+                "js-yaml": "^4.1.1"
             }
         },
         "node_modules/@changesets/pre": {
@@ -547,15 +549,15 @@
             }
         },
         "node_modules/@changesets/read": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.5.tgz",
-            "integrity": "sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+            "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@changesets/git": "^3.0.4",
                 "@changesets/logger": "^0.1.1",
-                "@changesets/parse": "^0.4.1",
+                "@changesets/parse": "^0.4.3",
                 "@changesets/types": "^6.1.0",
                 "fs-extra": "^7.0.1",
                 "p-filter": "^2.1.0",
@@ -883,9 +885,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-            "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
             "cpu": [
                 "arm64"
             ],
@@ -917,9 +919,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-            "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
             "cpu": [
                 "arm64"
             ],
@@ -951,9 +953,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-            "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
             "cpu": [
                 "arm64"
             ],
@@ -1035,6 +1037,28 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@inquirer/external-editor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1083,26 +1107,13 @@
             }
         },
         "node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+            "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@jest/schemas": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1134,9 +1145,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.29",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-            "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1156,6 +1167,13 @@
                 "find-up": "^4.1.0",
                 "fs-extra": "^8.1.0"
             }
+        },
+        "node_modules/@manypkg/find-root/node_modules/@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@manypkg/find-root/node_modules/fs-extra": {
             "version": "8.1.0",
@@ -1407,9 +1425,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.2.tgz",
-            "integrity": "sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+            "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
             "cpu": [
                 "arm"
             ],
@@ -1421,9 +1439,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.2.tgz",
-            "integrity": "sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+            "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
             "cpu": [
                 "arm64"
             ],
@@ -1435,9 +1453,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.2.tgz",
-            "integrity": "sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+            "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
             "cpu": [
                 "arm64"
             ],
@@ -1449,9 +1467,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.2.tgz",
-            "integrity": "sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+            "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
             "cpu": [
                 "x64"
             ],
@@ -1463,9 +1481,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.2.tgz",
-            "integrity": "sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+            "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1477,9 +1495,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.2.tgz",
-            "integrity": "sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+            "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
             "cpu": [
                 "x64"
             ],
@@ -1491,13 +1509,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.2.tgz",
-            "integrity": "sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+            "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1505,13 +1526,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.2.tgz",
-            "integrity": "sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+            "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1519,13 +1543,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.2.tgz",
-            "integrity": "sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+            "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1533,41 +1560,84 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.2.tgz",
-            "integrity": "sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+            "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.2.tgz",
-            "integrity": "sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+            "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.2.tgz",
-            "integrity": "sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==",
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+            "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+            "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+            "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1575,13 +1645,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.2.tgz",
-            "integrity": "sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+            "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1589,13 +1662,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.2.tgz",
-            "integrity": "sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+            "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1603,13 +1679,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.2.tgz",
-            "integrity": "sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+            "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1617,13 +1696,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz",
-            "integrity": "sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+            "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1631,9 +1713,26 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.2.tgz",
-            "integrity": "sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+            "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+            "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
             "cpu": [
                 "x64"
             ],
@@ -1641,13 +1740,27 @@
             "license": "MIT",
             "optional": true,
             "os": [
-                "linux"
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+            "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.2.tgz",
-            "integrity": "sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+            "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
             "cpu": [
                 "arm64"
             ],
@@ -1659,9 +1772,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.2.tgz",
-            "integrity": "sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+            "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
             "cpu": [
                 "ia32"
             ],
@@ -1672,10 +1785,10 @@
                 "win32"
             ]
         },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.2.tgz",
-            "integrity": "sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==",
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+            "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
             "cpu": [
                 "x64"
             ],
@@ -1686,12 +1799,19 @@
                 "win32"
             ]
         },
-        "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+            "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@testing-library/dom": {
             "version": "10.4.0",
@@ -1842,9 +1962,9 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1859,17 +1979,28 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1900,104 +2031,150 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/@vitest/expect": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-            "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+        "node_modules/@vitest/coverage-v8": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+            "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "chai": "^4.3.10"
+                "@ampproject/remapping": "^2.3.0",
+                "@bcoe/v8-coverage": "^1.0.2",
+                "ast-v8-to-istanbul": "^0.3.3",
+                "debug": "^4.4.1",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-lib-source-maps": "^5.0.6",
+                "istanbul-reports": "^3.1.7",
+                "magic-string": "^0.30.17",
+                "magicast": "^0.3.5",
+                "std-env": "^3.9.0",
+                "test-exclude": "^7.0.1",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "3.2.6",
+                "vitest": "3.2.6"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/pretty-format": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-            "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+        "node_modules/@vitest/mocker": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+            "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^1.2.0"
+                "@vitest/spy": "3.2.6",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-            "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "1.6.1",
-                "p-limit": "^5.0.0",
-                "pathe": "^1.1.1"
+                "@vitest/utils": "3.2.6",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/runner/node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@vitest/snapshot": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-            "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "pretty-format": "^29.7.0"
+                "@vitest/pretty-format": "3.2.6",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-            "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyspy": "^2.2.0"
+                "tinyspy": "^4.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-            "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "diff-sequences": "^29.6.3",
-                "estree-walker": "^3.0.3",
-                "loupe": "^2.3.7",
-                "pretty-format": "^29.7.0"
+                "@vitest/pretty-format": "3.2.6",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -2019,19 +2196,6 @@
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
             },
             "engines": {
                 "node": ">=0.4.0"
@@ -2076,6 +2240,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2091,14 +2256,11 @@
             "license": "MIT"
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "license": "Python-2.0"
         },
         "node_modules/aria-query": {
             "version": "5.3.2",
@@ -2121,13 +2283,25 @@
             }
         },
         "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">=12"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+            "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
             }
         },
         "node_modules/asynckit": {
@@ -2138,11 +2312,14 @@
             "license": "MIT"
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/better-path-resolve": {
             "version": "1.0.0",
@@ -2158,14 +2335,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -2222,22 +2401,20 @@
             }
         },
         "node_modules/chai": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.1.0"
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -2271,23 +2448,20 @@
             }
         },
         "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
             "engines": {
-                "node": "*"
+                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -2304,22 +2478,6 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/color-convert": {
@@ -2364,13 +2522,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/confbox": {
             "version": "0.1.8",
@@ -2483,14 +2634,11 @@
             "license": "MIT"
         },
         "node_modules/deep-eql": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -2524,16 +2672,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/dir-glob": {
@@ -2755,30 +2893,6 @@
                 "@types/estree": "^1.0.0"
             }
         },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
         "node_modules/expect-type": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -2795,21 +2909,6 @@
             "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -2829,9 +2928,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2902,17 +3001,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-            "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2932,13 +3031,6 @@
             "engines": {
                 "node": ">=6 <7 || >=8"
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -2963,16 +3055,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -3014,36 +3096,23 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
-            "engines": {
-                "node": "*"
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3060,6 +3129,39 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globby": {
@@ -3143,9 +3245,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3214,27 +3316,21 @@
                 "human-id": "dist/cli.js"
             }
         },
-        "node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
         "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore": {
@@ -3256,25 +3352,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -3325,19 +3402,6 @@
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/is-subdir": {
             "version": "1.2.0",
@@ -3450,21 +3514,30 @@
             }
         },
         "node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -3560,23 +3633,6 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/local-pkg": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.3",
-                "pkg-types": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3591,16 +3647,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.sortby": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-            "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -3612,14 +3661,11 @@
             "license": "MIT"
         },
         "node_modules/loupe": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.1"
-            }
+            "license": "MIT"
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
@@ -3687,13 +3733,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3741,19 +3780,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3765,16 +3791,19 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "*"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minipass": {
@@ -3799,13 +3828,6 @@
                 "pkg-types": "^1.3.0",
                 "ufo": "^1.5.4"
             }
-        },
-        "node_modules/mlly/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/mri": {
             "version": "1.2.0",
@@ -3837,9 +3859,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -3901,35 +3923,6 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/nwsapi": {
             "version": "2.2.20",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -3941,42 +3934,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4092,16 +4049,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4140,20 +4087,20 @@
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">= 14.16"
             }
         },
         "node_modules/picocolors": {
@@ -4164,9 +4111,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4208,17 +4155,10 @@
                 "pathe": "^2.0.1"
             }
         },
-        "node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -4236,7 +4176,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -4301,21 +4241,6 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/psl": {
@@ -4409,13 +4334,6 @@
                 "react": "^19.2.3"
             }
         },
-        "node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/read-yaml-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -4430,6 +4348,30 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/js-yaml": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/readdirp": {
@@ -4489,13 +4431,13 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.44.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
-            "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+            "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@types/estree": "1.0.9"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -4505,26 +4447,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.44.2",
-                "@rollup/rollup-android-arm64": "4.44.2",
-                "@rollup/rollup-darwin-arm64": "4.44.2",
-                "@rollup/rollup-darwin-x64": "4.44.2",
-                "@rollup/rollup-freebsd-arm64": "4.44.2",
-                "@rollup/rollup-freebsd-x64": "4.44.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.44.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.44.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.44.2",
-                "@rollup/rollup-linux-arm64-musl": "4.44.2",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.44.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.44.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.44.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.44.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.44.2",
-                "@rollup/rollup-linux-x64-gnu": "4.44.2",
-                "@rollup/rollup-linux-x64-musl": "4.44.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.44.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.44.2",
-                "@rollup/rollup-win32-x64-msvc": "4.44.2",
+                "@rollup/rollup-android-arm-eabi": "4.62.0",
+                "@rollup/rollup-android-arm64": "4.62.0",
+                "@rollup/rollup-darwin-arm64": "4.62.0",
+                "@rollup/rollup-darwin-x64": "4.62.0",
+                "@rollup/rollup-freebsd-arm64": "4.62.0",
+                "@rollup/rollup-freebsd-x64": "4.62.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+                "@rollup/rollup-linux-arm64-musl": "4.62.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+                "@rollup/rollup-linux-loong64-musl": "4.62.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+                "@rollup/rollup-linux-x64-gnu": "4.62.0",
+                "@rollup/rollup-linux-x64-musl": "4.62.0",
+                "@rollup/rollup-openbsd-x64": "4.62.0",
+                "@rollup/rollup-openharmony-arm64": "4.62.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+                "@rollup/rollup-win32-x64-gnu": "4.62.0",
+                "@rollup/rollup-win32-x64-msvc": "4.62.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -4653,17 +4600,13 @@
             }
         },
         "node_modules/source-map": {
-            "version": "0.8.0-beta.0",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-            "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-            "deprecated": "The work that was done in this beta branch won't be included in future versions",
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "whatwg-url": "^7.0.0"
-            },
             "engines": {
-                "node": ">= 8"
+                "node": ">= 12"
             }
         },
         "node_modules/source-map-js": {
@@ -4674,35 +4617,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map/node_modules/tr46": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-            "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/source-map/node_modules/webidl-conversions": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/source-map/node_modules/whatwg-url": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
             }
         },
         "node_modules/spawndamnit": {
@@ -4844,19 +4758,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4871,9 +4772,9 @@
             }
         },
         "node_modules/strip-literal": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-            "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4882,6 +4783,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sucrase": {
             "version": "3.35.0",
@@ -4904,53 +4812,6 @@
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/sucrase/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/sucrase/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/supports-color": {
@@ -4987,18 +4848,18 @@
             }
         },
         "node_modules/test-exclude": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+            "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
-                "glob": "^7.1.4",
-                "minimatch": "^3.0.4"
+                "glob": "^10.4.1",
+                "minimatch": "^10.2.2"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
         },
         "node_modules/thenify": {
@@ -5081,9 +4942,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5093,20 +4954,10 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/tinypool": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-            "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/tinyrainbow": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5114,26 +4965,13 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-            "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -5206,9 +5044,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/tsup": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
-            "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+            "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5217,14 +5055,14 @@
                 "chokidar": "^4.0.3",
                 "consola": "^3.4.0",
                 "debug": "^4.4.0",
-                "esbuild": "^0.25.0",
+                "esbuild": "^0.27.0",
                 "fix-dts-default-cjs-exports": "^1.0.0",
                 "joycon": "^3.1.1",
                 "picocolors": "^1.1.1",
                 "postcss-load-config": "^6.0.1",
                 "resolve-from": "^5.0.0",
                 "rollup": "^4.34.8",
-                "source-map": "0.8.0-beta.0",
+                "source-map": "^0.7.6",
                 "sucrase": "^3.35.0",
                 "tinyexec": "^0.3.2",
                 "tinyglobby": "^0.2.11",
@@ -5259,9 +5097,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-            "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
@@ -5276,9 +5114,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/android-arm": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-            "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
             "cpu": [
                 "arm"
             ],
@@ -5293,9 +5131,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/android-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-            "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5310,9 +5148,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/android-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-            "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
             "cpu": [
                 "x64"
             ],
@@ -5327,9 +5165,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-            "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
             "cpu": [
                 "arm64"
             ],
@@ -5344,9 +5182,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-            "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
             "cpu": [
                 "x64"
             ],
@@ -5361,9 +5199,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-            "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
             "cpu": [
                 "arm64"
             ],
@@ -5378,9 +5216,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-            "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
             "cpu": [
                 "x64"
             ],
@@ -5395,9 +5233,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-arm": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-            "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
             "cpu": [
                 "arm"
             ],
@@ -5412,9 +5250,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-            "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
             "cpu": [
                 "arm64"
             ],
@@ -5429,9 +5267,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-            "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
             "cpu": [
                 "ia32"
             ],
@@ -5446,9 +5284,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-            "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
             "cpu": [
                 "loong64"
             ],
@@ -5463,9 +5301,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-            "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
             "cpu": [
                 "mips64el"
             ],
@@ -5480,9 +5318,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-            "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -5497,9 +5335,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-            "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -5514,9 +5352,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-            "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
@@ -5531,9 +5369,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/linux-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-            "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
             "cpu": [
                 "x64"
             ],
@@ -5548,9 +5386,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-            "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
@@ -5565,9 +5403,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-            "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
@@ -5582,9 +5420,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-            "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
             "cpu": [
                 "x64"
             ],
@@ -5599,9 +5437,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-            "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
@@ -5616,9 +5454,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-            "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
@@ -5633,9 +5471,9 @@
             }
         },
         "node_modules/tsup/node_modules/@esbuild/win32-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-            "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
@@ -5650,9 +5488,9 @@
             }
         },
         "node_modules/tsup/node_modules/esbuild": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-            "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -5663,42 +5501,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.9",
-                "@esbuild/android-arm": "0.25.9",
-                "@esbuild/android-arm64": "0.25.9",
-                "@esbuild/android-x64": "0.25.9",
-                "@esbuild/darwin-arm64": "0.25.9",
-                "@esbuild/darwin-x64": "0.25.9",
-                "@esbuild/freebsd-arm64": "0.25.9",
-                "@esbuild/freebsd-x64": "0.25.9",
-                "@esbuild/linux-arm": "0.25.9",
-                "@esbuild/linux-arm64": "0.25.9",
-                "@esbuild/linux-ia32": "0.25.9",
-                "@esbuild/linux-loong64": "0.25.9",
-                "@esbuild/linux-mips64el": "0.25.9",
-                "@esbuild/linux-ppc64": "0.25.9",
-                "@esbuild/linux-riscv64": "0.25.9",
-                "@esbuild/linux-s390x": "0.25.9",
-                "@esbuild/linux-x64": "0.25.9",
-                "@esbuild/netbsd-arm64": "0.25.9",
-                "@esbuild/netbsd-x64": "0.25.9",
-                "@esbuild/openbsd-arm64": "0.25.9",
-                "@esbuild/openbsd-x64": "0.25.9",
-                "@esbuild/openharmony-arm64": "0.25.9",
-                "@esbuild/sunos-x64": "0.25.9",
-                "@esbuild/win32-arm64": "0.25.9",
-                "@esbuild/win32-ia32": "0.25.9",
-                "@esbuild/win32-x64": "0.25.9"
-            }
-        },
-        "node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/typescript": {
@@ -5763,33 +5591,10 @@
                 "requires-port": "^1.0.0"
             }
         },
-        "node_modules/vite-node": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-            "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.3.4",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "vite": "^5.0.0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/vite-node/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+        "node_modules/vite": {
+            "version": "5.4.21",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5844,6 +5649,125 @@
                 "terser": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.6",
+                "@vitest/mocker": "3.2.6",
+                "@vitest/pretty-format": "^3.2.6",
+                "@vitest/runner": "3.2.6",
+                "@vitest/snapshot": "3.2.6",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.6",
+                "@vitest/ui": "3.2.6",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
             }
         },
         "node_modules/w3c-xmlserializer": {
@@ -6069,17 +5993,10 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6115,19 +6032,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/yocto-queue": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "packages/bushitsu-client": {
             "name": "@aituber-onair/bushitsu-client",
             "version": "0.2.1",
@@ -6141,7 +6045,7 @@
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "typescript": "^5.7.2",
-                "vitest": "^2.1.6"
+                "vitest": "^3.2.6"
             },
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0"
@@ -6167,339 +6071,6 @@
                 "@types/react": "^19.2.0"
             }
         },
-        "packages/bushitsu-client/node_modules/@vitest/expect": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-            "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/spy": "2.1.9",
-                "@vitest/utils": "2.1.9",
-                "chai": "^5.1.2",
-                "tinyrainbow": "^1.2.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/@vitest/mocker": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-            "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/spy": "2.1.9",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.12"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "msw": "^2.4.9",
-                "vite": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "msw": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/bushitsu-client/node_modules/@vitest/runner": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-            "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/utils": "2.1.9",
-                "pathe": "^1.1.2"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/@vitest/snapshot": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-            "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/pretty-format": "2.1.9",
-                "magic-string": "^0.30.12",
-                "pathe": "^1.1.2"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/@vitest/spy": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-            "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tinyspy": "^3.0.2"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/@vitest/utils": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-            "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/pretty-format": "2.1.9",
-                "loupe": "^3.1.2",
-                "tinyrainbow": "^1.2.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/assertion-error": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "packages/bushitsu-client/node_modules/chai": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
-            "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "packages/bushitsu-client/node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 16"
-            }
-        },
-        "packages/bushitsu-client/node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "packages/bushitsu-client/node_modules/loupe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
-            "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/bushitsu-client/node_modules/pathval": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.16"
-            }
-        },
-        "packages/bushitsu-client/node_modules/tinypool": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            }
-        },
-        "packages/bushitsu-client/node_modules/tinyspy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "packages/bushitsu-client/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/bushitsu-client/node_modules/vite-node": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-            "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.3.7",
-                "es-module-lexer": "^1.5.4",
-                "pathe": "^1.1.2",
-                "vite": "^5.0.0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "packages/bushitsu-client/node_modules/vitest": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-            "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "2.1.9",
-                "@vitest/mocker": "2.1.9",
-                "@vitest/pretty-format": "^2.1.9",
-                "@vitest/runner": "2.1.9",
-                "@vitest/snapshot": "2.1.9",
-                "@vitest/spy": "2.1.9",
-                "@vitest/utils": "2.1.9",
-                "chai": "^5.1.2",
-                "debug": "^4.3.7",
-                "expect-type": "^1.1.0",
-                "magic-string": "^0.30.12",
-                "pathe": "^1.1.2",
-                "std-env": "^3.8.0",
-                "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.1",
-                "tinypool": "^1.0.1",
-                "tinyrainbow": "^1.2.0",
-                "vite": "^5.0.0",
-                "vite-node": "2.1.9",
-                "why-is-node-running": "^2.3.0"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "2.1.9",
-                "@vitest/ui": "2.1.9",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/chat": {
             "name": "@aituber-onair/chat",
             "version": "0.39.0",
@@ -6507,10 +6078,10 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "tsup": "^8.0.1",
                 "typescript": "^5.0.0",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/chat/node_modules/@types/node": {
@@ -6523,160 +6094,6 @@
                 "undici-types": "~5.26.4"
             }
         },
-        "packages/chat/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/chat/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/chat/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/comment-intelligence": {
             "name": "@aituber-onair/comment-intelligence",
             "version": "0.0.2",
@@ -6684,11 +6101,11 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "jsdom": "^22.1.0",
                 "typescript": "^5.0.0",
                 "vite": "^5.4.21",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/comment-intelligence/node_modules/@types/node": {
@@ -6699,160 +6116,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
-            }
-        },
-        "packages/comment-intelligence/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/comment-intelligence/node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/comment-intelligence/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
             }
         },
         "packages/core": {
@@ -6866,9 +6129,9 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "typescript": "^5.0.0",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             },
             "peerDependencies": {
                 "@pixiv/three-vrm": "^1.0.9"
@@ -6882,160 +6145,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
-            }
-        },
-        "packages/core/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/core/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/core/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
             }
         },
         "packages/create-aituber-onair": {
@@ -7067,10 +6176,10 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "jsdom": "^22.1.0",
                 "typescript": "^5.0.0",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/kizuna/node_modules/@types/node": {
@@ -7083,160 +6192,6 @@
                 "undici-types": "~5.26.4"
             }
         },
-        "packages/kizuna/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/kizuna/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/kizuna/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/manneri": {
             "name": "@aituber-onair/manneri",
             "version": "0.3.3",
@@ -7244,11 +6199,11 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "jsdom": "^22.1.0",
                 "typescript": "^5.0.0",
                 "vite": "^5.4.21",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/manneri/node_modules/@types/node": {
@@ -7261,160 +6216,6 @@
                 "undici-types": "~5.26.4"
             }
         },
-        "packages/manneri/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/manneri/node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/manneri/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/noise": {
             "name": "@aituber-onair/noise",
             "version": "0.0.1",
@@ -7425,11 +6226,11 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "jsdom": "^22.1.0",
                 "typescript": "^5.0.0",
                 "vite": "^5.4.21",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/noise/node_modules/@types/node": {
@@ -7442,160 +6243,6 @@
                 "undici-types": "~5.26.4"
             }
         },
-        "packages/noise/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/noise/node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/noise/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/voice": {
             "name": "@aituber-onair/voice",
             "version": "0.17.0",
@@ -7603,10 +6250,10 @@
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
-                "@vitest/coverage-v8": "^1.3.1",
+                "@vitest/coverage-v8": "^3.2.6",
                 "jsdom": "^22.1.0",
                 "typescript": "^5.0.0",
-                "vitest": "^1.3.1"
+                "vitest": "^3.2.6"
             }
         },
         "packages/voice/node_modules/@types/node": {
@@ -7617,160 +6264,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
-            }
-        },
-        "packages/voice/node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "1.6.1"
-            }
-        },
-        "packages/voice/node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/voice/node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
-            },
-            "bin": {
-                "vitest": "vitest.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
-                "happy-dom": "*",
-                "jsdom": "*"
-            },
-            "peerDependenciesMeta": {
-                "@edge-runtime/vm": {
-                    "optional": true
-                },
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitest/browser": {
-                    "optional": true
-                },
-                "@vitest/ui": {
-                    "optional": true
-                },
-                "happy-dom": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                }
             }
         }
     }

--- a/packages/bushitsu-client/package.json
+++ b/packages/bushitsu-client/package.json
@@ -77,6 +77,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.6"
+    "vitest": "^3.2.6"
   }
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -55,10 +55,10 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "tsup": "^8.0.1",
     "typescript": "^5.0.0",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/comment-intelligence/package.json
+++ b/packages/comment-intelligence/package.json
@@ -39,11 +39,11 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^22.1.0",
     "typescript": "^5.0.0",
     "vite": "^5.4.21",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "browserslist": ["defaults", "not IE 11"],
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,9 +30,9 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "typescript": "^5.0.0",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kizuna/package.json
+++ b/packages/kizuna/package.json
@@ -39,10 +39,10 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^22.1.0",
     "typescript": "^5.0.0",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "browserslist": ["defaults", "not IE 11"],
   "publishConfig": {

--- a/packages/manneri/package.json
+++ b/packages/manneri/package.json
@@ -40,11 +40,11 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^22.1.0",
     "typescript": "^5.0.0",
     "vite": "^5.4.21",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "browserslist": ["defaults", "not IE 11"],
   "publishConfig": {

--- a/packages/manneri/vitest.config.ts
+++ b/packages/manneri/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
+    fakeTimers: {
+      toFake: [
+        'Date',
+        'setTimeout',
+        'clearTimeout',
+        'setInterval',
+        'clearInterval',
+        'setImmediate',
+        'clearImmediate',
+      ],
+    },
     coverage: {
       exclude: ['examples/**'],
       thresholds: {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -57,11 +57,11 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^22.1.0",
     "typescript": "^5.0.0",
     "vite": "^5.4.21",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "browserslist": ["defaults", "not IE 11"],
   "publishConfig": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -34,10 +34,10 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^22.1.0",
     "typescript": "^5.0.0",
-    "vitest": "^1.3.1"
+    "vitest": "^3.2.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
﻿## Summary
- Update direct `vitest` and `@vitest/coverage-v8` ranges to `^3.2.6` across workspaces.
- Regenerate `package-lock.json` so npm audit no longer reports critical vulnerabilities.
- Add a Vitest fake timer setting in `@aituber-onair/manneri` so jsdom `performance` is not overwritten under Vitest 3.2.6.

## Security notes
- Before this change, npm audit reported critical advisories through vulnerable Vitest/form-data paths.
- After this change, `npm audit --workspaces --audit-level=critical` exits 0.
- Remaining audit findings are `esbuild`/`vite`/`tsup` high/moderate items; npm requires a breaking `vite@8.0.16` force update for those, so they are deliberately left out of this focused PR.

## Duplicate check
- Official open issues: none found.
- Official open PRs: none found.
- Searched recent PRs/issues for security/audit/CVE/Vite overlap; no active duplicate was found.

## Verification
- `npm ci` passed.
- `npm audit --workspaces --audit-level=critical` passed.
- `npm run lint --workspaces` passed.
- `npm -w @aituber-onair/manneri run test` passed.

## Known verification limits
- `npm run fmt:check --workspaces` fails on this Windows worktree due existing CRLF/LF formatting diagnostics across baseline files.
- `npm run test --workspaces` reached package tests but failed on existing workspace build-order/type-resolution issues for `core`/`noise` before their local dependencies' dist declarations were available.
- `npm run build --workspaces` fails on Windows because several package scripts use POSIX `rm -rf`, and `core` also starts before `chat`/`voice` dist declarations are available.

## Scope note
- No `_docs` files or fork-only custom features are included.
