### PR TITLE
[codex] Expose chat provider capabilities

### DIFF
--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aituber-onair/chat
 
+## Unreleased
+
+### Minor Changes
+
+- Added provider capability discovery APIs for UI and agent planning, including
+  metadata for tools, MCP, JSON mode, vision, response length, and reasoning
+  effort support.
+
 ## 0.43.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -1092,6 +1092,37 @@ console.log(modelLevel); // 'unknown'
 - `unsupported`: リクエスト送信前に非対応と分かっている
 - `unknown`: 事前判定できないが、実際には成功する可能性がある
 
+### プロバイダー機能の事前判定
+
+UI やエージェント実行環境は、チャットサービスを作成する前にプロバイダーの
+機能を確認できます。
+
+```typescript
+const capabilities = ChatServiceFactory.getProviderCapabilities(
+  'openai',
+  'gpt-5.4-mini',
+);
+
+if (capabilities?.jsonMode) {
+  // JSON mode のトグル表示や responseFormat の指定が安全にできます。
+}
+
+if (!capabilities?.mcp) {
+  // このプロバイダーでは MCP server 設定を無効化できます。
+}
+```
+
+`getProviderCapabilities(provider, model?)` は `models`, `defaultModel`,
+`vision`, `tools`, `mcp`, `jsonMode`, `responseLength`, 対応する
+`reasoningEffort` などの機械可読な metadata を返します。プロバイダー選択 UI
+やダッシュボードを作る場合は `getAllProviderCapabilities()` も利用できます。
+
+capability object は実行前の判断に使う静的 metadata です。API key、endpoint、
+base URL、MCP server 定義、その他のユーザー設定は含みません。これにより、UI
+では非対応の設定を実行前に非表示/無効化でき、エージェント側では tools、MCP、
+vision、JSON mode、reasoning 設定を使うべきかを provider 固有ロジックの
+ベタ書きなしで判断できます。
+
 ## 利用可能なプロバイダー
 
 現在、以下のAIプロバイダーが組み込まれています：

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -1107,6 +1107,37 @@ Semantics:
 - `unsupported`: Known to reject vision before sending the request
 - `unknown`: Cannot be pre-validated, but vision requests may still succeed
 
+### Provider Capability Discovery
+
+UI and agent runtimes can inspect provider features before creating a chat
+service:
+
+```typescript
+const capabilities = ChatServiceFactory.getProviderCapabilities(
+  'openai',
+  'gpt-5.4-mini',
+);
+
+if (capabilities?.jsonMode) {
+  // Show a JSON mode toggle or pass responseFormat safely.
+}
+
+if (!capabilities?.mcp) {
+  // Disable MCP server settings for this provider.
+}
+```
+
+`getProviderCapabilities(provider, model?)` returns machine-readable metadata
+such as `models`, `defaultModel`, `vision`, `tools`, `mcp`, `jsonMode`,
+`responseLength`, and supported `reasoningEffort` values. Use
+`getAllProviderCapabilities()` to populate provider pickers or dashboards.
+
+The capability object is static planning metadata. It does not include API keys,
+endpoints, base URLs, MCP server definitions, or other user configuration. This
+helps UI surfaces hide unsupported controls before execution, and lets agents
+choose whether to use tools, MCP, vision, JSON mode, or reasoning settings
+without hard-coding provider-specific rules.
+
 ## Available Providers
 
 Currently, the following AI providers are built-in:

--- a/packages/chat/src/services/ChatServiceFactory.ts
+++ b/packages/chat/src/services/ChatServiceFactory.ts
@@ -7,6 +7,39 @@ import {
   VisionSupportLevel,
 } from './providers/ChatServiceProvider';
 import { DEFAULT_CHAT_SERVICE_PROVIDERS } from './providers';
+import type { ChatProviderCapabilities } from '../types/capabilities';
+
+const TOOL_SUPPORTED_PROVIDERS = new Set<string>([
+  'openai',
+  'openai-compatible',
+  'openrouter',
+  'gemini',
+  'claude',
+  'zai',
+  'xai',
+  'kimi',
+  'deepseek',
+  'mistral',
+  'sakana',
+  'plamo',
+]);
+
+const MCP_SUPPORTED_PROVIDERS = new Set<string>(['openai', 'gemini', 'claude']);
+
+const JSON_MODE_SUPPORTED_PROVIDERS = new Set<string>([
+  'openai',
+  'openai-compatible',
+  'zai',
+  'kimi',
+]);
+
+const REASONING_EFFORT_BY_PROVIDER: Record<string, string[]> = {
+  openai: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+  openrouter: ['none', 'minimal', 'low', 'medium', 'high'],
+  mistral: ['low', 'medium', 'high'],
+  plamo: ['none', 'medium'],
+  xai: ['low', 'high'],
+};
 
 /**
  * Chat service factory
@@ -69,6 +102,52 @@ export class ChatServiceFactory {
   static getSupportedModels(providerName: string): string[] {
     const provider = this.providers.get(providerName);
     return provider ? provider.getSupportedModels() : [];
+  }
+
+  /**
+   * Get machine-readable provider capabilities for UI and agent planning.
+   */
+  static getProviderCapabilities(
+    providerName: string,
+    model?: string,
+  ): ChatProviderCapabilities | undefined {
+    const provider = this.providers.get(providerName);
+    if (!provider) {
+      return undefined;
+    }
+
+    const vision = model
+      ? this.getVisionSupportLevelForModel(providerName, model)
+      : provider.getVisionSupportLevel();
+
+    return {
+      provider: providerName,
+      models: provider.getSupportedModels(),
+      defaultModel:
+        typeof provider.getDefaultModel === 'function'
+          ? provider.getDefaultModel()
+          : undefined,
+      text: true,
+      streaming: true,
+      vision,
+      tools: TOOL_SUPPORTED_PROVIDERS.has(providerName),
+      mcp: MCP_SUPPORTED_PROVIDERS.has(providerName),
+      jsonMode: JSON_MODE_SUPPORTED_PROVIDERS.has(providerName),
+      responseLength: true,
+      reasoningEffort: REASONING_EFFORT_BY_PROVIDER[providerName] ?? [],
+    };
+  }
+
+  /**
+   * Get machine-readable capabilities for all registered providers.
+   */
+  static getAllProviderCapabilities(): ChatProviderCapabilities[] {
+    return this.getAvailableProviders()
+      .map((providerName) => this.getProviderCapabilities(providerName))
+      .filter(
+        (capabilities): capabilities is ChatProviderCapabilities =>
+          capabilities !== undefined,
+      );
   }
 
   /**

--- a/packages/chat/src/services/providers/openai/OpenAIChatService.ts
+++ b/packages/chat/src/services/providers/openai/OpenAIChatService.ts
@@ -14,6 +14,7 @@ import type {
   ToolChatCompletion,
   ToolDefinition,
 } from '../../../types';
+import type { BaseChatServiceOptions } from '../ChatServiceProvider';
 import { StreamTextAccumulator } from '../../../utils/streamTextAccumulator';
 import { ChatServiceHttpClient } from '../../../utils/chatServiceHttpClient';
 import {
@@ -27,6 +28,10 @@ import {
   parseOpenAIResponsesStream,
 } from './responsesParser';
 import { buildOpenAIRequestBody } from './openaiRequestBuilder';
+
+type OpenAIResponseFormat = NonNullable<
+  BaseChatServiceOptions['responseFormat']
+>;
 
 /**
  * OpenAI implementation of ChatService
@@ -45,6 +50,7 @@ export class OpenAIChatService implements ChatService {
   private verbosity?: 'low' | 'medium' | 'high';
   private reasoning_effort?: OpenAIReasoningEffort;
   private enableReasoningSummary?: boolean;
+  private responseFormat?: OpenAIResponseFormat;
 
   /**
    * Constructor
@@ -65,6 +71,7 @@ export class OpenAIChatService implements ChatService {
     enableReasoningSummary: boolean = false,
     provider: string = 'openai',
     validateVisionModel: boolean = true,
+    responseFormat?: OpenAIResponseFormat,
   ) {
     this.provider = provider;
     this.apiKey = apiKey;
@@ -77,6 +84,7 @@ export class OpenAIChatService implements ChatService {
     this.verbosity = verbosity;
     this.reasoning_effort = reasoning_effort;
     this.enableReasoningSummary = enableReasoningSummary;
+    this.responseFormat = responseFormat;
 
     // Official OpenAI validates vision model names strictly.
     // Compatible providers can skip this to support arbitrary local IDs.
@@ -274,6 +282,7 @@ export class OpenAIChatService implements ChatService {
       verbosity: this.verbosity,
       reasoning_effort: this.reasoning_effort,
       enableReasoningSummary: this.enableReasoningSummary,
+      responseFormat: this.responseFormat,
       maxTokens,
     });
     const headers: Record<string, string> = {};

--- a/packages/chat/src/services/providers/openai/OpenAIChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/openai/OpenAIChatServiceProvider.ts
@@ -91,7 +91,7 @@ export class OpenAIChatServiceProvider
         ? ENDPOINT_OPENAI_RESPONSES_API
         : ENDPOINT_OPENAI_CHAT_COMPLETIONS_API);
 
-    return new OpenAIChatService(
+    const serviceArgs: ConstructorParameters<typeof OpenAIChatService> = [
       optimizedOptions.apiKey,
       modelName,
       visionModel,
@@ -103,7 +103,13 @@ export class OpenAIChatServiceProvider
       optimizedOptions.reasoning_effort,
       optimizedOptions.enableReasoningSummary,
       this.getProviderName(),
-    );
+    ];
+
+    if (optimizedOptions.responseFormat !== undefined) {
+      serviceArgs.push(true, optimizedOptions.responseFormat);
+    }
+
+    return new OpenAIChatService(...serviceArgs);
   }
 
   /**

--- a/packages/chat/src/services/providers/openai/openaiRequestBuilder.ts
+++ b/packages/chat/src/services/providers/openai/openaiRequestBuilder.ts
@@ -18,7 +18,12 @@ import type {
   MessageWithVision,
   ToolDefinition,
 } from '../../../types';
+import type { BaseChatServiceOptions } from '../ChatServiceProvider';
 import { buildOpenAIToolsDefinition } from './openaiToolBuilder';
+
+type OpenAIResponseFormat = NonNullable<
+  BaseChatServiceOptions['responseFormat']
+>;
 
 const GPT5_RESPONSE_LENGTH_MIN_TOKENS: Record<ChatResponseLength, number> = {
   [CHAT_RESPONSE_LENGTH.VERY_SHORT]: 800,
@@ -58,8 +63,20 @@ type BuildOpenAIRequestBodyOptions = {
   verbosity?: 'low' | 'medium' | 'high';
   reasoning_effort?: OpenAIReasoningEffort;
   enableReasoningSummary?: boolean;
+  responseFormat?: OpenAIResponseFormat;
   maxTokens?: number;
 };
+
+function toResponsesTextFormat(responseFormat: OpenAIResponseFormat): any {
+  if (responseFormat.type !== 'json_schema') {
+    return responseFormat;
+  }
+
+  return {
+    type: responseFormat.type,
+    ...responseFormat.json_schema,
+  };
+}
 
 /**
  * Build request body based on the endpoint type.
@@ -76,6 +93,7 @@ export function buildOpenAIRequestBody({
   verbosity,
   reasoning_effort,
   enableReasoningSummary,
+  responseFormat,
   maxTokens,
 }: BuildOpenAIRequestBodyOptions): any {
   const isResponsesAPI = endpoint === ENDPOINT_OPENAI_RESPONSES_API;
@@ -155,6 +173,17 @@ export function buildOpenAIRequestBody({
       if (verbosity) {
         body.verbosity = verbosity;
       }
+    }
+  }
+
+  if (responseFormat) {
+    if (isResponsesAPI) {
+      body.text = {
+        ...body.text,
+        format: toResponsesTextFormat(responseFormat),
+      };
+    } else {
+      body.response_format = responseFormat;
     }
   }
 

--- a/packages/chat/src/services/providers/openaiCompatible/OpenAICompatibleChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/openaiCompatible/OpenAICompatibleChatServiceProvider.ts
@@ -18,7 +18,7 @@ export class OpenAICompatibleChatServiceProvider
 {
   createChatService(options: OpenAICompatibleChatServiceOptions): ChatService {
     this.validateRequiredOptions(options);
-    return new OpenAIChatService(
+    const serviceArgs: ConstructorParameters<typeof OpenAIChatService> = [
       options.apiKey?.trim() ?? '',
       options.model,
       options.visionModel ?? options.model,
@@ -31,7 +31,13 @@ export class OpenAICompatibleChatServiceProvider
       options.enableReasoningSummary,
       this.getProviderName(),
       false,
-    );
+    ];
+
+    if (options.responseFormat !== undefined) {
+      serviceArgs.push(options.responseFormat);
+    }
+
+    return new OpenAIChatService(...serviceArgs);
   }
 
   getProviderName(): string {

--- a/packages/chat/src/types/capabilities.ts
+++ b/packages/chat/src/types/capabilities.ts
@@ -1,0 +1,15 @@
+import type { VisionSupportLevel } from '../services/providers/ChatServiceProvider';
+
+export interface ChatProviderCapabilities {
+  provider: string;
+  models: string[];
+  defaultModel?: string;
+  text: boolean;
+  streaming: boolean;
+  vision: VisionSupportLevel;
+  tools: boolean;
+  mcp: boolean;
+  jsonMode: boolean;
+  responseLength: boolean;
+  reasoningEffort: string[];
+}

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -17,3 +17,4 @@ export * from './toolChat';
 
 // MCP related type definitions
 export * from './mcp';
+export type { ChatProviderCapabilities } from './capabilities';

--- a/packages/chat/tests/ChatServiceFactory.test.ts
+++ b/packages/chat/tests/ChatServiceFactory.test.ts
@@ -328,6 +328,50 @@ describe('ChatServiceFactory', () => {
     });
   });
 
+  describe('getProviderCapabilities', () => {
+    it('returns machine-readable capabilities for a provider', () => {
+      const capabilities = ChatServiceFactory.getProviderCapabilities('openai');
+
+      expect(capabilities).toEqual(
+        expect.objectContaining({
+          provider: 'openai',
+          text: true,
+          streaming: true,
+          tools: true,
+          mcp: true,
+          jsonMode: true,
+          responseLength: true,
+        }),
+      );
+      expect(capabilities?.models.length).toBeGreaterThan(0);
+      expect(capabilities?.reasoningEffort).toContain('medium');
+    });
+
+    it('returns model-level vision support when a model is specified', () => {
+      const capabilities = ChatServiceFactory.getProviderCapabilities(
+        'openai-compatible',
+        'local-model',
+      );
+
+      expect(capabilities?.vision).toBe('unknown');
+      expect(capabilities?.tools).toBe(true);
+      expect(capabilities?.mcp).toBe(false);
+    });
+
+    it('returns undefined for unknown providers', () => {
+      expect(
+        ChatServiceFactory.getProviderCapabilities('unknown-provider'),
+      ).toBeUndefined();
+    });
+
+    it('returns capabilities for all registered providers', () => {
+      const capabilities = ChatServiceFactory.getAllProviderCapabilities();
+
+      expect(capabilities.map((item) => item.provider)).toContain('openai');
+      expect(capabilities.map((item) => item.provider)).toContain('plamo');
+    });
+  });
+
   describe('getVisionSupportLevel', () => {
     it('should return provider-level vision support', () => {
       const mockProvider = new MockChatServiceProvider();

--- a/packages/chat/tests/providers/openaiRequestBuilder.test.ts
+++ b/packages/chat/tests/providers/openaiRequestBuilder.test.ts
@@ -146,6 +146,66 @@ describe('buildOpenAIRequestBody', () => {
     ]);
   });
 
+  it('adds response_format for chat completions JSON mode', () => {
+    const body = buildOpenAIRequestBody({
+      provider: 'openai',
+      endpoint: ENDPOINT_OPENAI_CHAT_COMPLETIONS_API,
+      messages,
+      model: MODEL_GPT_5_4_MINI,
+      stream: false,
+      tools: [],
+      mcpServers: [],
+      responseFormat: { type: 'json_object' },
+    });
+
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('maps responseFormat into responses text.format', () => {
+    const body = buildOpenAIRequestBody({
+      provider: 'openai',
+      endpoint: ENDPOINT_OPENAI_RESPONSES_API,
+      messages,
+      model: MODEL_GPT_5_4_MINI,
+      stream: false,
+      tools: [],
+      mcpServers: [],
+      verbosity: 'low',
+      responseFormat: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'sample',
+          schema: {
+            type: 'object',
+            properties: {
+              answer: { type: 'string' },
+            },
+            required: ['answer'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+    });
+
+    expect(body.text).toEqual({
+      verbosity: 'low',
+      format: {
+        type: 'json_schema',
+        name: 'sample',
+        schema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+          },
+          required: ['answer'],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    });
+  });
+
   it('normalizes Mistral image_url blocks to string URLs', () => {
     const visionMessages: MessageWithVision[] = [
       {


### PR DESCRIPTION
## Summary

- Add machine-readable chat provider capability discovery through `ChatServiceFactory.getProviderCapabilities()` and `getAllProviderCapabilities()`.
- Export the `ChatProviderCapabilities` type for UI and agent planning.
- Document how UI surfaces and agents can use capability metadata to enable/disable tools, MCP, JSON mode, vision, response length, and reasoning controls before execution.
- Wire `responseFormat` through OpenAI and OpenAI-compatible request paths so advertised JSON mode capability matches runtime behavior.

## Why

Agents and UI code need a safe way to inspect provider features before sending a request. This avoids hard-coding provider rules and prevents users from enabling settings that a provider cannot use.

## Validation

- `npm run fmt` passed
- `npm run lint` passed
- `npm -w @aituber-onair/chat run build` passed
- `npm -w @aituber-onair/chat run test` passed (`60 files / 474 tests`)
- `npm run build` passed
- `npm run test` failed in unrelated `@aituber-onair/voice` tests: `tests/OpenAiEngine.test.ts` has 2 failures with `blob.arrayBuffer is not a function`; chat workspace tests passed separately.

## Security / Internal Info Check

Capability metadata does not include API keys, endpoints, base URLs, MCP server definitions, or other user configuration. The diff was scanned for secrets and local paths; no actual secrets or machine-specific paths were found.