### PR TITLE
[codex] Add answered memory to comment intelligence

### DIFF
--- a/packages/comment-intelligence/CHANGELOG.md
+++ b/packages/comment-intelligence/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Exports `DEFAULT_COMMENT_INTELLIGENCE_CONFIG` for agent and UI introspection.
 - Adds a small Node.js agent decision sample that demonstrates compact output,
   full detail output, and the tool definition summary.
+- Adds answered comment memory so apps can mark comments as answered and have
+  later rules-based ranking deterministically deprioritize or exclude those
+  comments, with TTL and optional viewer-level dedupe.
 
 ## 0.0.4
 

--- a/packages/comment-intelligence/README.ja.md
+++ b/packages/comment-intelligence/README.ja.md
@@ -13,6 +13,7 @@ AIチューバーがライブコメントを安全かつ自然に扱うための
 - LLMなしで未選択コメントを要約します。
 - `@aituber-onair/core` に渡す安全な文脈と指示を生成します。
 - ルール違反した視聴者を短時間覚えて、以降のコメントを拾わないようにできます。
+- 返答済みコメントを短時間覚えて、以降のランキングで下げる、または除外できます。
 - 必要な場合だけ、アプリ側から注入された LLM provider を使えます。
 
 ## やらないこと
@@ -51,6 +52,20 @@ await core.processChat(promptForCore);
 ```
 
 ライブ配信中に視聴者ごとの安全状態を覚えたい場合は、同じ `intelligence` インスタンスを使い続けてください。関数型の `analyzeComments()` は単発分析には便利ですが、過去の視聴者状態は覚えません。
+
+アプリが選択コメントを読み上げ・返答し終えたら、同じインスタンスに
+`markAnswered()` を呼んでください。以降の rules 分析では一致する
+コメントに `ignored_recently` が付き、初期設定では優先度が下がります。
+
+```ts
+const result = await intelligence.analyze({ comments });
+const selected = result.selectedComments[0];
+
+if (selected) {
+  await core.processChat(selected.text);
+  intelligence.markAnswered(selected.id, { authorId: selected.author.id });
+}
+```
 
 ## ライブコメントフィルターサンプル
 
@@ -162,6 +177,42 @@ const result = await intelligence.analyze({
 });
 ```
 
+### 同じコメント・同じ視聴者を何度も拾わない
+
+answered memory は初期状態で有効ですが、アプリから明示シグナルが渡る
+までは何もしません。選択コメントの処理後に `markAnswered(commentId)`
+を呼ぶか、単発の `analyze()` に `answeredCommentIds` /
+`answeredViewerIds` を渡します。インスタンスは設定された TTL の間だけ
+返答済み状態を保持します。
+
+```ts
+const intelligence = createCommentIntelligence({
+  ranking: {
+    answeredMemory: {
+      ttlMs: 10 * 60 * 1000,
+      mode: 'deprioritize', // または 'exclude'
+      dedupeByViewer: true,
+    },
+  },
+});
+
+intelligence.markAnswered('comment-1', {
+  authorId: 'viewer-1',
+});
+
+const result = await intelligence.analyze({
+  comments,
+  answeredCommentIds: ['comment-from-app-state'],
+});
+
+console.log(result.answeredCommentIds);
+console.log(intelligence.listAnsweredStates());
+```
+
+`clearAnswered(commentId)` で1件だけ、`clearAnswered()` で配信ローカルの
+answered memory 全体を消せます。`getAnsweredState(commentId)` と
+`listAnsweredStates()` は dashboard や debug 用に使えます。
+
 ## rules mode
 
 `rules` が初期値です。このモードでは LLM provider を呼びません。安全判定、ランキング、未選択コメント要約、LLM向け文脈生成はすべてローカルのルールで行います。
@@ -236,6 +287,8 @@ console.log(debugDecision.rankedComments);
 
 関数・定数: `createCommentIntelligence`, `analyzeComments`, `normalizeYouTubeComment`, `normalizeTwitchComment`, `normalizeWebComment`, `formatCommentIntelligencePrompt`, `toAgentCommentDecision`, `createChatServiceCommentAnalysisProvider`, `DEFAULT_COMMENT_INTELLIGENCE_CONFIG`, `ANALYZE_LIVE_COMMENTS_TOOL`, `COMMENT_INTELLIGENCE_AGENT_TOOLS`。
 
-`createCommentIntelligence()` が返す object には、`analyze()`, `getViewerSafetyState()`, `resetViewerSafetyState()` があります。
+`createCommentIntelligence()` が返す object には、`analyze()`,
+`markAnswered()`, `getAnsweredState()`, `listAnsweredStates()`,
+`clearAnswered()`, `getViewerSafetyState()`, `resetViewerSafetyState()` があります。
 
-主な型: `LiveComment`, `CommentAuthor`, `ViewerProfile`, `ViewerSafetyState`, `StreamState`, `RankedComment`, `SafetyReport`, `IgnoredCommentsSummary`, `CommentIntelligenceResult`, `CommentIntelligenceConfig`, `AnalyzeCommentsInput`, `AgentCommentDecision`, `AgentSelectedComment`, `AgentSafetySummary`, `AgentToolDefinition`, LLM provider/result types。
+主な型: `LiveComment`, `CommentAuthor`, `ViewerProfile`, `ViewerSafetyState`, `AnsweredState`, `StreamState`, `RankedComment`, `SafetyReport`, `IgnoredCommentsSummary`, `CommentIntelligenceResult`, `CommentIntelligenceConfig`, `AnalyzeCommentsInput`, `AgentCommentDecision`, `AgentSelectedComment`, `AgentSafetySummary`, `AgentToolDefinition`, LLM provider/result types。

--- a/packages/comment-intelligence/README.md
+++ b/packages/comment-intelligence/README.md
@@ -15,6 +15,8 @@ It helps your AI character decide which comment to respond to, which comments to
 - Summarizes ignored comments without calling an LLM by default.
 - Builds safe context and instructions for `@aituber-onair/core`.
 - Keeps short-lived viewer safety memory so repeat unsafe viewers can be skipped.
+- Keeps short-lived answered comment memory so already answered comments can be
+  deprioritized or excluded in later ranking.
 - Optionally accepts an injected LLM analysis provider.
 
 ## What It Does Not Do
@@ -53,6 +55,20 @@ await core.processChat(promptForCore);
 ```
 
 Keep the same `intelligence` instance for a live stream if you want viewer safety memory to work across batches. The stateless `analyzeComments()` helper is useful for one-shot analysis, but it does not remember previous viewers.
+
+Use `markAnswered()` on the same instance after your app finishes reading or
+replying to a selected comment. Later `rules` analysis will mark matching
+comments with `ignored_recently` and deprioritize them by default.
+
+```ts
+const result = await intelligence.analyze({ comments });
+const selected = result.selectedComments[0];
+
+if (selected) {
+  await core.processChat(selected.text);
+  intelligence.markAnswered(selected.id, { authorId: selected.author.id });
+}
+```
 
 ## Live Comment Filter Example
 
@@ -177,6 +193,41 @@ const result = await intelligence.analyze({
 });
 ```
 
+### Avoid answering the same comment or viewer repeatedly
+
+Answered memory is enabled by default, but it is a no-op until the app provides
+an explicit signal. Call `markAnswered(commentId)` after the selected comment
+has been handled, or pass `answeredCommentIds` / `answeredViewerIds` to a single
+`analyze()` call. The instance keeps answered state for the configured TTL.
+
+```ts
+const intelligence = createCommentIntelligence({
+  ranking: {
+    answeredMemory: {
+      ttlMs: 10 * 60 * 1000,
+      mode: 'deprioritize', // or 'exclude'
+      dedupeByViewer: true,
+    },
+  },
+});
+
+intelligence.markAnswered('comment-1', {
+  authorId: 'viewer-1',
+});
+
+const result = await intelligence.analyze({
+  comments,
+  answeredCommentIds: ['comment-from-app-state'],
+});
+
+console.log(result.answeredCommentIds);
+console.log(intelligence.listAnsweredStates());
+```
+
+Use `clearAnswered(commentId)` to forget one comment or `clearAnswered()` to
+clear the stream-local answered memory. `getAnsweredState(commentId)` and
+`listAnsweredStates()` are intended for dashboards and debugging.
+
 ## Rules Mode
 
 `rules` mode is the default and never calls an LLM provider. It uses local heuristics for safety, ranking, ignored-comment summaries, and LLM context.
@@ -266,6 +317,13 @@ your stream.
 
 Functions and constants: `createCommentIntelligence`, `analyzeComments`, `normalizeYouTubeComment`, `normalizeTwitchComment`, `normalizeWebComment`, `formatCommentIntelligencePrompt`, `toAgentCommentDecision`, `createChatServiceCommentAnalysisProvider`, `DEFAULT_COMMENT_INTELLIGENCE_CONFIG`, `ANALYZE_LIVE_COMMENTS_TOOL`, `COMMENT_INTELLIGENCE_AGENT_TOOLS`.
 
-The object returned by `createCommentIntelligence()` exposes `analyze()`, `getViewerSafetyState()`, and `resetViewerSafetyState()`.
+The object returned by `createCommentIntelligence()` exposes `analyze()`,
+`markAnswered()`, `getAnsweredState()`, `listAnsweredStates()`,
+`clearAnswered()`, `getViewerSafetyState()`, and `resetViewerSafetyState()`.
 
-Types include `LiveComment`, `CommentAuthor`, `ViewerProfile`, `ViewerSafetyState`, `StreamState`, `RankedComment`, `SafetyReport`, `IgnoredCommentsSummary`, `CommentIntelligenceResult`, `CommentIntelligenceConfig`, `AnalyzeCommentsInput`, `AgentCommentDecision`, `AgentSelectedComment`, `AgentSafetySummary`, `AgentToolDefinition`, and optional LLM provider/result types.
+Types include `LiveComment`, `CommentAuthor`, `ViewerProfile`,
+`ViewerSafetyState`, `AnsweredState`, `StreamState`, `RankedComment`,
+`SafetyReport`, `IgnoredCommentsSummary`, `CommentIntelligenceResult`,
+`CommentIntelligenceConfig`, `AnalyzeCommentsInput`, `AgentCommentDecision`,
+`AgentSelectedComment`, `AgentSafetySummary`, `AgentToolDefinition`, and
+optional LLM provider/result types.

--- a/packages/comment-intelligence/src/createCommentIntelligence.ts
+++ b/packages/comment-intelligence/src/createCommentIntelligence.ts
@@ -2,6 +2,7 @@ import type {
   CommentAnalysisMode,
   CommentIntelligenceConfig,
 } from './types/config.js';
+import type { AnsweredState } from './types/answered.js';
 import type { LLMCommentAnalysisResult } from './types/llm.js';
 import type {
   AnalyzeCommentsInput,
@@ -37,6 +38,12 @@ export const DEFAULT_COMMENT_INTELLIGENCE_CONFIG: CommentIntelligenceConfig = {
     topicFilter: 'prefer',
     maxSelectedComments: 1,
     minScore: 0.3,
+    answeredMemory: {
+      enabled: true,
+      ttlMs: 10 * 60 * 1000,
+      mode: 'deprioritize',
+      dedupeByViewer: false,
+    },
   },
   summary: {
     enabled: true,
@@ -58,13 +65,47 @@ export const DEFAULT_COMMENT_INTELLIGENCE_CONFIG: CommentIntelligenceConfig = {
 export function createCommentIntelligence(config?: CommentIntelligenceConfig) {
   const baseConfig = mergeConfig(DEFAULT_COMMENT_INTELLIGENCE_CONFIG, config);
   const viewerSafetyStates = new Map<string, ViewerSafetyState>();
+  const answeredStates = new Map<string, AnsweredState>();
 
   return {
     async analyze(
       input: AnalyzeCommentsInput
     ): Promise<CommentIntelligenceResult> {
       const mergedConfig = mergeConfig(baseConfig, input.options);
-      return analyzeWithConfig(input, mergedConfig, viewerSafetyStates);
+      return analyzeWithConfig(
+        input,
+        mergedConfig,
+        viewerSafetyStates,
+        answeredStates
+      );
+    },
+    markAnswered(
+      commentId: string | string[],
+      options?: { authorId?: string; at?: number }
+    ): void {
+      const ids = Array.isArray(commentId) ? commentId : [commentId];
+      const answeredAt = options?.at ?? Date.now();
+      for (const id of ids) {
+        answeredStates.set(id, {
+          commentId: id,
+          authorId: options?.authorId,
+          answeredAt,
+        });
+      }
+    },
+    getAnsweredState(commentId: string): AnsweredState | undefined {
+      const state = answeredStates.get(commentId);
+      return state ? { ...state } : undefined;
+    },
+    listAnsweredStates(): AnsweredState[] {
+      return [...answeredStates.values()].map((state) => ({ ...state }));
+    },
+    clearAnswered(commentId?: string): void {
+      if (commentId) {
+        answeredStates.delete(commentId);
+        return;
+      }
+      answeredStates.clear();
     },
     getViewerSafetyState(viewerId: string): ViewerSafetyState | undefined {
       const state = viewerSafetyStates.get(viewerId);
@@ -105,6 +146,10 @@ function mergeConfig(
     ranking: {
       ...base.ranking,
       ...override?.ranking,
+      answeredMemory: {
+        ...base.ranking?.answeredMemory,
+        ...override?.ranking?.answeredMemory,
+      },
       weights: {
         ...base.ranking?.weights,
         ...override?.ranking?.weights,
@@ -119,13 +164,15 @@ function mergeConfig(
 async function analyzeWithConfig(
   input: AnalyzeCommentsInput,
   config: CommentIntelligenceConfig,
-  viewerSafetyStates: Map<string, ViewerSafetyState>
+  viewerSafetyStates: Map<string, ViewerSafetyState>,
+  answeredStates: Map<string, AnsweredState>
 ): Promise<CommentIntelligenceResult> {
   const rulesResult = buildRulesResult(
     input,
     config,
     false,
-    viewerSafetyStates
+    viewerSafetyStates,
+    answeredStates
   );
   const llmProvider = config.analysis?.llmProvider;
   const mode = config.analysis?.mode ?? 'rules';
@@ -174,9 +221,16 @@ function buildRulesResult(
   input: AnalyzeCommentsInput,
   config: CommentIntelligenceConfig,
   usedLLM: boolean,
-  viewerSafetyStates: Map<string, ViewerSafetyState>
+  viewerSafetyStates: Map<string, ViewerSafetyState>,
+  answeredStates: Map<string, AnsweredState>
 ): CommentIntelligenceResult {
   pruneExpiredViewerBlocks(viewerSafetyStates);
+  pruneExpiredAnsweredStates(answeredStates, config.ranking?.answeredMemory);
+  const answeredInput = buildAnsweredRankingInput(
+    input,
+    answeredStates,
+    config.ranking?.answeredMemory
+  );
 
   let safetyReports = input.comments.map((comment) =>
     ruleBasedSafetyProvider.check(comment, config.safety)
@@ -193,6 +247,8 @@ function buildRulesResult(
     safetyReports,
     viewerProfiles: input.viewerProfiles,
     viewerSafetyStates: [...viewerSafetyStates.values()],
+    answeredStates: answeredInput.states,
+    answeredViewerIds: answeredInput.viewerIds,
     streamState: input.streamState,
     config: config.ranking,
   });
@@ -224,6 +280,7 @@ function buildRulesResult(
     safetyReports,
     contextForLLM: [],
     instructionForLLM: '',
+    answeredCommentIds: answeredInput.matchedCommentIds,
     debug: {
       mode: config.analysis?.mode ?? 'rules',
       usedLLM,
@@ -274,16 +331,22 @@ function applyLLMResult(
     const report = safetyReportByCommentId.get(comment.id);
     return !report?.shouldIgnore;
   };
+  const excludesAnswered =
+    rankingConfig?.answeredMemory?.enabled !== false &&
+    rankingConfig?.answeredMemory?.mode === 'exclude';
+  const isSelectableComment = (comment: RankedComment) =>
+    isSafeComment(comment) &&
+    (!excludesAnswered || !comment.reasons.includes('ignored_recently'));
   const selectedFromLLM =
     llmResult.selectedCommentIds
       ?.filter((id) => llmCommentIds.has(id))
       ?.map((id) => rankedById.get(id))
       .filter((comment): comment is RankedComment => Boolean(comment))
-      .filter(isSafeComment) ?? [];
+      .filter(isSelectableComment) ?? [];
   const topicRelatedRanked = rankedComments
     .filter((comment) => llmCommentIds.has(comment.id))
     .filter((comment) => comment.reasons.includes('topic_related'))
-    .filter(isSafeComment)
+    .filter(isSelectableComment)
     .sort((a, b) => b.score - a.score);
   const maxSelected = rankingConfig?.maxSelectedComments ?? 1;
   const selectedComments = selectLLMAwareComments({
@@ -328,6 +391,59 @@ function applyLLMResult(
       blockedViewerIds: rulesResult.debug?.blockedViewerIds ?? [],
       llmUnmatchedIds,
     },
+  };
+}
+
+function buildAnsweredRankingInput(
+  input: AnalyzeCommentsInput,
+  answeredStates: Map<string, AnsweredState>,
+  config?: NonNullable<CommentIntelligenceConfig['ranking']>['answeredMemory']
+): {
+  states: AnsweredState[];
+  viewerIds: string[];
+  matchedCommentIds: string[];
+} {
+  if (config?.enabled === false) {
+    return { states: [], viewerIds: [], matchedCommentIds: [] };
+  }
+
+  const commentsById = new Map(
+    input.comments.map((comment) => [comment.id, comment])
+  );
+  const states = [...answeredStates.values()].map((state) => ({ ...state }));
+
+  for (const commentId of input.answeredCommentIds ?? []) {
+    const comment = commentsById.get(commentId);
+    states.push({
+      commentId,
+      authorId: comment?.author.id,
+      answeredAt: Date.now(),
+    });
+  }
+
+  const viewerIds = [...new Set(input.answeredViewerIds ?? [])];
+  const answeredCommentIds = new Set(states.map((state) => state.commentId));
+  const answeredViewerIds = new Set(viewerIds);
+  if (config?.dedupeByViewer) {
+    for (const state of states) {
+      if (state.authorId) {
+        answeredViewerIds.add(state.authorId);
+      }
+    }
+  }
+
+  const matchedCommentIds = input.comments
+    .filter(
+      (comment) =>
+        answeredCommentIds.has(comment.id) ||
+        answeredViewerIds.has(comment.author.id)
+    )
+    .map((comment) => comment.id);
+
+  return {
+    states,
+    viewerIds,
+    matchedCommentIds,
   };
 }
 
@@ -567,6 +683,28 @@ function pruneExpiredViewerBlocks(
   for (const [viewerId, state] of viewerSafetyStates.entries()) {
     if (state.blockedUntil !== undefined && state.blockedUntil <= Date.now()) {
       viewerSafetyStates.delete(viewerId);
+    }
+  }
+}
+
+function pruneExpiredAnsweredStates(
+  answeredStates: Map<string, AnsweredState>,
+  config?: NonNullable<CommentIntelligenceConfig['ranking']>['answeredMemory']
+): void {
+  if (config?.enabled === false) {
+    return;
+  }
+
+  const ttlMs = config?.ttlMs ?? 10 * 60 * 1000;
+  if (ttlMs <= 0) {
+    answeredStates.clear();
+    return;
+  }
+
+  const now = Date.now();
+  for (const [commentId, state] of answeredStates.entries()) {
+    if (state.answeredAt + ttlMs <= now) {
+      answeredStates.delete(commentId);
     }
   }
 }

--- a/packages/comment-intelligence/src/index.ts
+++ b/packages/comment-intelligence/src/index.ts
@@ -20,6 +20,7 @@ export type {
   LiveComment,
 } from './types/comment.js';
 export { DEFAULT_COMMENT_INTELLIGENCE_CONFIG } from './createCommentIntelligence.js';
+export type { AnsweredState } from './types/answered.js';
 export type { CommentIntelligenceConfig } from './types/config.js';
 export type { CommentAnalysisMode } from './types/config.js';
 export type { RecentAiMessage, StreamState } from './types/context.js';

--- a/packages/comment-intelligence/src/ranking/rankComments.ts
+++ b/packages/comment-intelligence/src/ranking/rankComments.ts
@@ -1,6 +1,7 @@
 import type { LiveComment } from '../types/comment.js';
 import type { CommentIntelligenceConfig } from '../types/config.js';
 import type { StreamState } from '../types/context.js';
+import type { AnsweredState } from '../types/answered.js';
 import type { RankedComment } from '../types/ranking.js';
 import type { SafetyReport } from '../types/safety.js';
 import type { ViewerProfile, ViewerSafetyState } from '../types/viewer.js';
@@ -13,9 +14,13 @@ export type RankCommentsInput = {
   safetyReports: SafetyReport[];
   viewerProfiles?: ViewerProfile[];
   viewerSafetyStates?: ViewerSafetyState[];
+  answeredStates?: AnsweredState[];
+  answeredViewerIds?: string[];
   streamState?: StreamState;
   config?: NonNullable<CommentIntelligenceConfig['ranking']>;
 };
+
+const ANSWERED_COMMENT_PENALTY = 0.75;
 
 export function rankComments(_input: RankCommentsInput): {
   rankedComments: RankedComment[];
@@ -44,6 +49,23 @@ export function rankComments(_input: RankCommentsInput): {
       )
       .map((state) => state.viewerId)
   );
+  const answeredMemory = config.answeredMemory ?? {};
+  const answerMemoryEnabled = answeredMemory.enabled !== false;
+  const answeredCommentIds = new Set(
+    answerMemoryEnabled
+      ? (input.answeredStates ?? []).map((state) => state.commentId)
+      : []
+  );
+  const answeredViewerIds = new Set(
+    answerMemoryEnabled ? (input.answeredViewerIds ?? []) : []
+  );
+  if (answerMemoryEnabled && answeredMemory.dedupeByViewer) {
+    for (const state of input.answeredStates ?? []) {
+      if (state.authorId) {
+        answeredViewerIds.add(state.authorId);
+      }
+    }
+  }
   const seenTexts = new Map<string, number>();
   const freshestTimestamp = Math.max(
     0,
@@ -67,6 +89,9 @@ export function rankComments(_input: RankCommentsInput): {
         safetyPenaltyMultiplier,
       });
       const isBlockedViewer = blockedViewerIds.has(comment.author.id);
+      const isAnswered =
+        answeredCommentIds.has(comment.id) ||
+        answeredViewerIds.has(comment.author.id);
       const safetyReport =
         safetyById.get(comment.id) ??
         (isBlockedViewer
@@ -78,14 +103,35 @@ export function rankComments(_input: RankCommentsInput): {
               reason: 'viewer is blocked due to previous unsafe comments',
             }
           : undefined);
-      const reasons = isBlockedViewer
-        ? [...scored.reasons, 'blocked_viewer' as const, 'unsafe' as const]
+      const baseReasons = isAnswered
+        ? [
+            ...scored.reasons.filter((reason) => reason !== 'fresh'),
+            'ignored_recently' as const,
+          ]
         : scored.reasons;
+      const reasons = isBlockedViewer
+        ? [...baseReasons, 'blocked_viewer' as const, 'unsafe' as const]
+        : baseReasons;
+      const scoreBreakdown = isAnswered
+        ? {
+            ...scored.scoreBreakdown,
+            novelty: 0,
+            freshness: 0,
+            penalty: scored.scoreBreakdown.penalty + ANSWERED_COMMENT_PENALTY,
+          }
+        : scored.scoreBreakdown;
+      const answeredScoreAdjustment = isAnswered
+        ? scored.scoreBreakdown.novelty * weights.novelty +
+          scored.scoreBreakdown.freshness * weights.freshness +
+          ANSWERED_COMMENT_PENALTY
+        : 0;
 
       return {
         ...comment,
-        score: isBlockedViewer ? scored.score - 2 : scored.score,
-        scoreBreakdown: scored.scoreBreakdown,
+        score:
+          (isBlockedViewer ? scored.score - 2 : scored.score) -
+          answeredScoreAdjustment,
+        scoreBreakdown,
         reasons,
         safetyReport,
       };
@@ -98,6 +144,11 @@ export function rankComments(_input: RankCommentsInput): {
     topicFilter === 'require' && Boolean(input.streamState?.topic?.trim());
   const selectedComments = rankedComments
     .filter((comment) => !comment.safetyReport?.shouldIgnore)
+    .filter(
+      (comment) =>
+        answeredMemory.mode !== 'exclude' ||
+        !comment.reasons.includes('ignored_recently')
+    )
     .filter((comment) => comment.score >= minScore)
     .filter(
       (comment) => !requiresTopic || comment.reasons.includes('topic_related')

--- a/packages/comment-intelligence/src/tools.ts
+++ b/packages/comment-intelligence/src/tools.ts
@@ -59,6 +59,18 @@ export const ANALYZE_LIVE_COMMENTS_TOOL: AgentToolDefinition = {
           language: { type: 'string', enum: ['ja', 'en', 'auto'] },
         },
       },
+      answeredCommentIds: {
+        type: 'array',
+        description:
+          'Comment ids that have already been answered in this session and should be deprioritized or excluded.',
+        items: { type: 'string' },
+      },
+      answeredViewerIds: {
+        type: 'array',
+        description:
+          'Viewer ids that have already been answered recently and should be deprioritized or excluded.',
+        items: { type: 'string' },
+      },
     },
     required: ['comments'],
   },

--- a/packages/comment-intelligence/src/types/answered.ts
+++ b/packages/comment-intelligence/src/types/answered.ts
@@ -1,0 +1,5 @@
+export type AnsweredState = {
+  commentId: string;
+  authorId?: string;
+  answeredAt: number;
+};

--- a/packages/comment-intelligence/src/types/config.ts
+++ b/packages/comment-intelligence/src/types/config.ts
@@ -26,6 +26,12 @@ export type CommentIntelligenceConfig = {
     topicFilter?: 'off' | 'prefer' | 'require';
     maxSelectedComments?: number;
     minScore?: number;
+    answeredMemory?: {
+      enabled?: boolean;
+      ttlMs?: number;
+      mode?: 'deprioritize' | 'exclude';
+      dedupeByViewer?: boolean;
+    };
     weights?: Partial<RankingWeights>;
   };
   summary?: {

--- a/packages/comment-intelligence/src/types/result.ts
+++ b/packages/comment-intelligence/src/types/result.ts
@@ -23,6 +23,7 @@ export type CommentIntelligenceResult = {
   safetyReports: SafetyReport[];
   contextForLLM: string[];
   instructionForLLM: string;
+  answeredCommentIds?: string[];
   debug?: CommentIntelligenceDebugInfo;
 };
 
@@ -30,6 +31,8 @@ export type AnalyzeCommentsInput = {
   comments: LiveComment[];
   recentMessages?: RecentAiMessage[];
   recentAiMessages?: RecentAiMessage[];
+  answeredCommentIds?: string[];
+  answeredViewerIds?: string[];
   viewerProfiles?: ViewerProfile[];
   streamState?: StreamState;
   options?: Partial<import('./config.js').CommentIntelligenceConfig>;

--- a/packages/comment-intelligence/test/answeredMemory.test.ts
+++ b/packages/comment-intelligence/test/answeredMemory.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCommentIntelligence } from '../src/createCommentIntelligence.js';
+import type { LiveComment } from '../src/types/comment.js';
+
+function comment(
+  id: string,
+  authorId: string,
+  text: string,
+  timestamp = Date.now()
+): LiveComment {
+  return {
+    id,
+    platform: 'youtube',
+    text,
+    timestamp,
+    author: {
+      id: authorId,
+      name: authorId,
+      displayName: authorId,
+    },
+  };
+}
+
+describe('answered memory', () => {
+  it('deprioritizes a marked answered comment in later analyses', async () => {
+    const intelligence = createCommentIntelligence({
+      ranking: {
+        answeredMemory: {
+          enabled: true,
+          mode: 'deprioritize',
+        },
+      },
+    });
+    intelligence.markAnswered('answered', { authorId: 'viewer-1' });
+
+    const result = await intelligence.analyze({
+      comments: [
+        comment('answered', 'viewer-1', '今日なにするの？', 1),
+        comment('fresh', 'viewer-2', 'どうやるの？', 1),
+      ],
+    });
+
+    expect(result.selectedComments[0].id).toBe('fresh');
+    expect(result.answeredCommentIds).toEqual(['answered']);
+    expect(
+      result.rankedComments.find((ranked) => ranked.id === 'answered')?.reasons
+    ).toContain('ignored_recently');
+  });
+
+  it('accepts per-call answered comment ids without storing them', async () => {
+    const intelligence = createCommentIntelligence();
+
+    const result = await intelligence.analyze({
+      comments: [
+        comment('answered', 'viewer-1', '今日なにするの？', 1),
+        comment('fresh', 'viewer-2', 'どうやるの？', 1),
+      ],
+      answeredCommentIds: ['answered'],
+    });
+
+    expect(result.selectedComments[0].id).toBe('fresh');
+    expect(result.answeredCommentIds).toEqual(['answered']);
+    expect(intelligence.listAnsweredStates()).toEqual([]);
+  });
+
+  it('accepts per-call answered viewer ids', async () => {
+    const intelligence = createCommentIntelligence();
+
+    const result = await intelligence.analyze({
+      comments: [
+        comment('same-viewer', 'viewer-1', '今日なにするの？', 1),
+        comment('other-viewer', 'viewer-2', 'どうやるの？', 1),
+      ],
+      answeredViewerIds: ['viewer-1'],
+    });
+
+    expect(result.selectedComments[0].id).toBe('other-viewer');
+    expect(result.answeredCommentIds).toEqual(['same-viewer']);
+    expect(
+      result.rankedComments.find((ranked) => ranked.id === 'same-viewer')
+        ?.reasons
+    ).toContain('ignored_recently');
+  });
+
+  it('excludes answered comments from selection when configured', async () => {
+    const intelligence = createCommentIntelligence({
+      ranking: {
+        answeredMemory: {
+          enabled: true,
+          mode: 'exclude',
+        },
+      },
+    });
+    intelligence.markAnswered('answered');
+
+    const result = await intelligence.analyze({
+      comments: [
+        comment('answered', 'viewer-1', '今日なにするの？', 1),
+        comment('fallback', 'viewer-2', 'こんにちは', 1),
+      ],
+    });
+
+    expect(result.rankedComments.map((ranked) => ranked.id)).toContain(
+      'answered'
+    );
+    expect(
+      result.selectedComments.map((selected) => selected.id)
+    ).not.toContain('answered');
+  });
+
+  it('dedupes later comments by viewer when configured', async () => {
+    const intelligence = createCommentIntelligence({
+      ranking: {
+        answeredMemory: {
+          enabled: true,
+          mode: 'deprioritize',
+          dedupeByViewer: true,
+        },
+      },
+    });
+    intelligence.markAnswered('old-comment', { authorId: 'viewer-1' });
+
+    const result = await intelligence.analyze({
+      comments: [
+        comment('same-viewer', 'viewer-1', '今日なにするの？', 1),
+        comment('other-viewer', 'viewer-2', 'どうやるの？', 1),
+      ],
+    });
+
+    expect(result.selectedComments[0].id).toBe('other-viewer');
+    expect(result.answeredCommentIds).toEqual(['same-viewer']);
+  });
+
+  it('allows answered comments again after ttl expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T10:00:00.000Z'));
+
+    const intelligence = createCommentIntelligence({
+      ranking: {
+        answeredMemory: {
+          enabled: true,
+          ttlMs: 1000,
+          mode: 'deprioritize',
+        },
+      },
+    });
+    intelligence.markAnswered('answered', { at: Date.now() });
+
+    vi.setSystemTime(new Date('2026-05-24T10:00:02.000Z'));
+    const result = await intelligence.analyze({
+      comments: [
+        comment('answered', 'viewer-1', '今日なにするの？', Date.now()),
+      ],
+    });
+
+    expect(result.selectedComments[0].id).toBe('answered');
+    expect(result.answeredCommentIds).toEqual([]);
+    expect(intelligence.getAnsweredState('answered')).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it('does not apply answered memory when disabled', async () => {
+    const intelligence = createCommentIntelligence({
+      ranking: {
+        answeredMemory: {
+          enabled: false,
+          mode: 'exclude',
+        },
+      },
+    });
+    intelligence.markAnswered('answered');
+
+    const result = await intelligence.analyze({
+      comments: [comment('answered', 'viewer-1', '今日なにするの？', 1)],
+      answeredCommentIds: ['answered'],
+      answeredViewerIds: ['viewer-1'],
+    });
+
+    expect(result.selectedComments[0].id).toBe('answered');
+    expect(result.answeredCommentIds).toEqual([]);
+    expect(result.rankedComments[0].reasons).not.toContain('ignored_recently');
+  });
+
+  it('exposes and clears answered state', () => {
+    const intelligence = createCommentIntelligence();
+
+    intelligence.markAnswered(['a', 'b'], { authorId: 'viewer', at: 123 });
+
+    expect(intelligence.getAnsweredState('a')).toEqual({
+      commentId: 'a',
+      authorId: 'viewer',
+      answeredAt: 123,
+    });
+    expect(intelligence.listAnsweredStates()).toHaveLength(2);
+
+    intelligence.clearAnswered('a');
+    expect(intelligence.getAnsweredState('a')).toBeUndefined();
+    expect(intelligence.listAnsweredStates()).toHaveLength(1);
+
+    intelligence.clearAnswered();
+    expect(intelligence.listAnsweredStates()).toEqual([]);
+  });
+});

--- a/packages/comment-intelligence/test/rankComments.test.ts
+++ b/packages/comment-intelligence/test/rankComments.test.ts
@@ -233,4 +233,99 @@ describe('rankComments', () => {
     expect(result.rankedComments[1].reasons).toContain('duplicate');
     expect(result.rankedComments[1].scoreBreakdown.penalty).toBeGreaterThan(0);
   });
+
+  it('deprioritizes answered comments and marks them ignored_recently', () => {
+    const result = rankComments({
+      comments: [
+        comment('answered', '今日なにするの？', 'viewer-1', 1),
+        comment('fresh', 'どうやるの？', 'viewer-2', 1),
+      ],
+      safetyReports: [],
+      answeredStates: [{ commentId: 'answered', answeredAt: Date.now() }],
+      config: {
+        answeredMemory: { enabled: true, mode: 'deprioritize' },
+      },
+    });
+
+    expect(result.selectedComments[0].id).toBe('fresh');
+    const answered = result.rankedComments.find(
+      (ranked) => ranked.id === 'answered'
+    );
+    expect(answered?.reasons).toContain('ignored_recently');
+    expect(answered?.scoreBreakdown.novelty).toBe(0);
+    expect(answered?.scoreBreakdown.freshness).toBe(0);
+    expect(answered?.scoreBreakdown.penalty).toBeGreaterThan(0);
+  });
+
+  it('keeps answered comments ranked but excludes them from selection', () => {
+    const result = rankComments({
+      comments: [
+        comment('answered', '今日なにするの？', 'viewer-1', 1),
+        comment('fallback', 'こんにちは', 'viewer-2', 1),
+      ],
+      safetyReports: [],
+      answeredStates: [{ commentId: 'answered', answeredAt: Date.now() }],
+      config: {
+        answeredMemory: { enabled: true, mode: 'exclude' },
+      },
+    });
+
+    expect(result.rankedComments.map((ranked) => ranked.id)).toContain(
+      'answered'
+    );
+    expect(
+      result.selectedComments.map((selected) => selected.id)
+    ).not.toContain('answered');
+  });
+
+  it('deprioritizes comments from answered viewers when dedupeByViewer is enabled', () => {
+    const result = rankComments({
+      comments: [
+        comment('same-viewer', '今日なにするの？', 'viewer-1', 1),
+        comment('other-viewer', 'どうやるの？', 'viewer-2', 1),
+      ],
+      safetyReports: [],
+      answeredStates: [
+        {
+          commentId: 'old-comment',
+          authorId: 'viewer-1',
+          answeredAt: Date.now(),
+        },
+      ],
+      config: {
+        answeredMemory: {
+          enabled: true,
+          mode: 'deprioritize',
+          dedupeByViewer: true,
+        },
+      },
+    });
+
+    expect(result.selectedComments[0].id).toBe('other-viewer');
+    expect(
+      result.rankedComments.find((ranked) => ranked.id === 'same-viewer')
+        ?.reasons
+    ).toContain('ignored_recently');
+  });
+
+  it('does not change ranking when answered memory is empty', () => {
+    const comments = [
+      comment('greeting', 'こんにちは', 'viewer-1', 1),
+      comment('question', '今日なにするの？', 'viewer-2', 1),
+    ];
+    const baseline = rankComments({ comments, safetyReports: [] });
+    const withEmptyAnswered = rankComments({
+      comments,
+      safetyReports: [],
+      answeredStates: [],
+      config: { answeredMemory: { enabled: true } },
+    });
+
+    expect(withEmptyAnswered.rankedComments.map((ranked) => ranked.id)).toEqual(
+      baseline.rankedComments.map((ranked) => ranked.id)
+    );
+    expect(
+      withEmptyAnswered.selectedComments.map((selected) => selected.id)
+    ).toEqual(baseline.selectedComments.map((selected) => selected.id));
+  });
 });


### PR DESCRIPTION
## Summary

Adds session-scoped answered comment memory to `@aituber-onair/comment-intelligence` so apps can explicitly mark comments as answered and have later analysis avoid selecting them again.

## Changes

- Add `AnsweredState` and answered memory configuration under `ranking.answeredMemory`.
- Add instance APIs: `markAnswered()`, `getAnsweredState()`, `listAnsweredStates()`, and `clearAnswered()`.
- Add per-call `answeredCommentIds` and `answeredViewerIds` inputs.
- Pass answered state into rules ranking, mark matches with `ignored_recently`, and support both `deprioritize` and `exclude` modes.
- Support TTL pruning and optional viewer-level dedupe.
- Expose `answeredCommentIds` on analysis results for dashboard/debug introspection.
- Update agent tool schema, English/Japanese docs, and the package changelog.

## Privacy / Internal Information Check

Reviewed the staged diff and new files for secrets, tokens, API keys, local absolute paths, `.env` references, and user-specific local identifiers. No sensitive or private information was found.

## Validation

- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`