### PR TITLE
feat(chat): add Ministral 3 and GLM model support

### DIFF
--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @aituber-onair/chat
 
+## Unreleased
+
+### Minor Changes
+
+- Added the Ministral 3 family (`ministral-3b-2512`,
+  `ministral-8b-2512`, and `ministral-14b-2512`) to the Mistral provider,
+  including vision support, the React basic selector, tests, and
+  English/Japanese documentation.
+- Added Z.ai GLM-5.1 (`glm-5.1`) for text chat and GLM-5V-Turbo
+  (`glm-5v-turbo`) for vision chat, including provider support, the React
+  basic selector, tests, and English/Japanese documentation.
+
 ## 0.46.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -671,8 +671,8 @@ const zaiService = ChatServiceFactory.createChatService('zai', {
 
 注意:
 - Z.aiはOpenAI互換のChat Completionsを利用します。
-- テキスト対応モデル: `glm-5.2`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-FlashX`, `glm-4.7-Flash`, `glm-4.6`
-- ビジョン対応モデル: `glm-4.6V`, `glm-4.6V-FlashX`, `glm-4.6V-Flash`
+- テキスト対応モデル: `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-FlashX`, `glm-4.7-Flash`, `glm-4.6`
+- ビジョン対応モデル: `glm-5v-turbo`, `glm-4.6V`, `glm-4.6V-FlashX`, `glm-4.6V-Flash`
 - `thinking` はデフォルトで無効化しています。
 
 #### xAI（Grok）
@@ -760,7 +760,8 @@ await mistralService.processChat(
 注意:
 - Mistralは`https://api.mistral.ai/v1/chat/completions`のChat Completionsを利用します。
 - デフォルトモデルは`mistral-small-latest`です。低コスト、汎用チャット品質、vision対応、adjustable reasoning対応のバランスがよいためサンプル向けの既定値にしています。
-- 対応モデル: `mistral-small-latest`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, `mistral-medium-2508`
+- 対応モデル: `mistral-small-latest`, `ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, `mistral-medium-2508`
+- Ministral 3系は同じChat Completions endpointでtext、vision、streaming、function callingに対応します。
 - `reasoning_effort`は`'none' | 'high'`に対応し、Mistral公式docsに合わせて`mistral-small-latest`と`mistral-medium-3-5`にだけ送信します。それ以外のモデルでは省略します。
 
 reasoning例:
@@ -1138,11 +1139,11 @@ vision、JSON mode、reasoning 設定を使うべきかを provider 固有ロジ
 - **Gemini**: Gemini 3.5 Flash、Gemini 3.1 Flash-Lite、Gemini 3.1 Pro Preview、Gemini 3 Flash Preview、Gemini 2.5 Pro、Gemini 2.5 Flash、Gemini 2.5 Flash Lite、Gemma 4 31B IT、Gemma 4 26B A4B IT などの推奨モデルをサポート。Gemini 3.5 Flash はチャット用途向けに minimal thinking を自動適用します。Gemini 3.1 Flash-Lite Preview、Gemini 3 Pro Preview、Gemini 2.5 Flash Lite Preview などの lifecycle 上 deprecated なモデルは明示指定用に export を残しています
 - **Claude**: Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5 に加え、まだ利用可能だが非推奨の Claude 4 Opus, Claude 4 Sonnet, Claude 3 Haiku をサポート
 - **OpenRouter**: OpenRouterのキュレーション済みモデル一覧（OpenAI/Claude/Gemini/Z.ai/Kimi）をサポート。モデルIDはOpenRouter節を参照してください
-- **Z.ai**: GLM-5.2/GLM-5/GLM-5-Turbo（テキスト）、GLM-4.7/4.6（テキスト）、GLM-4.6V系（ビジョン）をサポート
+- **Z.ai**: GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo（テキスト）、GLM-4.7/4.6（テキスト）、GLM-5V-Turbo/GLM-4.6V系（ビジョン）をサポート
 - **xAI**: Grok 4.5 をチャット用途向けに `reasoning_effort: 'low'` デフォルトでサポート。加えて Grok 4.3、Grok 4.20 の Reasoning/Non-Reasoning、Grok 4-1 Fast の Reasoning/Non-Reasoning をサポートし、全モデルでビジョン対応
 - **Kimi**: Kimi K2.7 Code（`kimi-k2.7-code`）、Kimi K2.7 Code HighSpeed（`kimi-k2.7-code-highspeed`）、Kimi K2.6（`kimi-k2.6`、デフォルト）、Kimi K2.5（`kimi-k2.5`、いずれもビジョン対応）をサポート
 - **DeepSeek**: DeepSeek V4 Flash（`deepseek-v4-flash`）と DeepSeek V4 Pro（`deepseek-v4-pro`）をOpenAI互換Chat Completions経由でサポート。legacy alias の`deepseek-chat`と`deepseek-reasoner`はDeepSeek側で非推奨です
-- **Mistral**: `mistral-small-latest`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, `mistral-medium-2508`などの現行generalist modelをサポートし、streamingとvisionにも対応。adjustable `reasoning_effort`は対応モデルにだけ送信します
+- **Mistral**: Ministral 3系（`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`）と現行generalist modelをサポートし、streamingとvisionにも対応。adjustable `reasoning_effort`は対応モデルにだけ送信します
 - **Sakana AI**: Fugu（`fugu`）と Fugu Ultra（`fugu-ultra`, `fugu-ultra-20260615`）をOpenAI互換Chat Completions経由でサポート
 - **PLaMo**: PLaMo 3.0 Prime（`plamo-3.0-prime`, デフォルト）と PLaMo 2.2 Prime（`plamo-2.2-prime`）をOpenAI互換Chat Completions経由でサポート
 - **Gemini Nano**: Chromeブラウザ内蔵AI（LanguageModel API）。デバイス上で動作し、APIキー不要。Chrome 138以降でPrompt APIフラグの有効化が必要。非ストリーミング、ビジョン非対応

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -684,8 +684,8 @@ const zaiService = ChatServiceFactory.createChatService('zai', {
 
 Notes:
 - Z.ai uses OpenAI-compatible Chat Completions.
-- Supported text models: `glm-5.2`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-FlashX`, `glm-4.7-Flash`, `glm-4.6`
-- Supported vision models: `glm-4.6V`, `glm-4.6V-FlashX`, `glm-4.6V-Flash`
+- Supported text models: `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-FlashX`, `glm-4.7-Flash`, `glm-4.6`
+- Supported vision models: `glm-5v-turbo`, `glm-4.6V`, `glm-4.6V-FlashX`, `glm-4.6V-Flash`
 - `thinking` is disabled by default to match fast response behavior.
 
 #### xAI (Grok)
@@ -773,7 +773,8 @@ await mistralService.processChat(
 Notes:
 - Mistral uses Chat Completions at `https://api.mistral.ai/v1/chat/completions`.
 - Default model: `mistral-small-latest`, chosen for the sample-friendly balance of low cost, strong general chat quality, vision support, and adjustable reasoning support.
-- Supported models: `mistral-small-latest`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, `mistral-medium-2508`.
+- Supported models: `mistral-small-latest`, `ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, `mistral-medium-2508`.
+- Ministral 3 models support text, vision, streaming, and function calling through the same Chat Completions endpoint.
 - `reasoning_effort` is supported as `'none' | 'high'` and is only sent for `mistral-small-latest` and `mistral-medium-3-5`, matching Mistral's adjustable reasoning docs. It is omitted for other models.
 
 Reasoning example:
@@ -1154,11 +1155,11 @@ Currently, the following AI providers are built-in:
 - **Gemini**: Supports recommended models like Gemini 3.5 Flash, Gemini 3.1 Flash-Lite, Gemini 3.1 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite, Gemma 4 31B IT, and Gemma 4 26B A4B IT. Gemini 3.5 Flash automatically uses minimal thinking for chat-style responses. Deprecated lifecycle models such as Gemini 3.1 Flash-Lite Preview, Gemini 3 Pro Preview, and Gemini 2.5 Flash Lite Preview remain exported for explicit use.
 - **Claude**: Supports current Claude API model IDs including Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5, plus deprecated-but-still-available Claude 4 Opus, Claude 4 Sonnet, and Claude 3 Haiku
 - **OpenRouter**: Supports a curated OpenRouter model list (OpenAI/Claude/Gemini/Z.ai/Kimi). See the OpenRouter section for model IDs.
-- **Z.ai**: Supports GLM-5.2/GLM-5/GLM-5-Turbo (text), GLM-4.7/4.6 (text), and GLM-4.6V family (vision)
+- **Z.ai**: Supports GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo (text), GLM-4.7/4.6 (text), and GLM-5V-Turbo/GLM-4.6V family (vision)
 - **xAI**: Supports Grok 4.5 with `reasoning_effort: 'low'` by default for chat-style responses, plus Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, and Grok 4-1 Fast Reasoning/Non-Reasoning, all with vision support.
 - **Kimi**: Supports Kimi K2.7 Code (`kimi-k2.7-code`), Kimi K2.7 Code HighSpeed (`kimi-k2.7-code-highspeed`), Kimi K2.6 (`kimi-k2.6`, default), and Kimi K2.5 (`kimi-k2.5`) with vision support
 - **DeepSeek**: Supports DeepSeek V4 Flash (`deepseek-v4-flash`) and DeepSeek V4 Pro (`deepseek-v4-pro`) via OpenAI-compatible Chat Completions. Legacy aliases `deepseek-chat` and `deepseek-reasoner` are deprecated by DeepSeek.
-- **Mistral**: Supports current Mistral generalist models including `mistral-small-latest`, `mistral-medium-3-5`, `mistral-large-latest`, `mistral-large-2512`, `mistral-small-2603`, and `mistral-medium-2508`, with streaming and vision support. Adjustable `reasoning_effort` is only sent for supported models.
+- **Mistral**: Supports the Ministral 3 family (`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`) and current Mistral generalist models, with streaming and vision support. Adjustable `reasoning_effort` is only sent for supported models.
 - **Sakana AI**: Supports Fugu (`fugu`) and Fugu Ultra (`fugu-ultra`, `fugu-ultra-20260615`) via OpenAI-compatible Chat Completions.
 - **PLaMo**: Supports PLaMo 3.0 Prime (`plamo-3.0-prime`, default) and PLaMo 2.2 Prime (`plamo-2.2-prime`) via OpenAI-compatible Chat Completions.
 - **Gemini Nano**: Chrome built-in AI (LanguageModel API). Runs on-device with no API key required. Chrome 138+ with Prompt API flags enabled. Non-streaming, no vision support.

--- a/packages/chat/examples/react-basic/README.md
+++ b/packages/chat/examples/react-basic/README.md
@@ -141,8 +141,8 @@ Use the dropdown to select response length:
 - Persistence: Fetched dynamic free model IDs are saved under localStorage root key `AITuberOnAirChat_example_react-basic`
 
 **Z.ai**
-- Models: GLM-5.2, GLM-5, GLM-5-Turbo, GLM-4.7/4.6, GLM-4.6V family
-- Vision: GLM-4.6V family (`glm-5.2`, `glm-5`, and `glm-5-turbo` are currently text-only)
+- Models: GLM-5.2, GLM-5.1, GLM-5, GLM-5-Turbo, GLM-5V-Turbo, GLM-4.7/4.6, GLM-4.6V family
+- Vision: GLM-5V-Turbo and GLM-4.6V family (`glm-5.2`, `glm-5.1`, `glm-5`, and `glm-5-turbo` are text-only)
 - Best for: OpenAI-compatible GLM integration
 
 **xAI**
@@ -162,7 +162,7 @@ Use the dropdown to select response length:
 - Best for: DeepSeek's OpenAI-compatible API without manually configuring an endpoint
 
 **Mistral**
-- Models: Mistral Small Latest, Mistral Medium 3.5, Mistral Large Latest, Mistral Large 3, Mistral Small 4, Mistral Medium 3.1
+- Models: Mistral Small Latest, Ministral 3 3B/8B/14B, Mistral Medium 3.5, Mistral Large Latest, Mistral Large 3, Mistral Small 4, Mistral Medium 3.1
 - Vision: Supported
 - Best for: Mistral Chat Completions with streaming and optional adjustable reasoning
 

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -101,8 +101,10 @@ import {
   MODEL_MOONSHOTAI_KIMI_K2_7_CODE,
   // Z.ai models
   MODEL_GLM_5_2,
+  MODEL_GLM_5_1,
   MODEL_GLM_5,
   MODEL_GLM_5_TURBO,
+  MODEL_GLM_5V_TURBO,
   MODEL_GLM_4_7,
   MODEL_GLM_4_7_FLASHX,
   MODEL_GLM_4_7_FLASH,
@@ -126,6 +128,9 @@ import {
   MODEL_DEEPSEEK_V4_FLASH,
   MODEL_DEEPSEEK_V4_PRO,
   // Mistral models
+  MODEL_MINISTRAL_3B_2512,
+  MODEL_MINISTRAL_8B_2512,
+  MODEL_MINISTRAL_14B_2512,
   MODEL_MISTRAL_SMALL_LATEST,
   MODEL_MISTRAL_MEDIUM_3_5,
   MODEL_MISTRAL_LARGE_LATEST,
@@ -926,6 +931,12 @@ export const allModels: ProviderModel[] = [
     default: true,
   },
   {
+    id: MODEL_GLM_5_1,
+    name: 'GLM-5.1',
+    provider: 'zai',
+    default: false,
+  },
+  {
     id: MODEL_GLM_5,
     name: 'GLM-5',
     provider: 'zai',
@@ -934,6 +945,12 @@ export const allModels: ProviderModel[] = [
   {
     id: MODEL_GLM_5_TURBO,
     name: 'GLM-5-Turbo',
+    provider: 'zai',
+    default: false,
+  },
+  {
+    id: MODEL_GLM_5V_TURBO,
+    name: 'GLM-5V-Turbo',
     provider: 'zai',
     default: false,
   },
@@ -1064,6 +1081,24 @@ export const allModels: ProviderModel[] = [
     name: 'Mistral Small Latest',
     provider: 'mistral',
     default: true,
+  },
+  {
+    id: MODEL_MINISTRAL_3B_2512,
+    name: 'Ministral 3 3B',
+    provider: 'mistral',
+    default: false,
+  },
+  {
+    id: MODEL_MINISTRAL_8B_2512,
+    name: 'Ministral 3 8B',
+    provider: 'mistral',
+    default: false,
+  },
+  {
+    id: MODEL_MINISTRAL_14B_2512,
+    name: 'Ministral 3 14B',
+    provider: 'mistral',
+    default: false,
   },
   {
     id: MODEL_MISTRAL_MEDIUM_3_5,

--- a/packages/chat/src/constants/mistral.ts
+++ b/packages/chat/src/constants/mistral.ts
@@ -1,6 +1,11 @@
 export const MISTRAL_API_BASE_URL = 'https://api.mistral.ai/v1';
 export const ENDPOINT_MISTRAL_CHAT_COMPLETIONS_API = `${MISTRAL_API_BASE_URL}/chat/completions`;
 
+// Ministral 3 compact multimodal models
+export const MODEL_MINISTRAL_3B_2512 = 'ministral-3b-2512';
+export const MODEL_MINISTRAL_8B_2512 = 'ministral-8b-2512';
+export const MODEL_MINISTRAL_14B_2512 = 'ministral-14b-2512';
+
 // Mistral generalist models
 export const MODEL_MISTRAL_SMALL_LATEST = 'mistral-small-latest';
 export const MODEL_MISTRAL_SMALL_2603 = 'mistral-small-2603';
@@ -13,6 +18,9 @@ export type MistralReasoningEffort = 'none' | 'high';
 
 export const MISTRAL_SUPPORTED_MODELS = [
   MODEL_MISTRAL_SMALL_LATEST,
+  MODEL_MINISTRAL_3B_2512,
+  MODEL_MINISTRAL_8B_2512,
+  MODEL_MINISTRAL_14B_2512,
   MODEL_MISTRAL_MEDIUM_3_5,
   MODEL_MISTRAL_LARGE_LATEST,
   MODEL_MISTRAL_LARGE_2512,
@@ -27,6 +35,9 @@ export const MISTRAL_REASONING_EFFORT_SUPPORTED_MODELS = [
 
 export const MISTRAL_VISION_SUPPORTED_MODELS = [
   MODEL_MISTRAL_SMALL_LATEST,
+  MODEL_MINISTRAL_3B_2512,
+  MODEL_MINISTRAL_8B_2512,
+  MODEL_MINISTRAL_14B_2512,
   MODEL_MISTRAL_SMALL_2603,
   MODEL_MISTRAL_MEDIUM_3_5,
   MODEL_MISTRAL_MEDIUM_2508,

--- a/packages/chat/src/constants/zai.ts
+++ b/packages/chat/src/constants/zai.ts
@@ -3,8 +3,10 @@ export const ENDPOINT_ZAI_CHAT_COMPLETIONS_API =
 
 // Z.ai GLM models
 export const MODEL_GLM_5_2 = 'glm-5.2';
+export const MODEL_GLM_5_1 = 'glm-5.1';
 export const MODEL_GLM_5 = 'glm-5';
 export const MODEL_GLM_5_TURBO = 'glm-5-turbo';
+export const MODEL_GLM_5V_TURBO = 'glm-5v-turbo';
 export const MODEL_GLM_4_7 = 'glm-4.7';
 export const MODEL_GLM_4_7_FLASHX = 'glm-4.7-FlashX';
 export const MODEL_GLM_4_7_FLASH = 'glm-4.7-Flash';
@@ -15,6 +17,7 @@ export const MODEL_GLM_4_6V_FLASH = 'glm-4.6V-Flash';
 
 // Vision support for models
 export const ZAI_VISION_SUPPORTED_MODELS = [
+  MODEL_GLM_5V_TURBO,
   MODEL_GLM_4_6V,
   MODEL_GLM_4_6V_FLASHX,
   MODEL_GLM_4_6V_FLASH,

--- a/packages/chat/src/services/providers/zai/ZAIChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/zai/ZAIChatServiceProvider.ts
@@ -1,8 +1,10 @@
 import {
   ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
   MODEL_GLM_5_2,
+  MODEL_GLM_5_1,
   MODEL_GLM_5,
   MODEL_GLM_5_TURBO,
+  MODEL_GLM_5V_TURBO,
   MODEL_GLM_4_7,
   MODEL_GLM_4_7_FLASHX,
   MODEL_GLM_4_7_FLASH,
@@ -71,8 +73,10 @@ export class ZAIChatServiceProvider
   getSupportedModels(): string[] {
     return [
       MODEL_GLM_5_2,
+      MODEL_GLM_5_1,
       MODEL_GLM_5,
       MODEL_GLM_5_TURBO,
+      MODEL_GLM_5V_TURBO,
       MODEL_GLM_4_7,
       MODEL_GLM_4_7_FLASHX,
       MODEL_GLM_4_7_FLASH,

--- a/packages/chat/tests/ChatServiceFactory.test.ts
+++ b/packages/chat/tests/ChatServiceFactory.test.ts
@@ -309,6 +309,9 @@ describe('ChatServiceFactory', () => {
       const mistralModels = ChatServiceFactory.getSupportedModels('mistral');
       expect(mistralModels).toEqual([
         'mistral-small-latest',
+        'ministral-3b-2512',
+        'ministral-8b-2512',
+        'ministral-14b-2512',
         'mistral-medium-3-5',
         'mistral-large-latest',
         'mistral-large-2512',

--- a/packages/chat/tests/providers/MistralChatService.test.ts
+++ b/packages/chat/tests/providers/MistralChatService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ENDPOINT_MISTRAL_CHAT_COMPLETIONS_API,
-  MODEL_MISTRAL_LARGE_2512,
+  MODEL_MINISTRAL_8B_2512,
   MODEL_MISTRAL_MEDIUM_2508,
   MODEL_MISTRAL_MEDIUM_3_5,
   MODEL_MISTRAL_SMALL_LATEST,
@@ -58,10 +58,7 @@ describe('MistralChatService', () => {
     const postSpy = vi
       .spyOn(ChatServiceHttpClient, 'post')
       .mockResolvedValue(createOneShotResponse('ok'));
-    const service = new MistralChatService(
-      'test-key',
-      MODEL_MISTRAL_LARGE_2512,
-    );
+    const service = new MistralChatService('test-key', MODEL_MINISTRAL_8B_2512);
 
     await service.chatOnce(messages, false);
 
@@ -69,7 +66,7 @@ describe('MistralChatService', () => {
     expect(postSpy).toHaveBeenCalledWith(
       ENDPOINT_MISTRAL_CHAT_COMPLETIONS_API,
       expect.objectContaining({
-        model: MODEL_MISTRAL_LARGE_2512,
+        model: MODEL_MINISTRAL_8B_2512,
         stream: false,
         messages,
       }),

--- a/packages/chat/tests/providers/MistralChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/MistralChatServiceProvider.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   ENDPOINT_MISTRAL_CHAT_COMPLETIONS_API,
+  MODEL_MINISTRAL_14B_2512,
+  MODEL_MINISTRAL_3B_2512,
+  MODEL_MINISTRAL_8B_2512,
   MODEL_MISTRAL_LARGE_2512,
   MODEL_MISTRAL_LARGE_LATEST,
   MODEL_MISTRAL_MEDIUM_2508,
@@ -21,6 +24,9 @@ describe('MistralChatServiceProvider', () => {
   it('returns current Mistral supported models', () => {
     expect(provider.getSupportedModels()).toEqual([
       MODEL_MISTRAL_SMALL_LATEST,
+      MODEL_MINISTRAL_3B_2512,
+      MODEL_MINISTRAL_8B_2512,
+      MODEL_MINISTRAL_14B_2512,
       MODEL_MISTRAL_MEDIUM_3_5,
       MODEL_MISTRAL_LARGE_LATEST,
       MODEL_MISTRAL_LARGE_2512,
@@ -36,6 +42,11 @@ describe('MistralChatServiceProvider', () => {
   it('reports vision support for supported Mistral models', () => {
     expect(provider.supportsVision()).toBe(true);
     expect(provider.supportsVisionForModel(MODEL_MISTRAL_SMALL_LATEST)).toBe(
+      true,
+    );
+    expect(provider.supportsVisionForModel(MODEL_MINISTRAL_3B_2512)).toBe(true);
+    expect(provider.supportsVisionForModel(MODEL_MINISTRAL_8B_2512)).toBe(true);
+    expect(provider.supportsVisionForModel(MODEL_MINISTRAL_14B_2512)).toBe(
       true,
     );
     expect(provider.getVisionSupportLevel()).toBe('supported');

--- a/packages/chat/tests/providers/ZAIChatService.test.ts
+++ b/packages/chat/tests/providers/ZAIChatService.test.ts
@@ -2,12 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
   MODEL_GLM_4_6,
+  MODEL_GLM_5_1,
   MODEL_GLM_5_2,
   MODEL_GLM_5_TURBO,
+  MODEL_GLM_5V_TURBO,
 } from '../../src/constants';
 import { ZAIChatService } from '../../src/services/providers/zai/ZAIChatService';
 import { ChatServiceHttpClient } from '../../src/utils/chatServiceHttpClient';
-import type { Message, ToolDefinition } from '../../src/types';
+import type {
+  Message,
+  MessageWithVision,
+  ToolDefinition,
+} from '../../src/types';
 
 const messages: Message[] = [{ role: 'user', content: 'hello' }];
 
@@ -60,6 +66,60 @@ describe('ZAIChatService request body', () => {
         model: MODEL_GLM_5_2,
         stream: false,
         messages,
+      }),
+      { Authorization: 'Bearer test-key' },
+    );
+  });
+
+  it('sends glm-5.1 with OpenAI-compatible chat completions payload', async () => {
+    const postSpy = vi
+      .spyOn(ChatServiceHttpClient, 'post')
+      .mockResolvedValue(createOkResponse());
+    const service = new ZAIChatService('test-key', MODEL_GLM_5_1);
+
+    await service.chatOnce(messages, false);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
+      expect.objectContaining({
+        model: MODEL_GLM_5_1,
+        stream: false,
+        messages,
+      }),
+      { Authorization: 'Bearer test-key' },
+    );
+  });
+
+  it('sends glm-5v-turbo vision messages through chat completions', async () => {
+    const postSpy = vi
+      .spyOn(ChatServiceHttpClient, 'post')
+      .mockResolvedValue(createOkResponse());
+    const visionMessages: MessageWithVision[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.png' },
+          },
+        ],
+      },
+    ];
+    const service = new ZAIChatService(
+      'test-key',
+      MODEL_GLM_5_1,
+      MODEL_GLM_5V_TURBO,
+    );
+
+    await service.visionChatOnce(visionMessages, false);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
+      expect.objectContaining({
+        model: MODEL_GLM_5V_TURBO,
+        stream: false,
+        messages: visionMessages,
       }),
       { Authorization: 'Bearer test-key' },
     );

--- a/packages/chat/tests/providers/ZAIChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/ZAIChatServiceProvider.test.ts
@@ -4,8 +4,10 @@ import type { ZAIChatServiceOptions } from '../../src/services/providers/ChatSer
 import {
   ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
   MODEL_GLM_5_2,
+  MODEL_GLM_5_1,
   MODEL_GLM_5,
   MODEL_GLM_5_TURBO,
+  MODEL_GLM_5V_TURBO,
   MODEL_GLM_4_7,
   MODEL_GLM_4_7_FLASHX,
   MODEL_GLM_4_7_FLASH,
@@ -37,8 +39,10 @@ describe('ZAIChatServiceProvider', () => {
       const models = provider.getSupportedModels();
       expect(models).toEqual([
         MODEL_GLM_5_2,
+        MODEL_GLM_5_1,
         MODEL_GLM_5,
         MODEL_GLM_5_TURBO,
+        MODEL_GLM_5V_TURBO,
         MODEL_GLM_4_7,
         MODEL_GLM_4_7_FLASHX,
         MODEL_GLM_4_7_FLASH,
@@ -65,6 +69,10 @@ describe('ZAIChatServiceProvider', () => {
 
   describe('supportsVisionForModel', () => {
     it('should return true for vision-supported models', () => {
+      expect(provider.supportsVisionForModel(MODEL_GLM_5V_TURBO)).toBe(true);
+      expect(provider.getVisionSupportLevelForModel(MODEL_GLM_5V_TURBO)).toBe(
+        'supported',
+      );
       expect(provider.supportsVisionForModel(MODEL_GLM_4_6V_FLASH)).toBe(true);
     });
 
@@ -74,6 +82,10 @@ describe('ZAIChatServiceProvider', () => {
 
     it('should return false for glm-5', () => {
       expect(provider.supportsVisionForModel(MODEL_GLM_5)).toBe(false);
+    });
+
+    it('should return false for glm-5.1', () => {
+      expect(provider.supportsVisionForModel(MODEL_GLM_5_1)).toBe(false);
     });
 
     it('should return false for glm-5.2', () => {
@@ -114,15 +126,15 @@ describe('ZAIChatServiceProvider', () => {
     it('should use vision model when main model supports vision', () => {
       const options: ZAIChatServiceOptions = {
         apiKey: 'test-api-key',
-        model: MODEL_GLM_4_6V_FLASH,
+        model: MODEL_GLM_5V_TURBO,
       };
 
       provider.createChatService(options);
 
       expect(ZAIChatService).toHaveBeenCalledWith(
         'test-api-key',
-        MODEL_GLM_4_6V_FLASH,
-        MODEL_GLM_4_6V_FLASH,
+        MODEL_GLM_5V_TURBO,
+        MODEL_GLM_5V_TURBO,
         undefined,
         ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
         undefined,


### PR DESCRIPTION
## Summary

- add the Ministral 3 3B, 8B, and 14B models to the Mistral provider with vision support
- add GLM-5.1 for text chat and GLM-5V-Turbo for vision chat to the Z.ai provider
- expose the new models in the React basic selector and update tests, documentation, and the Unreleased changelog

## Why

These models are available through the existing Mistral and Z.ai Chat Completions integrations, so users can select them without adding new provider APIs.

## Validation

- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`
