### PR TITLE
[codex] Preserve Sakana and PLaMo provider options in core

### DIFF
--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -17,6 +17,8 @@ import {
   XAIChatServiceOptions,
   DeepSeekChatServiceOptions,
   MistralChatServiceOptions,
+  SakanaChatServiceOptions,
+  PlamoChatServiceOptions,
 } from '@aituber-onair/chat';
 import { OpenAISummarizer } from '../services/chat/providers/openai/OpenAISummarizer';
 import { GeminiSummarizer } from '../services/chat/providers/gemini/GeminiSummarizer';
@@ -368,8 +370,25 @@ export class AITuberOnAirCore extends EventEmitter {
           ...(providerOptions as ProviderOptionsByName<'xai'> | undefined),
         } as XAIChatServiceOptions;
       }
+      case 'sakana': {
+        return {
+          ...baseOptions,
+          ...(providerOptions as ProviderOptionsByName<'sakana'> | undefined),
+        } as SakanaChatServiceOptions;
+      }
+      case 'plamo': {
+        return {
+          ...baseOptions,
+          ...(providerOptions as ProviderOptionsByName<'plamo'> | undefined),
+        } as PlamoChatServiceOptions;
+      }
       default:
-        return baseOptions as ChatServiceOptionsByProvider['openai'];
+        return {
+          ...baseOptions,
+          ...(providerOptions as
+            | Partial<ChatServiceOptionsByProvider[ChatProviderName]>
+            | undefined),
+        } as ChatServiceOptionsByProvider[ChatProviderName];
     }
   }
 

--- a/packages/core/tests/core/AITuberOnAirCore.options.test.ts
+++ b/packages/core/tests/core/AITuberOnAirCore.options.test.ts
@@ -145,6 +145,58 @@ describe('AITuberOnAirCore buildChatServiceOptions', () => {
     );
   });
 
+  it('passes provider-specific options for sakana', () => {
+    const options = createOptions({
+      chatProvider: 'sakana',
+      model: 'fugu-ultra',
+      providerOptions: {
+        responseLength: 'short',
+        endpoint: 'https://example.invalid/v1/chat/completions',
+      },
+    });
+
+    new AITuberOnAirCore(options);
+
+    const mockCreate = vi.mocked(ChatServiceFactory.createChatService);
+    expect(mockCreate).toHaveBeenCalledWith(
+      'sakana',
+      expect.objectContaining({
+        apiKey: 'test-api-key',
+        model: 'fugu-ultra',
+        responseLength: 'short',
+        endpoint: 'https://example.invalid/v1/chat/completions',
+        tools: [],
+      }),
+    );
+  });
+
+  it('passes provider-specific options for plamo', () => {
+    const options = createOptions({
+      chatProvider: 'plamo',
+      model: 'plamo-3.0-prime',
+      providerOptions: {
+        responseLength: 'long',
+        reasoning_effort: 'medium',
+        baseUrl: 'https://example.invalid/v1',
+      },
+    });
+
+    new AITuberOnAirCore(options);
+
+    const mockCreate = vi.mocked(ChatServiceFactory.createChatService);
+    expect(mockCreate).toHaveBeenCalledWith(
+      'plamo',
+      expect.objectContaining({
+        apiKey: 'test-api-key',
+        model: 'plamo-3.0-prime',
+        responseLength: 'long',
+        reasoning_effort: 'medium',
+        baseUrl: 'https://example.invalid/v1',
+        tools: [],
+      }),
+    );
+  });
+
   it('switches voice engine via switchEngine when voice service exists', () => {
     const core = new AITuberOnAirCore(
       createOptions({


### PR DESCRIPTION
## Summary

- Add explicit `sakana` and `plamo` branches to `AITuberOnAirCore.buildChatServiceOptions()` so provider-specific options are preserved.
- Preserve future/unknown provider options in the default fallback by merging `providerOptions` with the base chat service options.
- Add core tests covering Sakana and PLaMo option forwarding.

## Root Cause

`AITuberOnAirCore.buildChatServiceOptions()` did not include dedicated branches for the `sakana` and `plamo` chat providers. As a result, provider-specific values such as `responseLength`, `endpoint`, `baseUrl`, and PLaMo `reasoning_effort` could be dropped before reaching `ChatServiceFactory.createChatService()`.

## Impact

Users configuring `@aituber-onair/core` with `chatProvider: 'sakana'` or `chatProvider: 'plamo'` can now pass provider options through core without losing them. Existing provider branches are left unchanged.

## Validation

- `npm -w @aituber-onair/chat run build`
- `npm -w @aituber-onair/core run build`
- `npm -w @aituber-onair/core run test`