### PR TITLE
fix: bound external chat inputs

### DIFF
--- a/packages/bushitsu-client/src/client/BushitsuClient.ts
+++ b/packages/bushitsu-client/src/client/BushitsuClient.ts
@@ -21,6 +21,78 @@ interface BushitsuClientDependencies {
   transport?: BushitsuTransport;
 }
 
+const MAX_INCOMING_MESSAGE_BYTES = 64 * 1024;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const getUtf8ByteLength = (value: string): number => {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).byteLength;
+  }
+  return value.length;
+};
+
+const parseBushitsuMessage = (rawData: string): BushitsuMessage | null => {
+  if (getUtf8ByteLength(rawData) > MAX_INCOMING_MESSAGE_BYTES) {
+    console.warn('[BushitsuClient] Ignoring oversized WebSocket message');
+    return null;
+  }
+
+  const parsed: unknown = JSON.parse(rawData);
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  const { type, room, timestamp, data } = parsed;
+  if (
+    type !== 'chat' &&
+    type !== 'user_event' &&
+    type !== 'system'
+  ) {
+    return null;
+  }
+  if (typeof room !== 'string' || typeof timestamp !== 'string') {
+    return null;
+  }
+  if (!isRecord(data) || typeof data.from !== 'string') {
+    return null;
+  }
+  if (data.fromId !== undefined && typeof data.fromId !== 'string') {
+    return null;
+  }
+  if (data.text !== undefined && typeof data.text !== 'string') {
+    return null;
+  }
+  if (data.mention !== undefined && !isStringArray(data.mention)) {
+    return null;
+  }
+  if (data.event !== undefined && typeof data.event !== 'string') {
+    return null;
+  }
+  if (data.user !== undefined && typeof data.user !== 'string') {
+    return null;
+  }
+
+  return {
+    type,
+    room,
+    timestamp,
+    data: {
+      from: data.from,
+      fromId: data.fromId,
+      text: data.text,
+      mention: data.mention,
+      event: data.event,
+      user: data.user,
+      details: data.details,
+    },
+  };
+};
+
 export class BushitsuClient {
   private readonly options: BushitsuClientOptions;
   private readonly transport: BushitsuTransport;
@@ -111,7 +183,11 @@ export class BushitsuClient {
    */
   private handleMessage(event: BushitsuTransportMessageEvent) {
     try {
-      const message: BushitsuMessage = JSON.parse(event.data);
+      const message = parseBushitsuMessage(event.data);
+      if (!message) {
+        console.warn('[BushitsuClient] Ignoring invalid WebSocket message');
+        return;
+      }
 
       if (message.type === 'chat') {
         const { from, fromId, text, mention } = message.data;

--- a/packages/bushitsu-client/src/client/types.ts
+++ b/packages/bushitsu-client/src/client/types.ts
@@ -12,7 +12,7 @@ export interface BushitsuMessage {
     mention?: string[];
     event?: string; // user_event type
     user?: string; // user_event type
-    details?: any; // system type
+    details?: unknown; // system type
   };
 }
 

--- a/packages/bushitsu-client/tests/nodeBinding.test.ts
+++ b/packages/bushitsu-client/tests/nodeBinding.test.ts
@@ -51,6 +51,73 @@ describe('createNodeBushitsuClient', () => {
     expect(() => client.sendMessage('some message')).not.toThrow();
     client.disconnect();
   });
+
+  it('ignores malformed WebSocket payloads', async () => {
+    const received: string[] = [];
+
+    const client = createNodeBushitsuClient({
+      serverUrl: 'http://localhost:8080',
+      room: 'test-room',
+      userName: 'tester',
+      onReceiveMessage: (text) => {
+        received.push(text);
+      },
+      webSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    await client.connect();
+
+    MockWebSocket.emitMessage('{"type":"chat","data":{"text":"missing"}}');
+    MockWebSocket.emitMessage(
+      JSON.stringify({
+        type: 'chat',
+        room: 'test-room',
+        timestamp: new Date().toISOString(),
+        data: {
+          from: 'another-user',
+          text: 'bad mention',
+          mention: [42],
+        },
+      }),
+    );
+
+    expect(received).toEqual([]);
+
+    client.disconnect();
+  });
+
+  it('ignores oversized WebSocket payloads', async () => {
+    const received: string[] = [];
+
+    const client = createNodeBushitsuClient({
+      serverUrl: 'http://localhost:8080',
+      room: 'test-room',
+      userName: 'tester',
+      onReceiveMessage: (text) => {
+        received.push(text);
+      },
+      webSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    await client.connect();
+
+    const payload: BushitsuMessage = {
+      type: 'chat',
+      room: 'test-room',
+      timestamp: new Date().toISOString(),
+      data: {
+        from: 'another-user',
+        text: 'x'.repeat(70 * 1024),
+        mention: [],
+      },
+    };
+
+    MockWebSocket.emitMessage(JSON.stringify(payload));
+
+    expect(received).toEqual([]);
+
+    client.disconnect();
+  });
 });
 
 class MockWebSocket {

--- a/packages/core/examples/react-live2d-app/src/services/twitch/twitchService.ts
+++ b/packages/core/examples/react-live2d-app/src/services/twitch/twitchService.ts
@@ -22,6 +22,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -232,12 +260,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
         });
@@ -262,4 +289,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }

--- a/packages/core/examples/react-pngtuber-app/src/services/twitch/twitchService.ts
+++ b/packages/core/examples/react-pngtuber-app/src/services/twitch/twitchService.ts
@@ -24,6 +24,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -234,12 +262,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           id: messageId,
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
@@ -266,4 +293,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }

--- a/packages/core/examples/react-vrm-app/src/services/twitch/twitchService.ts
+++ b/packages/core/examples/react-vrm-app/src/services/twitch/twitchService.ts
@@ -22,6 +22,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -232,12 +260,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
         });
@@ -262,4 +289,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }

--- a/packages/create-aituber-onair/templates/live2d/src/services/twitch/twitchService.ts
+++ b/packages/create-aituber-onair/templates/live2d/src/services/twitch/twitchService.ts
@@ -22,6 +22,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -232,12 +260,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
         });
@@ -262,4 +289,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }

--- a/packages/create-aituber-onair/templates/pngtuber/src/services/twitch/twitchService.ts
+++ b/packages/create-aituber-onair/templates/pngtuber/src/services/twitch/twitchService.ts
@@ -22,6 +22,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -232,12 +260,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
         });
@@ -262,4 +289,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }

--- a/packages/create-aituber-onair/templates/vrm/src/services/twitch/twitchService.ts
+++ b/packages/create-aituber-onair/templates/vrm/src/services/twitch/twitchService.ts
@@ -22,6 +22,34 @@ let buffer: TwitchChatMessage[] = [];
 let pollTimer: number | null = null;
 let reconnectInProgress = false;
 const processedMessageIds = new Set<string>();
+const MAX_TWITCH_BUFFERED_MESSAGES = 100;
+const MAX_PROCESSED_MESSAGE_IDS = 500;
+const processedMessageIdQueue: string[] = [];
+
+function enqueueMessage(message: TwitchChatMessage) {
+  if (buffer.length >= MAX_TWITCH_BUFFERED_MESSAGES) {
+    buffer.shift();
+  }
+  buffer.push(message);
+}
+
+function rememberMessageId(messageId: string): boolean {
+  if (processedMessageIds.has(messageId)) {
+    return false;
+  }
+
+  processedMessageIds.add(messageId);
+  processedMessageIdQueue.push(messageId);
+
+  while (processedMessageIdQueue.length > MAX_PROCESSED_MESSAGE_IDS) {
+    const oldestMessageId = processedMessageIdQueue.shift();
+    if (oldestMessageId) {
+      processedMessageIds.delete(oldestMessageId);
+    }
+  }
+
+  return true;
+}
 
 export async function connectTwitchChat(
   options: ConnectTwitchChatOptions,
@@ -232,12 +260,11 @@ export async function connectTwitchChat(
         message.payload.subscription.type === 'channel.chat.message'
       ) {
         const messageId = message.payload.event.message_id;
-        if (processedMessageIds.has(messageId)) {
+        if (!rememberMessageId(messageId)) {
           return;
         }
 
-        processedMessageIds.add(messageId);
-        buffer.push({
+        enqueueMessage({
           userName: message.payload.event.chatter_user_name,
           userComment: message.payload.event.message.text,
         });
@@ -262,4 +289,5 @@ export function disconnectTwitchChat() {
   buffer = [];
   reconnectInProgress = false;
   processedMessageIds.clear();
+  processedMessageIdQueue.length = 0;
 }


### PR DESCRIPTION
﻿## Summary
- Harden `@aituber-onair/bushitsu-client` WebSocket receive handling with bounded payload size and runtime message-shape validation.
- Ignore malformed or oversized inbound WebSocket payloads instead of letting them flow into message processing.
- Bound Twitch chat message buffers and processed-message ID caches in VRM/PNGtuber/Live2D examples and starter templates.

## Security notes
- Reduces denial-of-service risk from unbounded incoming WebSocket payloads and unbounded Twitch message/ID accumulation.
- Keeps behavior backwards-compatible for valid chat, user event, and system messages.

## Duplicate check
- Official open issues: none found.
- Official open PRs: none found.
- Searched recent PRs/issues for security/audit/CVE/WebSocket/Twitch overlap; no active duplicate was found.

## Verification
- `npm -w @aituber-onair/bushitsu-client run lint` passed.
- `npm -w @aituber-onair/bushitsu-client run test` passed: 7 files, 90 tests.
- `npm -w create-aituber-onair run test` passed: 8 node tests.
- Direct TypeScript check passed for all six changed Twitch service files:
  `npx tsc --target ES2020 --lib DOM,ES2020 --module ESNext --moduleResolution node --skipLibCheck --noEmit ...`

## Scope note
- No `_docs` files or fork-only custom features are included.
