### PR TITLE
[codex] Sync generated starter core dependency version

### DIFF
--- a/packages/create-aituber-onair/src/lib.ts
+++ b/packages/create-aituber-onair/src/lib.ts
@@ -13,7 +13,7 @@ import { TEMPLATES, type TemplateId, isTemplateId } from './templates.js';
 
 const DEFAULT_PROJECT_NAME = 'my-aituber';
 const DEFAULT_TEMPLATE_ID: TemplateId = 'pngtuber';
-const CORE_VERSION = '0.26.3';
+const FALLBACK_CORE_VERSION = '0.26.5';
 
 export interface CliOptions {
   targetDir?: string;
@@ -29,6 +29,7 @@ export interface CreateProjectOptions {
   template: TemplateId;
   install: boolean;
   templateRoot?: string;
+  coreVersion?: string;
   runCommand?: (command: string, args: string[], cwd: string) => Promise<void>;
 }
 
@@ -116,6 +117,33 @@ export function defaultTemplateRoot(): string {
   return path.resolve(path.dirname(currentFile), '..', 'templates');
 }
 
+export async function resolveDefaultCoreVersion(): Promise<string> {
+  return resolveWorkspacePackageVersion(
+    path.resolve(defaultPackageRoot(), '..', 'core', 'package.json'),
+  );
+}
+
+function defaultPackageRoot(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  return path.resolve(path.dirname(currentFile), '..');
+}
+
+async function resolveWorkspacePackageVersion(
+  packageJsonPath: string,
+): Promise<string> {
+  try {
+    const rawPackageJson = await readFile(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(rawPackageJson) as { version?: unknown };
+    if (typeof packageJson.version === 'string' && packageJson.version) {
+      return packageJson.version;
+    }
+  } catch {
+    // Published packages do not include sibling workspace package.json files.
+  }
+
+  return FALLBACK_CORE_VERSION;
+}
+
 export function resolveTargetDir(cwd: string, targetDir?: string): string {
   return path.resolve(cwd, targetDir ?? DEFAULT_PROJECT_NAME);
 }
@@ -169,7 +197,12 @@ export async function createProject(
   await mkdir(projectDir, { recursive: true });
   await copyTemplate(sourceDir, projectDir);
   await restoreTemplateDotfiles(projectDir);
-  await updatePackageJson(projectDir, packageName, options.template);
+  await updatePackageJson(
+    projectDir,
+    packageName,
+    options.template,
+    options.coreVersion ?? (await resolveDefaultCoreVersion()),
+  );
 
   if (options.install) {
     const runCommand = options.runCommand ?? defaultRunCommand;
@@ -235,6 +268,7 @@ async function updatePackageJson(
   projectDir: string,
   packageName: string,
   template: TemplateId,
+  coreVersion: string,
 ): Promise<void> {
   const packageJsonPath = path.join(projectDir, 'package.json');
   const rawPackageJson = await readFile(packageJsonPath, 'utf8');
@@ -250,7 +284,7 @@ async function updatePackageJson(
   packageJson.private = true;
   packageJson.dependencies = {
     ...packageJson.dependencies,
-    '@aituber-onair/core': `^${CORE_VERSION}`,
+    '@aituber-onair/core': `^${coreVersion}`,
   };
 
   if (template === 'vrm') {

--- a/packages/create-aituber-onair/tests/lib.test.mjs
+++ b/packages/create-aituber-onair/tests/lib.test.mjs
@@ -7,6 +7,7 @@ import {
   CliError,
   createProject,
   parseArgs,
+  resolveDefaultCoreVersion,
   toPackageName,
 } from '../dist/lib.js';
 
@@ -54,7 +55,7 @@ test('createProject copies pngtuber template and rewrites package metadata', asy
   const rootFiles = await readdir(result.projectDir);
 
   assert.equal(packageJson.name, 'my-png-app');
-  assert.equal(packageJson.dependencies['@aituber-onair/core'], '^0.26.3');
+  assert.equal(packageJson.dependencies['@aituber-onair/core'], '^0.26.5');
   assert.equal(packageJson.dependencies['@pixiv/three-vrm'], undefined);
   assert.equal(rootFiles.includes('.gitignore'), true);
   assert.equal(rootFiles.includes('_gitignore'), false);
@@ -125,7 +126,7 @@ test('createProject copies pet template with bundled Miko assets', async () => {
   );
   const petFiles = await readdir(path.join(result.projectDir, 'public', 'pet'));
 
-  assert.equal(packageJson.dependencies['@aituber-onair/core'], '^0.26.3');
+  assert.equal(packageJson.dependencies['@aituber-onair/core'], '^0.26.5');
   assert.equal(
     packageJson.dependencies['@aituber-onair/comment-intelligence'],
     '^0.0.4',
@@ -157,4 +158,25 @@ test('createProject runs npm install when requested', async () => {
       cwd: path.join(cwd, 'install-app'),
     },
   ]);
+});
+
+test('createProject allows overriding the core dependency version', async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'create-aituber-onair-'));
+  const result = await createProject({
+    cwd,
+    targetDir: 'custom-core-app',
+    template: 'pngtuber',
+    install: false,
+    templateRoot: fixtureTemplateRoot,
+    coreVersion: '9.9.9',
+  });
+
+  const packageJson = JSON.parse(
+    await readFile(path.join(result.projectDir, 'package.json'), 'utf8'),
+  );
+  assert.equal(packageJson.dependencies['@aituber-onair/core'], '^9.9.9');
+});
+
+test('resolveDefaultCoreVersion reads the workspace core package version', async () => {
+  assert.equal(await resolveDefaultCoreVersion(), '0.26.5');
 });


### PR DESCRIPTION
## Summary

- Resolve the generated starter `@aituber-onair/core` dependency version from the workspace `packages/core/package.json` when available.
- Add a safe fallback core version for published `create-aituber-onair` packages that do not include sibling workspace package metadata.
- Add a `coreVersion` override option for tests and future scripting use.
- Update create CLI tests to verify generated package metadata uses `^0.26.5`.

## Root Cause

`create-aituber-onair` used a hard-coded core dependency version when rewriting generated starter `package.json` files. That value had drifted behind the current workspace `@aituber-onair/core` version.

## Impact

New starter projects generated from the workspace now receive the current core dependency range. Published CLI packages still work without the monorepo sibling package because the resolver falls back to the bundled version constant.

## Validation

- `npm -w create-aituber-onair run build`
- `npm -w create-aituber-onair run test`