### PR TITLE
[codex] Sync Kizuna exported version

### DIFF
--- a/packages/kizuna/src/index.ts
+++ b/packages/kizuna/src/index.ts
@@ -66,4 +66,4 @@ export type {
 } from './types';
 
 // Version information
-export const version = '0.0.1';
+export const version = '0.0.2';

--- a/packages/kizuna/tests/index.test.ts
+++ b/packages/kizuna/tests/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json';
+import { version } from '../src/index';
+
+describe('@aituber-onair/kizuna index exports', () => {
+  it('exports the package version', () => {
+    expect(version).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary

- Update the `@aituber-onair/kizuna` exported `version` constant to match `package.json`.
- Add an index export test that compares the runtime export with `packageJson.version`.

## Root Cause

The `version` export in `packages/kizuna/src/index.ts` had drifted from the package version declared in `packages/kizuna/package.json`.

## Impact

Consumers reading `version` from `@aituber-onair/kizuna` now receive the correct package version. The new test should catch future version drift without requiring additional package or lockfile changes.

## Validation

- `npm -w @aituber-onair/kizuna run build`
- `npm -w @aituber-onair/kizuna run test`