### PR TITLE
Fix PuruPuru emotion reaction timing

### DIFF
--- a/packages/core/examples/react-purupuru-app/package-lock.json
+++ b/packages/core/examples/react-purupuru-app/package-lock.json
@@ -26,7 +26,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^1.6.1"
       }
     },
     "../..": {

--- a/packages/core/examples/react-purupuru-app/package.json
+++ b/packages/core/examples/react-purupuru-app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "vitest run",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -28,6 +29,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/core/examples/react-purupuru-app/src/App.tsx
+++ b/packages/core/examples/react-purupuru-app/src/App.tsx
@@ -17,7 +17,7 @@ import type {
   ScreenplayLike,
 } from './lib/purupuruReactions';
 import {
-  createPuruPuruReactionFromScreenplay,
+  createLinkedPuruPuruReaction,
   withReactionId,
 } from './lib/purupuruReactions';
 import type { PuruPuruEffectAnchor } from './types/settings';
@@ -53,7 +53,6 @@ export default function App() {
   const avatarPackageRef = useRef<PuruPuruAvatarPackage | null>(null);
   const avatarLoadRequestRef = useRef(0);
   const avatarReactionIdRef = useRef(0);
-  const speechReactionRef = useRef<PuruPuruReactionDraft | null>(null);
   const [avatarReaction, setAvatarReaction] = useState<PuruPuruReaction | null>(
     null,
   );
@@ -64,36 +63,32 @@ export default function App() {
   }, []);
 
   const resetAvatarReaction = useCallback(() => {
-    speechReactionRef.current = null;
     setAvatarReaction(null);
   }, []);
 
   const handleAudioPlay = useCallback(
     async (arrayBuffer: ArrayBuffer) => {
-      await play(arrayBuffer, {
-        onStart: () => {
-          if (speechReactionRef.current) {
-            emitAvatarReaction(speechReactionRef.current);
-          } else {
-            setAvatarReaction(null);
-          }
-        },
-      });
+      await play(arrayBuffer);
     },
-    [emitAvatarReaction, play],
+    [play],
   );
 
   const handleSpeechStart = useCallback(
     (screenplay: ScreenplayLike) => {
-      speechReactionRef.current =
-        settingsHook.settings.visual.purupuruReactionControlMode === 'linked'
-          ? createPuruPuruReactionFromScreenplay(
-              screenplay,
-              settingsHook.settings.visual.purupuruEmotionEffectMap,
-            )
-          : null;
+      const reaction = createLinkedPuruPuruReaction(
+        settingsHook.settings.visual.purupuruReactionControlMode,
+        screenplay,
+        settingsHook.settings.visual.purupuruEmotionEffectMap,
+      );
+
+      if (reaction) {
+        emitAvatarReaction(reaction);
+      } else {
+        setAvatarReaction(null);
+      }
     },
     [
+      emitAvatarReaction,
       settingsHook.settings.visual.purupuruEmotionEffectMap,
       settingsHook.settings.visual.purupuruReactionControlMode,
     ],

--- a/packages/core/examples/react-purupuru-app/src/constants/prompts.ts
+++ b/packages/core/examples/react-purupuru-app/src/constants/prompts.ts
@@ -1,4 +1,4 @@
 export const DEFAULT_SYSTEM_PROMPT = [
   'あなたはフレンドリーなAITuberです。回答はできるだけ一言で、短く自然に返してください。',
-  '感情が明確な時だけ、文頭に [happy] [sad] [angry] [surprised] [relaxed] [neutral] のいずれかを付けてください。',
+  '返信の文頭には必ず内容に応じて [happy] [sad] [angry] [surprised] [relaxed] [neutral] のいずれかを付けてください。',
 ].join('\n');

--- a/packages/core/examples/react-purupuru-app/src/lib/purupuruReactions.test.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/purupuruReactions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLinkedPuruPuruReaction,
+  DEFAULT_PURUPURU_EMOTION_EFFECT_MAP,
+} from './purupuruReactions';
+
+describe('createLinkedPuruPuruReaction', () => {
+  it('creates the mapped reaction immediately in linked mode', () => {
+    const reaction = createLinkedPuruPuruReaction(
+      'linked',
+      { emotion: 'happy', text: 'うれしい！' },
+      DEFAULT_PURUPURU_EMOTION_EFFECT_MAP,
+    );
+
+    expect(reaction?.effect).toBe('happy');
+  });
+
+  it('uses a customized emotion effect mapping', () => {
+    const reaction = createLinkedPuruPuruReaction(
+      'linked',
+      { emotion: 'happy' },
+      { ...DEFAULT_PURUPURU_EMOTION_EFFECT_MAP, happy: 'surprised' },
+    );
+
+    expect(reaction?.effect).toBe('surprised');
+  });
+
+  it('returns null when the emotion mapping is none', () => {
+    const reaction = createLinkedPuruPuruReaction(
+      'linked',
+      { emotion: 'happy' },
+      { ...DEFAULT_PURUPURU_EMOTION_EFFECT_MAP, happy: null },
+    );
+
+    expect(reaction).toBeNull();
+  });
+
+  it.each(['none', 'manual'] as const)(
+    'does not create an automatic reaction in %s mode',
+    (controlMode) => {
+      const reaction = createLinkedPuruPuruReaction(
+        controlMode,
+        { emotion: 'happy' },
+        DEFAULT_PURUPURU_EMOTION_EFFECT_MAP,
+      );
+
+      expect(reaction).toBeNull();
+    },
+  );
+});

--- a/packages/core/examples/react-purupuru-app/src/lib/purupuruReactions.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/purupuruReactions.ts
@@ -77,6 +77,16 @@ export function createPuruPuruReactionFromScreenplay(
   return effect ? createPuruPuruReactionFromEmotion(effect) : null;
 }
 
+export function createLinkedPuruPuruReaction(
+  controlMode: PuruPuruReactionControlMode,
+  screenplay: unknown,
+  effectMap: PuruPuruEmotionEffectMap,
+): PuruPuruReactionDraft | null {
+  return controlMode === 'linked'
+    ? createPuruPuruReactionFromScreenplay(screenplay, effectMap)
+    : null;
+}
+
 export function resolvePuruPuruEmotionEffect(
   emotion: unknown,
   effectMap: PuruPuruEmotionEffectMap,


### PR DESCRIPTION
## Summary

- trigger linked PuruPuru avatar reactions as soon as a screenplay emotion is received
- decouple emotion effects from TTS generation and audio playback start
- require every default LLM response to begin with an emotion tag
- add unit coverage for linked, manual, none, and custom emotion mappings

## Root cause

The app stored the reaction derived from `screenplay.emotion` and waited for the audio playback `onStart` callback before emitting it. As a result, reactions were never shown when TTS was disabled, generation failed, or playback did not start.

## User impact

Linked reactions now appear immediately when the screenplay is received, regardless of TTS state. Manual previews and reaction cleanup at the end of speech remain unchanged.

## Validation

- `fmt`
- `npm run build`
- `npm test` (5 tests passed)
- `npm run lint`
- visual verification of linked happy reactions, none mode, and manual previews
