### PR TITLE
[codex] Move comment-intelligence agent changelog to Unreleased

### DIFF
--- a/packages/comment-intelligence/CHANGELOG.md
+++ b/packages/comment-intelligence/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @aituber-onair/comment-intelligence
 
+## Unreleased
+
+### Patch Changes
+
+- Adds `toAgentCommentDecision()` for compact agent-facing decisions that avoid
+  returning the full ranked comment list by default.
+- Adds SDK-independent agent tool definitions through
+  `ANALYZE_LIVE_COMMENTS_TOOL` and `COMMENT_INTELLIGENCE_AGENT_TOOLS`.
+- Exports `DEFAULT_COMMENT_INTELLIGENCE_CONFIG` for agent and UI introspection.
+- Adds a small Node.js agent decision sample that demonstrates compact output,
+  full detail output, and the tool definition summary.
+
 ## 0.0.4
 
 ### Patch Changes
@@ -21,14 +33,6 @@
   echo reliably.
 - Adds stream topic, stream title, and topic priority settings to the React
   examples and starter pet template.
-- Adds `toAgentCommentDecision()` for compact agent-facing decisions that avoid
-  returning the full ranked comment list by default.
-- Adds SDK-independent agent tool definitions through
-  `ANALYZE_LIVE_COMMENTS_TOOL` and `COMMENT_INTELLIGENCE_AGENT_TOOLS`.
-- Exports `DEFAULT_COMMENT_INTELLIGENCE_CONFIG` for agent and UI
-  introspection.
-- Adds a small Node.js agent decision sample that demonstrates compact output,
-  full detail output, and the tool definition summary.
 
 ## 0.0.3
 


### PR DESCRIPTION
## Summary

- Move the comment-intelligence agent-facing API changelog entries from the released `0.0.4` section into a new `Unreleased` section.
- Keep the existing `0.0.4` release notes focused on changes that were already included in the tagged `@aituber-onair/comment-intelligence@0.0.4` release.

## Why

`@aituber-onair/comment-intelligence@0.0.4` is already tagged and released, so the agent compact decision helper, SDK-independent tool definition, default config export, and agent decision sample should be documented as unreleased changes for the next package release.

## Validation

- `npm run fmt` passed
- `npm run lint` passed
- `npm -w @aituber-onair/comment-intelligence run build` passed
- `npm -w @aituber-onair/comment-intelligence run test` passed (`12 files / 137 tests`)
- `npm run build` passed
- `npm run test` failed in unrelated `@aituber-onair/voice` tests: `tests/OpenAiEngine.test.ts` has 2 failures with `blob.arrayBuffer is not a function`; comment-intelligence workspace tests passed separately.

## Security / Internal Info Check

This PR only moves changelog text. No secrets, API keys, local paths, or internal configuration values were added.