### PR TITLE
feat(chat): add Kimi K3 support

### DIFF
--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @aituber-onair/chat
 
+## Unreleased
+
+### Minor Changes
+
+- Added Kimi K3 (`kimi-k3`) as an explicit Kimi model with vision support,
+  while keeping Kimi K2.6 (`kimi-k2.6`) as the default chat model.
+- Added Kimi K3 request handling for its currently required
+  `reasoning_effort: 'max'`, `max_completion_tokens`, streaming, and tool-call
+  flows, including preservation of `reasoning_content` and `tool_calls` for
+  multi-turn history.
+- Updated the React basic example, tests, and English/Japanese documentation
+  for Kimi K3, with the reasoning control fixed to `max` until lower effort
+  levels become available in the official API.
+
 ## 0.47.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -697,18 +697,21 @@ const xaiService = ChatServiceFactory.createChatService('xai', {
 ```typescript
 const kimiService = ChatServiceFactory.createChatService('kimi', {
   apiKey: process.env.MOONSHOT_API_KEY,
-  model: 'kimi-k2.6',
+  model: 'kimi-k3',
   // Optional: エンドポイント/ベースURLの上書き
   // endpoint: 'https://api.moonshot.ai/v1/chat/completions',
   // baseUrl: 'https://api.moonshot.ai/v1',
-  thinking: { type: 'enabled' }
+  reasoning_effort: 'max'
 });
 ```
 
 注意:
 - KimiはOpenAI互換のChat Completionsを利用します。
-- 対応モデル: `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5`
+- 対応モデル: `kimi-k3`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5`
 - チャット用途向けのデフォルトモデルは引き続き `kimi-k2.6` です。
+- Kimi K3は高Reasoning用途向けの明示的な選択肢です。現在は `reasoning_effort: 'max'` のみ対応し、K2系の `thinking` オプションは利用できません。
+- Kimi K3の出力上限には `max_completion_tokens` を使用します。
+- Kimi K3の複数ターン・ツール呼び出しでは、`reasoning_content` と `tool_calls` を保持するため、返された `completion.assistant_message` を会話履歴へ追加してください。
 - Kimi K2.7 Code 系モデルはコーディング寄りで、thinking mode が必須のため、ツール使用時も `thinking` を有効のままにします。
 - Kimi K2.7 Code 系モデルで `thinking: { type: 'disabled' }` を明示指定すると、リクエスト送信前にエラーになります。
 - 旧 Kimi モデルでは、ツール使用時に `thinking` を `{ type: 'disabled' }` に強制します。
@@ -1141,7 +1144,7 @@ vision、JSON mode、reasoning 設定を使うべきかを provider 固有ロジ
 - **OpenRouter**: OpenRouterのキュレーション済みモデル一覧（OpenAI/Claude/Gemini/Z.ai/Kimi）をサポート。モデルIDはOpenRouter節を参照してください
 - **Z.ai**: GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo（テキスト）、GLM-4.7/4.6（テキスト）、GLM-5V-Turbo/GLM-4.6V系（ビジョン）をサポート
 - **xAI**: Grok 4.5 をチャット用途向けに `reasoning_effort: 'low'` デフォルトでサポート。加えて Grok 4.3、Grok 4.20 の Reasoning/Non-Reasoning、Grok 4-1 Fast の Reasoning/Non-Reasoning をサポートし、全モデルでビジョン対応
-- **Kimi**: Kimi K2.7 Code（`kimi-k2.7-code`）、Kimi K2.7 Code HighSpeed（`kimi-k2.7-code-highspeed`）、Kimi K2.6（`kimi-k2.6`、デフォルト）、Kimi K2.5（`kimi-k2.5`、いずれもビジョン対応）をサポート
+- **Kimi**: Kimi K3（`kimi-k3`、max reasoningのみ）、Kimi K2.7 Code（`kimi-k2.7-code`）、Kimi K2.7 Code HighSpeed（`kimi-k2.7-code-highspeed`）、Kimi K2.6（`kimi-k2.6`、デフォルト）、Kimi K2.5（`kimi-k2.5`、いずれもビジョン対応）をサポート
 - **DeepSeek**: DeepSeek V4 Flash（`deepseek-v4-flash`）と DeepSeek V4 Pro（`deepseek-v4-pro`）をOpenAI互換Chat Completions経由でサポート。legacy alias の`deepseek-chat`と`deepseek-reasoner`はDeepSeek側で非推奨です
 - **Mistral**: Ministral 3系（`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`）と現行generalist modelをサポートし、streamingとvisionにも対応。adjustable `reasoning_effort`は対応モデルにだけ送信します
 - **Sakana AI**: Fugu（`fugu`）と Fugu Ultra（`fugu-ultra`, `fugu-ultra-20260615`）をOpenAI互換Chat Completions経由でサポート

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -710,18 +710,21 @@ Notes:
 ```typescript
 const kimiService = ChatServiceFactory.createChatService('kimi', {
   apiKey: process.env.MOONSHOT_API_KEY,
-  model: 'kimi-k2.6',
+  model: 'kimi-k3',
   // Optional: override endpoint or baseUrl
   // endpoint: 'https://api.moonshot.ai/v1/chat/completions',
   // baseUrl: 'https://api.moonshot.ai/v1',
-  thinking: { type: 'enabled' }
+  reasoning_effort: 'max'
 });
 ```
 
 Notes:
 - Kimi uses OpenAI-compatible Chat Completions.
-- Supported models: `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5`
+- Supported models: `kimi-k3`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5`
 - `kimi-k2.6` remains the default model for chat-oriented usage.
+- Kimi K3 is an explicit high-reasoning option. It currently supports only `reasoning_effort: 'max'` and does not accept the K2.x `thinking` option.
+- Kimi K3 uses `max_completion_tokens` for configured response limits.
+- For Kimi K3 multi-turn and tool-call flows, append the returned `completion.assistant_message` to history so `reasoning_content` and `tool_calls` are preserved.
 - Kimi K2.7 Code models are coding-oriented and require thinking mode, so they keep `thinking` enabled even when tools are used.
 - Explicitly setting `thinking: { type: 'disabled' }` with Kimi K2.7 Code models throws before sending the request.
 - For older Kimi models, when tools are enabled, `thinking` is forced to `{ type: 'disabled' }`.
@@ -1157,7 +1160,7 @@ Currently, the following AI providers are built-in:
 - **OpenRouter**: Supports a curated OpenRouter model list (OpenAI/Claude/Gemini/Z.ai/Kimi). See the OpenRouter section for model IDs.
 - **Z.ai**: Supports GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo (text), GLM-4.7/4.6 (text), and GLM-5V-Turbo/GLM-4.6V family (vision)
 - **xAI**: Supports Grok 4.5 with `reasoning_effort: 'low'` by default for chat-style responses, plus Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, and Grok 4-1 Fast Reasoning/Non-Reasoning, all with vision support.
-- **Kimi**: Supports Kimi K2.7 Code (`kimi-k2.7-code`), Kimi K2.7 Code HighSpeed (`kimi-k2.7-code-highspeed`), Kimi K2.6 (`kimi-k2.6`, default), and Kimi K2.5 (`kimi-k2.5`) with vision support
+- **Kimi**: Supports Kimi K3 (`kimi-k3`, max reasoning only), Kimi K2.7 Code (`kimi-k2.7-code`), Kimi K2.7 Code HighSpeed (`kimi-k2.7-code-highspeed`), Kimi K2.6 (`kimi-k2.6`, default), and Kimi K2.5 (`kimi-k2.5`) with vision support
 - **DeepSeek**: Supports DeepSeek V4 Flash (`deepseek-v4-flash`) and DeepSeek V4 Pro (`deepseek-v4-pro`) via OpenAI-compatible Chat Completions. Legacy aliases `deepseek-chat` and `deepseek-reasoner` are deprecated by DeepSeek.
 - **Mistral**: Supports the Ministral 3 family (`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`) and current Mistral generalist models, with streaming and vision support. Adjustable `reasoning_effort` is only sent for supported models.
 - **Sakana AI**: Supports Fugu (`fugu`) and Fugu Ultra (`fugu-ultra`, `fugu-ultra-20260615`) via OpenAI-compatible Chat Completions.

--- a/packages/chat/examples/react-basic/README.md
+++ b/packages/chat/examples/react-basic/README.md
@@ -152,9 +152,10 @@ Use the dropdown to select response length:
 - Grok 4.5 exposes `reasoning_effort` and defaults to `low` for chat-style responses; Grok 4.3 defaults to `none` for lower latency
 
 **Kimi**
-- Models: Kimi K2.7 Code, Kimi K2.7 Code HighSpeed, Kimi K2.6, Kimi K2.5
+- Models: Kimi K3, Kimi K2.7 Code, Kimi K2.7 Code HighSpeed, Kimi K2.6, Kimi K2.5
 - Vision: Supported
-- Best for: Moonshot models with OpenAI-compatible API. Kimi K2.6 remains the chat-oriented default; Kimi K2.7 Code models are coding-oriented.
+- Best for: Moonshot models with OpenAI-compatible API. Kimi K2.6 remains the chat-oriented default; Kimi K3 is an explicit max-reasoning option, and Kimi K2.7 Code models are coding-oriented.
+- Kimi K3 reasoning: `max` only until the official API exposes lower reasoning levels.
 
 **DeepSeek**
 - Models: DeepSeek V4 Flash, DeepSeek V4 Pro

--- a/packages/chat/examples/react-basic/src/App.tsx
+++ b/packages/chat/examples/react-basic/src/App.tsx
@@ -9,12 +9,14 @@ import {
   allowsReasoningXHigh,
   getDefaultReasoningEffortForGPT5Model,
   isGPT5Model,
+  isKimiReasoningEffortModel,
   isXaiReasoningEffortModel,
   normalizeXaiReasoningEffort,
   type Message,
   type MessageWithVision,
   type ChatResponseLength,
   type GPT5PresetKey,
+  type ChatCompletionAssistantMessage,
 } from '@aituber-onair/chat';
 import './App.css';
 import ChatInterface from './components/ChatInterface';
@@ -46,6 +48,7 @@ interface ChatMessage extends Omit<Message, 'timestamp' | 'content'> {
   timestamp: Date;
   content: Message['content'] | MessageWithVision['content'];
   isStreaming?: boolean;
+  assistantMessage?: ChatCompletionAssistantMessage;
 }
 
 type ReasoningEffortLevel =
@@ -269,7 +272,11 @@ function App() {
         }
 
         if (provider === 'kimi') {
-          options.thinking = { type: kimiThinkingType };
+          if (isKimiReasoningEffortModel(selectedModel)) {
+            options.reasoning_effort = 'max';
+          } else {
+            options.thinking = { type: kimiThinkingType };
+          }
           if (kimiBaseUrl.trim()) {
             options.baseUrl = kimiBaseUrl.trim();
           }
@@ -371,8 +378,14 @@ function App() {
 
       try {
         const chatMessages: (Message | MessageWithVision)[] = messages
-          .filter((m) => m.role !== 'assistant' || m.content)
-          .map(({ role, content }) => ({ role, content }));
+          .filter(
+            (m) => m.role !== 'assistant' || m.content || m.assistantMessage,
+          )
+          .map((message) =>
+            message.assistantMessage
+              ? message.assistantMessage
+              : { role: message.role, content: message.content },
+          );
 
         chatMessages.push(apiMessage);
 
@@ -392,11 +405,16 @@ function App() {
               ),
             );
           },
-          async (complete) => {
+          async (complete, completion) => {
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === assistantMessage.id
-                  ? { ...msg, content: complete, isStreaming: false }
+                  ? {
+                      ...msg,
+                      content: complete,
+                      isStreaming: false,
+                      assistantMessage: completion?.assistant_message,
+                    }
                   : msg,
               ),
             );

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -120,6 +120,7 @@ import {
   MODEL_GROK_4_1_FAST_REASONING,
   MODEL_GROK_4_1_FAST_NON_REASONING,
   // Kimi models
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_6,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
@@ -146,6 +147,7 @@ import {
   MODEL_PLAMO_2_2_PRIME,
   // Gemini Nano models
   MODEL_GEMINI_NANO,
+  isKimiReasoningEffortModel,
 } from '@aituber-onair/chat';
 
 interface ProviderSelectorProps {
@@ -1037,6 +1039,12 @@ export const allModels: ProviderModel[] = [
 
   // Kimi models
   {
+    id: MODEL_KIMI_K3,
+    name: 'Kimi K3',
+    provider: 'kimi',
+    default: false,
+  },
+  {
     id: MODEL_KIMI_K2_7_CODE,
     name: 'Kimi K2.7 Code',
     provider: 'kimi',
@@ -1278,6 +1286,8 @@ export default function ProviderSelector({
     provider === 'xai' && isXaiReasoningEffortModel(selectedModel);
   const isXaiReasoningNoneModelSelected =
     provider === 'xai' && isXaiReasoningEffortNoneModel(selectedModel);
+  const isKimiReasoningModel =
+    provider === 'kimi' && isKimiReasoningEffortModel(selectedModel);
   const xaiReasoningEffort =
     reasoning_effort === 'low' ||
     reasoning_effort === 'medium' ||
@@ -2071,23 +2081,43 @@ export default function ProviderSelector({
 
           {provider === 'kimi' && (
             <>
-              <div className="config-group">
-                <label htmlFor="kimi-thinking-type">Thinking</label>
-                <select
-                  id="kimi-thinking-type"
-                  value={kimiThinkingType || 'enabled'}
-                  onChange={(e) =>
-                    onKimiThinkingTypeChange?.(
-                      e.target.value as 'enabled' | 'disabled',
-                    )
-                  }
-                  disabled={disabled}
-                  className="select-input"
-                >
-                  <option value="enabled">Enabled</option>
-                  <option value="disabled">Disabled</option>
-                </select>
-              </div>
+              {isKimiReasoningModel ? (
+                <div className="config-group">
+                  <label htmlFor="kimi-reasoning-effort">
+                    Reasoning Effort
+                  </label>
+                  <select
+                    id="kimi-reasoning-effort"
+                    value="max"
+                    disabled
+                    className="select-input"
+                  >
+                    <option value="max">Max (currently required)</option>
+                  </select>
+                  <span className="helper-text">
+                    Kimi K3 currently supports max only. Lower levels will be
+                    added after the official API supports them.
+                  </span>
+                </div>
+              ) : (
+                <div className="config-group">
+                  <label htmlFor="kimi-thinking-type">Thinking</label>
+                  <select
+                    id="kimi-thinking-type"
+                    value={kimiThinkingType || 'enabled'}
+                    onChange={(e) =>
+                      onKimiThinkingTypeChange?.(
+                        e.target.value as 'enabled' | 'disabled',
+                      )
+                    }
+                    disabled={disabled}
+                    className="select-input"
+                  >
+                    <option value="enabled">Enabled</option>
+                    <option value="disabled">Disabled</option>
+                  </select>
+                </div>
+              )}
 
               <div className="config-group config-full">
                 <label htmlFor="kimi-base-url">Base URL</label>

--- a/packages/chat/src/constants/kimi.ts
+++ b/packages/chat/src/constants/kimi.ts
@@ -2,13 +2,24 @@ export const ENDPOINT_KIMI_CHAT_COMPLETIONS_API =
   'https://api.moonshot.ai/v1/chat/completions';
 
 // Kimi models
+export const MODEL_KIMI_K3 = 'kimi-k3';
 export const MODEL_KIMI_K2_7_CODE = 'kimi-k2.7-code';
 export const MODEL_KIMI_K2_7_CODE_HIGHSPEED = 'kimi-k2.7-code-highspeed';
 export const MODEL_KIMI_K2_6 = 'kimi-k2.6';
 export const MODEL_KIMI_K2_5 = 'kimi-k2.5';
 
+export type KimiReasoningEffort = 'max';
+
+const KIMI_REASONING_EFFORTS_BY_MODEL: Record<
+  string,
+  readonly KimiReasoningEffort[]
+> = {
+  [MODEL_KIMI_K3]: ['max'],
+};
+
 // Vision support for models
 export const KIMI_VISION_SUPPORTED_MODELS = [
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
   MODEL_KIMI_K2_6,
@@ -33,4 +44,20 @@ export function isKimiVisionModel(model: string): boolean {
  */
 export function isKimiThinkingRequiredModel(model: string): boolean {
   return KIMI_THINKING_REQUIRED_MODELS.includes(model);
+}
+
+/**
+ * Get officially supported reasoning effort values for a Kimi model.
+ */
+export function getKimiSupportedReasoningEfforts(
+  model: string,
+): readonly KimiReasoningEffort[] {
+  return KIMI_REASONING_EFFORTS_BY_MODEL[model] ?? [];
+}
+
+/**
+ * Check if a model uses reasoning_effort instead of the K2.x thinking field.
+ */
+export function isKimiReasoningEffortModel(model: string): boolean {
+  return getKimiSupportedReasoningEfforts(model).length > 0;
 }

--- a/packages/chat/src/services/ChatService.ts
+++ b/packages/chat/src/services/ChatService.ts
@@ -30,7 +30,10 @@ export interface ChatService {
   processChat(
     messages: Message[],
     onPartialResponse: (text: string) => void,
-    onCompleteResponse: (text: string) => Promise<void>,
+    onCompleteResponse: (
+      text: string,
+      completion?: ToolChatCompletion,
+    ) => Promise<void>,
   ): Promise<void>;
 
   /**
@@ -42,7 +45,10 @@ export interface ChatService {
   processVisionChat(
     messages: MessageWithVision[],
     onPartialResponse: (text: string) => void,
-    onCompleteResponse: (text: string) => Promise<void>,
+    onCompleteResponse: (
+      text: string,
+      completion?: ToolChatCompletion,
+    ) => Promise<void>,
   ): Promise<void>;
 
   /**

--- a/packages/chat/src/services/providers/ChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/ChatServiceProvider.ts
@@ -3,6 +3,7 @@ import { ChatResponseLength, GPT5PresetKey } from '../../constants/chat';
 import type { MistralReasoningEffort } from '../../constants/mistral';
 import type { PlamoReasoningEffort } from '../../constants/plamo';
 import type { XaiReasoningEffort } from '../../constants/xai';
+import type { KimiReasoningEffort } from '../../constants/kimi';
 import { ToolDefinition, MCPServerConfig } from '../../types';
 
 /**
@@ -126,16 +127,21 @@ export type ClaudeChatServiceOptions = DisallowKeys<
   mcpServers?: MCPServerConfig[];
 };
 
-export type KimiChatServiceOptions = DisallowKeys<
-  BaseChatServiceOptions,
-  | 'verbosity'
-  | 'reasoning_effort'
-  | 'gpt5Preset'
-  | 'gpt5EndpointPreference'
-  | 'enableReasoningSummary'
-  | 'includeReasoning'
-  | 'reasoningMaxTokens'
->;
+export type KimiChatServiceOptions = Omit<
+  DisallowKeys<
+    BaseChatServiceOptions,
+    | 'verbosity'
+    | 'gpt5Preset'
+    | 'gpt5EndpointPreference'
+    | 'enableReasoningSummary'
+    | 'includeReasoning'
+    | 'reasoningMaxTokens'
+  >,
+  'reasoning_effort'
+> & {
+  /** Kimi K3 reasoning effort. Currently only max is supported. */
+  reasoning_effort?: KimiReasoningEffort;
+};
 
 export type DeepSeekChatServiceOptions = DisallowKeys<
   BaseChatServiceOptions,

--- a/packages/chat/src/services/providers/kimi/KimiChatService.ts
+++ b/packages/chat/src/services/providers/kimi/KimiChatService.ts
@@ -3,7 +3,10 @@ import { Message, MessageWithVision } from '../../../types';
 import { ToolDefinition, ToolChatCompletion } from '../../../types';
 import {
   ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+  KimiReasoningEffort,
   MODEL_KIMI_K2_6,
+  getKimiSupportedReasoningEfforts,
+  isKimiReasoningEffortModel,
   isKimiThinkingRequiredModel,
   isKimiVisionModel,
 } from '../../../constants/kimi';
@@ -15,7 +18,6 @@ import { ChatServiceHttpClient } from '../../../utils/chatServiceHttpClient';
 import {
   buildOpenAICompatibleTools,
   parseOpenAICompatibleOneShot,
-  parseOpenAICompatibleTextStream,
   parseOpenAICompatibleToolStream,
   processChatWithOptionalTools,
 } from '../../../utils';
@@ -41,6 +43,7 @@ export class KimiChatService implements ChatService {
     type: 'enabled' | 'disabled';
     clear_thinking?: boolean;
   };
+  private reasoningEffort?: KimiReasoningEffort;
 
   /**
    * Constructor
@@ -63,6 +66,7 @@ export class KimiChatService implements ChatService {
       type: 'enabled' | 'disabled';
       clear_thinking?: boolean;
     },
+    reasoningEffort?: KimiReasoningEffort,
   ) {
     this.apiKey = apiKey;
     this.model = model;
@@ -70,7 +74,21 @@ export class KimiChatService implements ChatService {
     this.endpoint = endpoint;
     this.responseLength = responseLength;
     this.responseFormat = responseFormat;
-    this.thinking = thinking ?? { type: 'enabled' };
+    this.thinking = thinking;
+    const supportedReasoningEfforts = getKimiSupportedReasoningEfforts(model);
+    if (
+      reasoningEffort !== undefined &&
+      !supportedReasoningEfforts.includes(reasoningEffort)
+    ) {
+      throw new Error(
+        `Model ${model} does not support reasoning_effort: ${reasoningEffort}.`,
+      );
+    }
+    this.reasoningEffort =
+      reasoningEffort ??
+      (isKimiReasoningEffortModel(model)
+        ? supportedReasoningEfforts[0]
+        : undefined);
 
     this.visionModel = visionModel;
   }
@@ -95,14 +113,14 @@ export class KimiChatService implements ChatService {
   async processChat(
     messages: Message[],
     onPartialResponse: (text: string) => void,
-    onCompleteResponse: (text: string) => Promise<void>,
+    onCompleteResponse: (
+      text: string,
+      completion?: ToolChatCompletion,
+    ) => Promise<void>,
   ): Promise<void> {
     await processChatWithOptionalTools({
       hasTools: this.tools.length > 0,
-      runWithoutTools: async () => {
-        const res = await this.callKimi(messages, this.model, true);
-        return this.handleStream(res, onPartialResponse);
-      },
+      runWithoutTools: () => this.chatOnce(messages, true, onPartialResponse),
       runWithTools: () => this.chatOnce(messages, true, onPartialResponse),
       onCompleteResponse,
       toolErrorMessage:
@@ -117,7 +135,10 @@ export class KimiChatService implements ChatService {
   async processVisionChat(
     messages: MessageWithVision[],
     onPartialResponse: (text: string) => void,
-    onCompleteResponse: (text: string) => Promise<void>,
+    onCompleteResponse: (
+      text: string,
+      completion?: ToolChatCompletion,
+    ) => Promise<void>,
   ): Promise<void> {
     if (!isKimiVisionModel(this.visionModel)) {
       throw new Error(
@@ -127,10 +148,8 @@ export class KimiChatService implements ChatService {
 
     await processChatWithOptionalTools({
       hasTools: this.tools.length > 0,
-      runWithoutTools: async () => {
-        const res = await this.callKimi(messages, this.visionModel, true);
-        return this.handleStream(res, onPartialResponse);
-      },
+      runWithoutTools: () =>
+        this.visionChatOnce(messages, true, onPartialResponse),
       runWithTools: () =>
         this.visionChatOnce(messages, true, onPartialResponse),
       onCompleteResponse,
@@ -222,11 +241,19 @@ export class KimiChatService implements ChatService {
         ? maxTokens
         : getMaxTokensForResponseLength(this.responseLength);
     if (tokenLimit !== undefined) {
-      body.max_tokens = tokenLimit;
+      if (isKimiReasoningEffortModel(model)) {
+        body.max_completion_tokens = tokenLimit;
+      } else {
+        body.max_tokens = tokenLimit;
+      }
     }
 
     if (this.responseFormat) {
       body.response_format = this.responseFormat;
+    }
+
+    if (isKimiReasoningEffortModel(model)) {
+      body.reasoning_effort = this.reasoningEffort ?? 'max';
     }
 
     const effectiveThinking = this.resolveEffectiveThinking(model);
@@ -266,6 +293,15 @@ export class KimiChatService implements ChatService {
         clear_thinking?: boolean;
       }
     | undefined {
+    if (isKimiReasoningEffortModel(model)) {
+      if (this.thinking) {
+        throw new Error(
+          `Model ${model} uses reasoning_effort and does not support the K2.x thinking option.`,
+        );
+      }
+      return undefined;
+    }
+
     if (isKimiThinkingRequiredModel(model)) {
       if (this.thinking?.type === 'disabled') {
         throw new Error(
@@ -279,18 +315,11 @@ export class KimiChatService implements ChatService {
       return { type: 'disabled' };
     }
 
-    return this.thinking;
+    return this.thinking ?? { type: 'enabled' };
   }
 
   private buildToolsDefinition(): any[] {
     return buildOpenAICompatibleTools(this.tools, 'chat-completions');
-  }
-
-  private async handleStream(res: Response, onPartial: (t: string) => void) {
-    return parseOpenAICompatibleTextStream(res, onPartial, {
-      onJsonError: (payload) =>
-        console.debug('Failed to parse SSE data:', payload),
-    });
   }
 
   /**
@@ -301,6 +330,7 @@ export class KimiChatService implements ChatService {
     onPartial: (t: string) => void,
   ): Promise<ToolChatCompletion> {
     return parseOpenAICompatibleToolStream(res, onPartial, {
+      preserveAssistantMessage: true,
       onJsonError: (payload) =>
         console.debug('Failed to parse SSE data:', payload),
     });
@@ -310,6 +340,8 @@ export class KimiChatService implements ChatService {
    * Parse non-streaming response
    */
   private parseOneShot(data: any): ToolChatCompletion {
-    return parseOpenAICompatibleOneShot(data);
+    return parseOpenAICompatibleOneShot(data, {
+      preserveAssistantMessage: true,
+    });
   }
 }

--- a/packages/chat/src/services/providers/kimi/KimiChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/kimi/KimiChatServiceProvider.ts
@@ -1,9 +1,12 @@
 import {
   ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
   MODEL_KIMI_K2_6,
   MODEL_KIMI_K2_5,
+  getKimiSupportedReasoningEfforts,
+  isKimiReasoningEffortModel,
   isKimiThinkingRequiredModel,
   isKimiVisionModel,
 } from '../../../constants/kimi';
@@ -43,6 +46,10 @@ export class KimiChatServiceProvider
 
     const tools: ToolDefinition[] | undefined = options.tools;
     const thinking = this.resolveThinking(model, tools, options.thinking);
+    const reasoningEffort = this.resolveReasoningEffort(
+      model,
+      options.reasoning_effort,
+    );
 
     return new KimiChatService(
       options.apiKey,
@@ -53,6 +60,7 @@ export class KimiChatServiceProvider
       options.responseLength,
       options.responseFormat,
       thinking,
+      reasoningEffort,
     );
   }
 
@@ -68,6 +76,7 @@ export class KimiChatServiceProvider
    */
   getSupportedModels(): string[] {
     return [
+      MODEL_KIMI_K3,
       MODEL_KIMI_K2_7_CODE,
       MODEL_KIMI_K2_7_CODE_HIGHSPEED,
       MODEL_KIMI_K2_6,
@@ -134,6 +143,15 @@ export class KimiChatServiceProvider
     tools: ToolDefinition[] | undefined,
     thinking: KimiChatServiceOptions['thinking'],
   ): KimiChatServiceOptions['thinking'] {
+    if (isKimiReasoningEffortModel(model)) {
+      if (thinking) {
+        throw new Error(
+          `Model ${model} uses reasoning_effort and does not support the K2.x thinking option.`,
+        );
+      }
+      return undefined;
+    }
+
     if (isKimiThinkingRequiredModel(model)) {
       if (thinking?.type === 'disabled') {
         throw new Error(
@@ -148,5 +166,30 @@ export class KimiChatServiceProvider
     }
 
     return thinking ?? this.defaultThinking;
+  }
+
+  private resolveReasoningEffort(
+    model: string,
+    reasoningEffort: KimiChatServiceOptions['reasoning_effort'],
+  ): KimiChatServiceOptions['reasoning_effort'] {
+    const supported = getKimiSupportedReasoningEfforts(model);
+
+    if (supported.length === 0) {
+      if (reasoningEffort !== undefined) {
+        throw new Error(
+          `Model ${model} does not support the reasoning_effort option.`,
+        );
+      }
+      return undefined;
+    }
+
+    const resolved = reasoningEffort ?? supported[0]!;
+    if (!supported.includes(resolved)) {
+      throw new Error(
+        `Model ${model} supports reasoning_effort values: ${supported.join(', ')}.`,
+      );
+    }
+
+    return resolved;
   }
 }

--- a/packages/chat/src/types/chat.ts
+++ b/packages/chat/src/types/chat.ts
@@ -2,6 +2,8 @@
  * AITuber OnAir Core type definitions
  */
 
+import type { ChatCompletionToolCall } from './toolChat';
+
 /**
  * Chat message basic type
  */
@@ -9,6 +11,14 @@ export interface Message {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
   timestamp?: number;
+  /** Provider reasoning state that must be preserved for some models. */
+  reasoning_content?: string;
+  /** OpenAI-compatible assistant tool calls. */
+  tool_calls?: ChatCompletionToolCall[];
+  /** OpenAI-compatible tool result reference. */
+  tool_call_id?: string;
+  /** Optional message or tool name. */
+  name?: string;
 }
 
 /**
@@ -27,8 +37,7 @@ export type VisionBlock =
 /**
  * Message type corresponding to vision (image)
  */
-export interface MessageWithVision {
-  role: 'system' | 'user' | 'assistant' | 'tool';
+export interface MessageWithVision extends Omit<Message, 'content'> {
   content: string | VisionBlock[];
 }
 

--- a/packages/chat/src/types/toolChat.ts
+++ b/packages/chat/src/types/toolChat.ts
@@ -18,6 +18,26 @@ export interface ToolResultBlock {
 
 export type CoreToolChatBlock = TextBlock | ToolUseBlock | ToolResultBlock;
 
+export interface ChatCompletionToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/**
+ * Assistant message that can be appended to OpenAI-compatible chat history.
+ */
+export interface ChatCompletionAssistantMessage {
+  role: 'assistant';
+  content: string;
+  reasoning_content?: string;
+  tool_calls?: ChatCompletionToolCall[];
+  [key: string]: unknown;
+}
+
 export interface ToolChatCompletion<B = CoreToolChatBlock> {
   blocks: B[];
   stop_reason: 'tool_use' | 'end';
@@ -26,6 +46,8 @@ export interface ToolChatCompletion<B = CoreToolChatBlock> {
   response_status?: string;
   incomplete_details?: { reason?: string; [key: string]: any } | null;
   usage?: Record<string, any>;
+  /** Complete assistant message for provider-compatible multi-turn history. */
+  assistant_message?: ChatCompletionAssistantMessage;
 }
 export type ToolChatBlock = CoreToolChatBlock;
 

--- a/packages/chat/src/utils/openaiCompatibleSse.ts
+++ b/packages/chat/src/utils/openaiCompatibleSse.ts
@@ -1,4 +1,9 @@
-import { ToolChatBlock, ToolChatCompletion } from '../types';
+import {
+  ChatCompletionAssistantMessage,
+  ChatCompletionToolCall,
+  ToolChatBlock,
+  ToolChatCompletion,
+} from '../types';
 import type { JsonParseErrorHandler } from './safeJsonParse';
 import { safeParseToolCallInput } from './safeJsonParse';
 import { StreamTextAccumulator } from './streamTextAccumulator';
@@ -6,6 +11,7 @@ import { StreamTextAccumulator } from './streamTextAccumulator';
 type SseParseOptions = {
   onJsonError?: JsonParseErrorHandler;
   appendTextBlock?: (blocks: ToolChatBlock[], text: string) => void;
+  preserveAssistantMessage?: boolean;
 };
 
 const parseJsonPayload = (
@@ -115,6 +121,8 @@ export async function parseOpenAICompatibleToolStream(
 ): Promise<ToolChatCompletion> {
   const textBlocks: ToolChatBlock[] = [];
   const toolCallsMap = new Map<number, any>();
+  let fullContent = '';
+  let reasoningContent = '';
   let finishReason: string | undefined;
   let usage: Record<string, any> | undefined;
   const appendTextBlock =
@@ -138,15 +146,25 @@ export async function parseOpenAICompatibleToolStream(
     if (content) {
       onPartial(content);
       appendTextBlock(textBlocks, content);
+      fullContent += content;
+    }
+
+    const reasoning = extractTextContent(delta?.reasoning_content);
+    if (reasoning) {
+      reasoningContent += reasoning;
     }
 
     if (delta?.tool_calls) {
       delta.tool_calls.forEach((c: any) => {
         const entry = toolCallsMap.get(c.index) ?? {
           id: c.id,
+          type: c.type,
           name: c.function?.name,
           args: '',
         };
+        if (c.id) entry.id = c.id;
+        if (c.type) entry.type = c.type;
+        if (c.function?.name) entry.name = c.function.name;
         entry.args += c.function?.arguments || '';
         toolCallsMap.set(c.index, entry);
       });
@@ -163,6 +181,26 @@ export async function parseOpenAICompatibleToolStream(
     }));
 
   const blocks = [...textBlocks, ...toolBlocks];
+  const assistantToolCalls: ChatCompletionToolCall[] = Array.from(
+    toolCallsMap.entries(),
+  )
+    .sort((a, b) => a[0] - b[0])
+    .map(([_, entry]) => ({
+      id: entry.id,
+      type: 'function',
+      function: {
+        name: entry.name,
+        arguments: entry.args,
+      },
+    }));
+  const assistantMessage: ChatCompletionAssistantMessage = {
+    role: 'assistant',
+    content: fullContent,
+    ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
+    ...(assistantToolCalls.length > 0
+      ? { tool_calls: assistantToolCalls }
+      : {}),
+  };
 
   return {
     blocks,
@@ -170,6 +208,9 @@ export async function parseOpenAICompatibleToolStream(
     truncated: finishReason === 'length',
     finish_reason: finishReason,
     usage,
+    ...(options.preserveAssistantMessage
+      ? { assistant_message: assistantMessage }
+      : {}),
   };
 }
 
@@ -179,6 +220,7 @@ export function parseOpenAICompatibleOneShot(
 ): ToolChatCompletion {
   const choice = data?.choices?.[0];
   const blocks: ToolChatBlock[] = [];
+  const content = extractTextContent(choice?.message?.content);
 
   if (choice?.message?.tool_calls?.length) {
     choice.message.tool_calls.forEach((c: any) =>
@@ -192,12 +234,17 @@ export function parseOpenAICompatibleOneShot(
         ),
       }),
     );
-  } else {
-    const content = extractTextContent(choice?.message?.content);
-    if (content) {
-      blocks.push({ type: 'text', text: content });
-    }
+  } else if (content) {
+    blocks.push({ type: 'text', text: content });
   }
+
+  const assistantMessage = choice?.message
+    ? ({
+        ...choice.message,
+        role: 'assistant',
+        content,
+      } as ChatCompletionAssistantMessage)
+    : undefined;
 
   return {
     blocks,
@@ -209,5 +256,8 @@ export function parseOpenAICompatibleOneShot(
     truncated: choice?.finish_reason === 'length',
     finish_reason: choice?.finish_reason,
     usage: data?.usage,
+    ...(options.preserveAssistantMessage
+      ? { assistant_message: assistantMessage }
+      : {}),
   };
 }

--- a/packages/chat/src/utils/processChatFlow.ts
+++ b/packages/chat/src/utils/processChatFlow.ts
@@ -3,9 +3,12 @@ import { StreamTextAccumulator } from './streamTextAccumulator';
 
 type ProcessChatFlowOptions<B = ToolChatBlock> = {
   hasTools: boolean;
-  runWithoutTools: () => Promise<string>;
+  runWithoutTools: () => Promise<string | ToolChatCompletion<B>>;
   runWithTools: () => Promise<ToolChatCompletion<B>>;
-  onCompleteResponse: (text: string) => Promise<void>;
+  onCompleteResponse: (
+    text: string,
+    completion?: ToolChatCompletion<B>,
+  ) => Promise<void>;
   toolErrorMessage: string;
   onToolBlocks?: (blocks: B[]) => void;
 };
@@ -14,8 +17,16 @@ export async function processChatWithOptionalTools<B = ToolChatBlock>(
   options: ProcessChatFlowOptions<B>,
 ): Promise<void> {
   if (!options.hasTools) {
-    const full = await options.runWithoutTools();
-    await options.onCompleteResponse(full);
+    const result = await options.runWithoutTools();
+    if (typeof result === 'string') {
+      await options.onCompleteResponse(result);
+      return;
+    }
+
+    const full = StreamTextAccumulator.getFullText(
+      result.blocks as ToolChatBlock[],
+    );
+    await options.onCompleteResponse(full, result);
     return;
   }
 
@@ -28,7 +39,7 @@ export async function processChatWithOptionalTools<B = ToolChatBlock>(
     const full = StreamTextAccumulator.getFullText(
       result.blocks as ToolChatBlock[],
     );
-    await options.onCompleteResponse(full);
+    await options.onCompleteResponse(full, result);
     return;
   }
 

--- a/packages/chat/tests/providers/KimiChatService.test.ts
+++ b/packages/chat/tests/providers/KimiChatService.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MODEL_KIMI_K2_6, MODEL_KIMI_K2_7_CODE } from '../../src/constants';
+import {
+  ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+  MODEL_KIMI_K3,
+  MODEL_KIMI_K2_6,
+  MODEL_KIMI_K2_7_CODE,
+} from '../../src/constants';
 import { KimiChatService } from '../../src/services/providers/kimi/KimiChatService';
+import { ChatServiceHttpClient } from '../../src/utils/chatServiceHttpClient';
 import type { Message, ToolDefinition } from '../../src/types';
 
 const messages: Message[] = [{ role: 'user', content: 'hello' }];
@@ -19,9 +25,122 @@ const tools: ToolDefinition[] = [
   },
 ];
 
+const createOneShotResponse = (message: Record<string, unknown>) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ finish_reason: 'stop', message }],
+    }),
+  }) as Response;
+
+const createStreamResponse = (chunks: string[]): Response => {
+  let index = 0;
+  const body = {
+    getReader: () => ({
+      read: async () => {
+        if (index >= chunks.length) {
+          return { done: true, value: undefined };
+        }
+        const value = new Uint8Array(Buffer.from(chunks[index], 'utf-8'));
+        index += 1;
+        return { done: false, value };
+      },
+    }),
+  };
+
+  return { body } as Response;
+};
+
 describe('KimiChatService request body', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    global.TextDecoder = class {
+      decode(value?: Uint8Array): string {
+        if (!value) return '';
+        return Buffer.from(value).toString('utf-8');
+      }
+    } as typeof TextDecoder;
+  });
+
+  it('sends Kimi K3 through Chat Completions with max reasoning', async () => {
+    const postSpy = vi.spyOn(ChatServiceHttpClient, 'post').mockResolvedValue(
+      createOneShotResponse({
+        role: 'assistant',
+        content: 'K3 response',
+        reasoning_content: 'K3 reasoning',
+      }),
+    );
+    const service = new KimiChatService(
+      'test-key',
+      MODEL_KIMI_K3,
+      MODEL_KIMI_K3,
+      undefined,
+      ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+      'short',
+      undefined,
+      undefined,
+      'max',
+    );
+
+    const result = await service.chatOnce(messages, false);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+      expect.objectContaining({
+        model: MODEL_KIMI_K3,
+        stream: false,
+        messages,
+        reasoning_effort: 'max',
+        max_completion_tokens: expect.any(Number),
+      }),
+      { Authorization: 'Bearer test-key' },
+    );
+    const body = postSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(body.thinking).toBeUndefined();
+    expect(body.max_tokens).toBeUndefined();
+    expect(result.assistant_message).toEqual({
+      role: 'assistant',
+      content: 'K3 response',
+      reasoning_content: 'K3 reasoning',
+    });
+  });
+
+  it('preserves Kimi K3 reasoning in streaming completion metadata', async () => {
+    vi.spyOn(ChatServiceHttpClient, 'post').mockResolvedValue(
+      createStreamResponse([
+        'data: {"choices":[{"delta":{"role":"assistant","reasoning_content":"Think "}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"more"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" K3"},"finish_reason":"stop"}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    );
+    const service = new KimiChatService(
+      'test-key',
+      MODEL_KIMI_K3,
+      MODEL_KIMI_K3,
+      undefined,
+      ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+      undefined,
+      undefined,
+      undefined,
+      'max',
+    );
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    await service.processChat(messages, vi.fn(), onComplete);
+
+    expect(onComplete).toHaveBeenCalledWith(
+      'Hello K3',
+      expect.objectContaining({
+        assistant_message: {
+          role: 'assistant',
+          content: 'Hello K3',
+          reasoning_content: 'Think more',
+        },
+      }),
+    );
   });
 
   it('keeps thinking enabled for Kimi K2.7 Code when tools are provided', () => {

--- a/packages/chat/tests/providers/KimiChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/KimiChatServiceProvider.test.ts
@@ -3,10 +3,12 @@ import { KimiChatServiceProvider } from '../../src/services/providers/kimi/KimiC
 import type { KimiChatServiceOptions } from '../../src/services/providers/ChatServiceProvider';
 import {
   ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
   MODEL_KIMI_K2_6,
   MODEL_KIMI_K2_5,
+  getKimiSupportedReasoningEfforts,
 } from '../../src/constants';
 
 vi.mock('../../src/services/providers/kimi/KimiChatService');
@@ -30,6 +32,7 @@ describe('KimiChatServiceProvider', () => {
     it('should return array of supported models', () => {
       const models = provider.getSupportedModels();
       expect(models).toEqual([
+        MODEL_KIMI_K3,
         MODEL_KIMI_K2_7_CODE,
         MODEL_KIMI_K2_7_CODE_HIGHSPEED,
         MODEL_KIMI_K2_6,
@@ -44,6 +47,13 @@ describe('KimiChatServiceProvider', () => {
     });
   });
 
+  describe('reasoning effort support', () => {
+    it('should expose only max for Kimi K3', () => {
+      expect(getKimiSupportedReasoningEfforts(MODEL_KIMI_K3)).toEqual(['max']);
+      expect(getKimiSupportedReasoningEfforts(MODEL_KIMI_K2_6)).toEqual([]);
+    });
+  });
+
   describe('supportsVision', () => {
     it('should return true', () => {
       expect(provider.supportsVision()).toBe(true);
@@ -53,6 +63,7 @@ describe('KimiChatServiceProvider', () => {
 
   describe('supportsVisionForModel', () => {
     it('should return true for vision-supported models', () => {
+      expect(provider.supportsVisionForModel(MODEL_KIMI_K3)).toBe(true);
       expect(provider.supportsVisionForModel(MODEL_KIMI_K2_7_CODE)).toBe(true);
       expect(
         provider.supportsVisionForModel(MODEL_KIMI_K2_7_CODE_HIGHSPEED),
@@ -86,7 +97,49 @@ describe('KimiChatServiceProvider', () => {
         undefined,
         undefined,
         expect.objectContaining({ type: 'enabled' }),
+        undefined,
       );
+    });
+
+    it('should create Kimi K3 with max reasoning and no K2 thinking option', () => {
+      const options: KimiChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_KIMI_K3,
+      };
+
+      provider.createChatService(options);
+
+      expect(KimiChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_KIMI_K3,
+        MODEL_KIMI_K3,
+        undefined,
+        ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+        undefined,
+        undefined,
+        undefined,
+        'max',
+      );
+    });
+
+    it('should reject the K2 thinking option for Kimi K3', () => {
+      expect(() => {
+        provider.createChatService({
+          apiKey: 'test-api-key',
+          model: MODEL_KIMI_K3,
+          thinking: { type: 'enabled' },
+        });
+      }).toThrow('does not support the K2.x thinking option');
+    });
+
+    it('should reject reasoning_effort for K2 models', () => {
+      expect(() => {
+        provider.createChatService({
+          apiKey: 'test-api-key',
+          model: MODEL_KIMI_K2_6,
+          reasoning_effort: 'max',
+        });
+      }).toThrow('does not support the reasoning_effort option');
     });
 
     it('should keep thinking enabled for Kimi K2.7 Code when tools are provided', () => {
@@ -112,6 +165,7 @@ describe('KimiChatServiceProvider', () => {
         undefined,
         undefined,
         expect.objectContaining({ type: 'enabled' }),
+        undefined,
       );
     });
 
@@ -148,6 +202,7 @@ describe('KimiChatServiceProvider', () => {
         undefined,
         undefined,
         expect.objectContaining({ type: 'disabled' }),
+        undefined,
       );
     });
 
@@ -168,6 +223,7 @@ describe('KimiChatServiceProvider', () => {
         undefined,
         undefined,
         expect.objectContaining({ type: 'enabled' }),
+        undefined,
       );
     });
 

--- a/packages/chat/tests/utils/openaiCompatibleSse.test.ts
+++ b/packages/chat/tests/utils/openaiCompatibleSse.test.ts
@@ -94,7 +94,9 @@ describe('openaiCompatibleSse', () => {
       'data: [DONE]\n\n',
     ]);
 
-    const result = await parseOpenAICompatibleToolStream(res, onPartial);
+    const result = await parseOpenAICompatibleToolStream(res, onPartial, {
+      preserveAssistantMessage: true,
+    });
 
     expect(onPartial).not.toHaveBeenCalled();
     expect(result.stop_reason).toBe('tool_use');
@@ -106,6 +108,20 @@ describe('openaiCompatibleSse', () => {
         input: { city: 'Tokyo' },
       },
     ]);
+    expect(result.assistant_message).toEqual({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'getWeather',
+            arguments: '{"city":"Tokyo"}',
+          },
+        },
+      ],
+    });
   });
 
   it('should keep text blocks when streaming tool arguments are invalid JSON', async () => {
@@ -173,6 +189,41 @@ describe('openaiCompatibleSse', () => {
     expect(result.blocks).toEqual([
       { type: 'tool_use', id: 'call_2', name: 'search', input: { q: 'hello' } },
     ]);
+  });
+
+  it('should preserve a complete one-shot assistant message when requested', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Calling search. ',
+      reasoning_content: 'A search is required.',
+      tool_calls: [
+        {
+          id: 'call_3',
+          type: 'function',
+          function: {
+            name: 'search',
+            arguments: JSON.stringify({ q: 'Kimi K3' }),
+          },
+        },
+      ],
+    };
+
+    const result = parseOpenAICompatibleOneShot(
+      {
+        choices: [{ finish_reason: 'tool_calls', message }],
+      },
+      { preserveAssistantMessage: true },
+    );
+
+    expect(result.blocks).toEqual([
+      {
+        type: 'tool_use',
+        id: 'call_3',
+        name: 'search',
+        input: { q: 'Kimi K3' },
+      },
+    ]);
+    expect(result.assistant_message).toEqual(message);
   });
 
   it('should fall back to empty input for invalid one-shot tool arguments', () => {

--- a/packages/chat/tests/utils/processChatFlow.test.ts
+++ b/packages/chat/tests/utils/processChatFlow.test.ts
@@ -42,7 +42,33 @@ describe('processChatWithOptionalTools', () => {
     expect(runWithoutTools).not.toHaveBeenCalled();
     expect(runWithTools).toHaveBeenCalledTimes(1);
     expect(onToolBlocks).toHaveBeenCalledWith([{ type: 'text', text: 'ok' }]);
-    expect(onCompleteResponse).toHaveBeenCalledWith('ok');
+    expect(onCompleteResponse).toHaveBeenCalledWith(
+      'ok',
+      expect.objectContaining({ stop_reason: 'end' }),
+    );
+  });
+
+  it('should pass completion metadata through the no-tools flow', async () => {
+    const completion = {
+      blocks: [{ type: 'text', text: 'hello' }],
+      stop_reason: 'end',
+      assistant_message: {
+        role: 'assistant',
+        content: 'hello',
+        reasoning_content: 'reasoning',
+      },
+    } as ToolChatCompletion;
+    const onCompleteResponse = vi.fn().mockResolvedValue(undefined);
+
+    await processChatWithOptionalTools({
+      hasTools: false,
+      runWithoutTools: vi.fn().mockResolvedValue(completion),
+      runWithTools: vi.fn(),
+      onCompleteResponse,
+      toolErrorMessage: 'tool error',
+    });
+
+    expect(onCompleteResponse).toHaveBeenCalledWith('hello', completion);
   });
 
   it('should throw when tool calls are present', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,13 +171,17 @@ export {
   ZAI_VISION_SUPPORTED_MODELS,
   ENDPOINT_ZAI_CHAT_COMPLETIONS_API,
   // Kimi model constants
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
   MODEL_KIMI_K2_6,
   MODEL_KIMI_K2_5,
+  type KimiReasoningEffort,
   KIMI_VISION_SUPPORTED_MODELS,
   KIMI_THINKING_REQUIRED_MODELS,
   ENDPOINT_KIMI_CHAT_COMPLETIONS_API,
+  getKimiSupportedReasoningEfforts,
+  isKimiReasoningEffortModel,
   isKimiVisionModel,
   isKimiThinkingRequiredModel,
   // DeepSeek model constants

--- a/packages/core/tests/index.chatExports.test.ts
+++ b/packages/core/tests/index.chatExports.test.ts
@@ -29,6 +29,7 @@ import {
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
+  MODEL_KIMI_K3,
   MODEL_KIMI_K2_7_CODE,
   MODEL_KIMI_K2_7_CODE_HIGHSPEED,
   MODEL_KIMI_K2_6,
@@ -76,7 +77,9 @@ import {
   allowsReasoningXHigh,
   allowsReasoningMax,
   getDefaultXaiReasoningEffort,
+  getKimiSupportedReasoningEfforts,
   isResponsesOnlyGPT5Model,
+  isKimiReasoningEffortModel,
   isKimiThinkingRequiredModel,
   isKimiVisionModel,
   isXaiReasoningEffortModel,
@@ -85,6 +88,7 @@ import {
   normalizeXaiReasoningEffort,
   refreshOpenRouterFreeModels,
   type ChatProviderCapabilities,
+  type KimiReasoningEffort,
   type RefreshOpenRouterFreeModelsResult,
   type VisionSupportLevel,
 } from '../src/index';
@@ -144,11 +148,15 @@ describe('Core index chat re-exports', () => {
   });
 
   it('re-exports current Kimi model constants', () => {
+    const reasoningEffort: KimiReasoningEffort = 'max';
+
+    expect(MODEL_KIMI_K3).toBe('kimi-k3');
     expect(MODEL_KIMI_K2_7_CODE).toBe('kimi-k2.7-code');
     expect(MODEL_KIMI_K2_7_CODE_HIGHSPEED).toBe('kimi-k2.7-code-highspeed');
     expect(MODEL_KIMI_K2_6).toBe('kimi-k2.6');
     expect(MODEL_KIMI_K2_5).toBe('kimi-k2.5');
     expect(KIMI_VISION_SUPPORTED_MODELS).toEqual([
+      MODEL_KIMI_K3,
       MODEL_KIMI_K2_7_CODE,
       MODEL_KIMI_K2_7_CODE_HIGHSPEED,
       MODEL_KIMI_K2_6,
@@ -158,6 +166,10 @@ describe('Core index chat re-exports', () => {
       MODEL_KIMI_K2_7_CODE,
       MODEL_KIMI_K2_7_CODE_HIGHSPEED,
     ]);
+    expect(reasoningEffort).toBe('max');
+    expect(getKimiSupportedReasoningEfforts(MODEL_KIMI_K3)).toEqual(['max']);
+    expect(isKimiReasoningEffortModel(MODEL_KIMI_K3)).toBe(true);
+    expect(isKimiVisionModel(MODEL_KIMI_K3)).toBe(true);
     expect(isKimiVisionModel(MODEL_KIMI_K2_7_CODE)).toBe(true);
     expect(isKimiThinkingRequiredModel(MODEL_KIMI_K2_7_CODE)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- add `kimi-k3` as an explicit Kimi model with vision support while keeping `kimi-k2.6` as the default
- send K3-specific `reasoning_effort: 'max'` and `max_completion_tokens` request fields
- preserve `reasoning_content` and `tool_calls` in assistant completion metadata for multi-turn history
- re-export the Kimi K3 constant, reasoning type, and capability helpers from `@aituber-onair/core`
- update the React basic example, contract tests, English/Japanese documentation, and the unreleased changelog

## Why

Kimi K3 is available through Moonshot AI's OpenAI-compatible Chat Completions API, but it currently requires maximum reasoning effort. Keeping it as an explicit opt-in model avoids changing the lower-latency chat-oriented default while making the new model available for users who want it.

The core export contract also needed to be synchronized with the expanded Kimi vision model list so repository-wide tests and downstream core imports remain consistent.

## User impact

Consumers can select `kimi-k3` and use the returned `completion.assistant_message` to retain provider-required reasoning and tool-call state across turns. K2.x models continue using their existing `thinking` behavior. Core consumers can import the Kimi K3 model constant and reasoning capability helpers from `@aituber-onair/core`.

## Validation

- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm --prefix packages/core/examples/react-basic run build`
- `npm --prefix packages/core/examples/react-pngtuber-app run build`
- visually verified the Kimi K3/K2.6 settings in the chat React example with no browser warnings or errors
- GitHub Actions: all required checks passed

## Notes

A live Moonshot API request was not performed because no API key was used during validation.