### PR TITLE
fix(core): defer OpenAI-compatible endpoint updates until validation

### DIFF
--- a/packages/core/examples/react-inochi2d-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-inochi2d-app/src/components/SettingsPanel.tsx
@@ -352,10 +352,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -980,11 +1005,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-live2d-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-live2d-app/src/components/SettingsPanel.tsx
@@ -352,10 +352,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -980,11 +1005,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-pet-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-pet-app/src/components/SettingsPanel.tsx
@@ -332,10 +332,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -1012,11 +1037,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-pngtuber-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-pngtuber-app/src/components/SettingsPanel.tsx
@@ -364,10 +364,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -997,11 +1022,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-psd-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-psd-app/src/components/SettingsPanel.tsx
@@ -797,10 +797,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const psdLayerOptions = useMemo(
@@ -1439,11 +1464,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
@@ -363,10 +363,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -992,11 +1017,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 

--- a/packages/core/examples/react-vrm-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-vrm-app/src/components/SettingsPanel.tsx
@@ -352,10 +352,35 @@ export function SettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState(
     settings.llm.systemPrompt,
   );
+  const committedEndpoint = settings.llm.endpoint || '';
+  const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
+  const [endpointError, setEndpointError] = useState('');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
       updateLLMSystemPrompt(systemPromptDraft);
+    }
+  };
+  const commitEndpoint = () => {
+    const endpoint = endpointDraft.trim();
+    let endpointUrl: URL;
+
+    try {
+      endpointUrl = new URL(endpoint);
+    } catch {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    if (endpointUrl.protocol !== 'http:' && endpointUrl.protocol !== 'https:') {
+      setEndpointError('Enter a full http:// or https:// URL.');
+      return;
+    }
+
+    setEndpointError('');
+    setEndpointDraft(endpoint);
+    if (endpoint !== committedEndpoint) {
+      updateLLMEndpoint(endpoint);
     }
   };
   const isOpenAIGPT5Model =
@@ -981,11 +1006,29 @@ export function SettingsPanel({
                 <input
                   id="llm-endpoint"
                   type="text"
-                  value={settings.llm.endpoint || ''}
-                  onChange={(e) => updateLLMEndpoint(e.target.value)}
+                  value={endpointDraft}
+                  onChange={(event) => {
+                    setEndpointDraft(event.target.value);
+                    setEndpointError('');
+                  }}
+                  onBlur={commitEndpoint}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  aria-invalid={endpointError ? true : undefined}
+                  aria-describedby={
+                    endpointError ? 'llm-endpoint-error' : undefined
+                  }
                   placeholder="http://localhost:11434/v1/chat/completions"
                   disabled={disabled}
                 />
+                {endpointError && (
+                  <p id="llm-endpoint-error" className="settings-field-error">
+                    {endpointError}
+                  </p>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## 概要

OpenAI互換プロバイダーのEndpoint URLを入力中に、入力途中の不完全な値が即時に設定へ反映され、アプリ全体がアンマウントされる問題を修正します。

## 原因

対象のアバター例ではEndpointの`onChange`ごとに設定を更新していました。設定更新を契機にAITuberOnAirCoreが再生成され、入力途中の値（例: `h`）がOpenAI互換Providerへ渡されます。Providerの完全URL検証で例外が発生し、設定画面を含むApp全体が消えるため、ブラウザリロードのように見えていました。

## 修正内容

- Endpoint入力をdraft stateと確定済み設定に分離
- blurまたはEnterでのみ設定へ反映
- `http://` / `https://` の完全URLを反映前に検証
- 不正な入力はインラインエラーとして表示し、Coreを再生成しない
- 以下7つのCore Reactアバター例へ同一修正を反映
  - react-pngtuber-app
  - react-vrm-app
  - react-live2d-app
  - react-pet-app
  - react-purupuru-app
  - react-psd-app
  - react-inochi2d-app

## 依存関係・影響範囲の確認

- 共通core/chat/voiceパッケージのコード、公開API、依存関係は変更なし
- `package.json` / `package-lock.json` の変更なし
- `create-aituber-onair` のtemplate-manifestが参照する7つの生成元すべてを更新済み
- Endpoint確定後のlocalStorage保存、AITuberOnAirCore、Comment Intelligenceへの依存経路を確認済み
- `npm ci`（rootおよび対象スターター）成功

## 検証

- ブラウザで入力途中の値を入力してもSettings画面が維持されることを確認
- 不完全URLはインラインエラーになり、接続処理へ進まないことを確認
- 正常なEndpoint確定後、リロードして設定が復元されることを確認
- 7例のproduction build成功
- 6例の既存test成功（Pet例はtest scriptなし、合計93テスト）
- LintはPNGTuber / Live2D / PSD / Inochi2Dで成功
- VRM / Pet / PuruPuruのlint失敗は既存のReact Hooks違反で、本変更箇所とは無関係

既存localStorageに不正値が残っているケースの救済は対象外です。