### PR TITLE
Add Grok 4.6 support to the chat package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6137,7 +6137,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
-                "@aituber-onair/chat": "^0.50.0",
+                "@aituber-onair/chat": "^0.51.0",
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
                 "@vitest/coverage-v8": "^1.3.1",
@@ -6146,7 +6146,7 @@
                 "vitest": "^1.3.1"
             },
             "peerDependencies": {
-                "@aituber-onair/chat": "^0.50.0"
+                "@aituber-onair/chat": "^0.51.0"
             },
             "peerDependenciesMeta": {
                 "@aituber-onair/chat": {
@@ -6692,7 +6692,7 @@
         },
         "packages/chat": {
             "name": "@aituber-onair/chat",
-            "version": "0.50.0",
+            "version": "0.51.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -7050,7 +7050,7 @@
             "version": "0.26.10",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.50.0",
+                "@aituber-onair/chat": "^0.51.0",
                 "@aituber-onair/voice": "^0.19.0"
             },
             "devDependencies": {
@@ -7610,7 +7610,7 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.50.0"
+                "@aituber-onair/chat": "^0.51.0"
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -55,7 +55,7 @@
     "directory": "packages/agent"
   },
   "peerDependencies": {
-    "@aituber-onair/chat": "^0.50.0"
+    "@aituber-onair/chat": "^0.51.0"
   },
   "peerDependenciesMeta": {
     "@aituber-onair/chat": {
@@ -63,7 +63,7 @@
     }
   },
   "devDependencies": {
-    "@aituber-onair/chat": "^0.50.0",
+    "@aituber-onair/chat": "^0.51.0",
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
     "@vitest/coverage-v8": "^1.3.1",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aituber-onair/chat
 
+## 0.51.0
+
+### Minor Changes
+
+- Added xAI Grok 4.6 (`grok-4.6`) as an explicit Chat Completions model with
+  streaming, vision, tool calling, and model-aware `reasoning_effort` support
+  for `low`, `medium`, `high`, and `xhigh`. The existing xAI default model
+  remains unchanged, while Grok 4.6 defaults to `low` for responsive character
+  chat.
+
 ## 0.50.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -723,17 +723,17 @@ const zaiService = ChatServiceFactory.createChatService('zai', {
 ```typescript
 const xaiService = ChatServiceFactory.createChatService('xai', {
   apiKey: process.env.XAI_API_KEY,
-  model: 'grok-4.5',
-  reasoning_effort: 'low', // 任意（Grok 4.5）: low, medium, high
-  visionModel: 'grok-4.3', // 任意: ビジョン対応の xAI モデルを指定
+  model: 'grok-4.6',
+  reasoning_effort: 'low', // 任意: low, medium, high, xhigh
+  visionModel: 'grok-4.6', // 任意: ビジョン対応の xAI モデルを指定
 });
 ```
 
 注意:
 - xAIはOpenAI互換のChat Completionsを利用します。
-- 対応モデル: `grok-4.5`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`
-- `reasoning_effort` は対応モデルにのみ送信されます。`grok-4.5` は `low`, `medium`, `high` に対応し、チャット用途向けにデフォルトは `low` です。`grok-4.3` は `none`, `low`, `medium`, `high` に対応し、デフォルトは `none` です。
-- 対応 xAI モデルではビジョンとツール・関数呼び出しを利用できます。Grok 4.5 も React basic サンプルで画像チャットを直接検証できるようにビジョン対応として有効化しています。
+- 対応モデル: `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`
+- `reasoning_effort` は対応モデルにのみ送信されます。`grok-4.6` は `low`, `medium`, `high`, `xhigh`、`grok-4.5` は `low`, `medium`, `high` に対応し、いずれもチャット用途向けにデフォルトは `low` です。`grok-4.3` は `none`, `low`, `medium`, `high` に対応し、デフォルトは `none` です。
+- 対応 xAI モデルではビジョンとツール・関数呼び出しを利用できます。Grok 4.6 も React basic サンプルで画像チャットを直接検証できるようにビジョン対応として有効化しています。
 
 #### Kimi（Moonshot）
 
@@ -1272,7 +1272,7 @@ vision、JSON mode、reasoning 設定を使うべきかを provider 固有ロジ
 - **Claude**: Claude Opus 5, Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5 に加え、まだ利用可能だが非推奨の Claude 4 Opus, Claude 4 Sonnet, Claude 3 Haiku をサポート。調整可能な `reasoning_effort` は対応モデルに限り `output_config.effort` として送信します
 - **OpenRouter**: OpenRouterのキュレーション済みモデル一覧（OpenAI/Claude/Gemini/Z.ai/xAI/Kimi/DeepSeek/Kwaipilot）をサポート。モデルIDはOpenRouter節を参照してください
 - **Z.ai**: GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo（テキスト）、GLM-4.7/4.6（テキスト）、GLM-5V-Turbo/GLM-4.6V系（ビジョン）をサポート
-- **xAI**: Grok 4.5 をチャット用途向けに `reasoning_effort: 'low'` デフォルトでサポート。加えて Grok 4.3、Grok 4.20 の Reasoning/Non-Reasoning、Grok 4-1 Fast の Reasoning/Non-Reasoning をサポートし、全モデルでビジョン対応
+- **xAI**: Grok 4.6 と Grok 4.5 をチャット用途向けに `reasoning_effort: 'low'` デフォルトでサポート。加えて Grok 4.3、Grok 4.20 の Reasoning/Non-Reasoning、Grok 4-1 Fast の Reasoning/Non-Reasoning をサポートし、全モデルでビジョン対応
 - **Kimi**: Kimi K3（`kimi-k3`、`low` / `high` / `max` reasoning、デフォルトは `max`）、Kimi K2.7 Code（`kimi-k2.7-code`）、Kimi K2.7 Code HighSpeed（`kimi-k2.7-code-highspeed`）、Kimi K2.6（`kimi-k2.6`、デフォルト）、Kimi K2.5（`kimi-k2.5`、いずれもビジョン対応）をサポート
 - **DeepSeek**: DeepSeek V4 Flash（`deepseek-v4-flash`）と DeepSeek V4 Pro（`deepseek-v4-pro`）をOpenAI互換Chat Completions経由でサポート。低遅延チャット向けにthinkingはデフォルト無効で、モデル別の`reasoning_effort`から有効化できます。legacy alias の`deepseek-chat`と`deepseek-reasoner`はDeepSeek側で非推奨です
 - **Mistral**: Ministral 3系（`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`）と現行generalist modelをサポートし、streamingとvisionにも対応。adjustable `reasoning_effort`は対応モデルにだけ送信します

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -740,17 +740,17 @@ Notes:
 ```typescript
 const xaiService = ChatServiceFactory.createChatService('xai', {
   apiKey: process.env.XAI_API_KEY,
-  model: 'grok-4.5',
-  reasoning_effort: 'low', // Optional for Grok 4.5: low, medium, high
-  visionModel: 'grok-4.3', // Optional: use a vision-capable xAI model
+  model: 'grok-4.6',
+  reasoning_effort: 'low', // Optional: low, medium, high, xhigh
+  visionModel: 'grok-4.6', // Optional: use a vision-capable xAI model
 });
 ```
 
 Notes:
 - xAI uses OpenAI-compatible Chat Completions.
-- Supported models: `grok-4.5`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`
-- `reasoning_effort` is sent only for models that support it. `grok-4.5` supports `low`, `medium`, and `high` and defaults to `low` for chat-style responses. `grok-4.3` supports `none`, `low`, `medium`, and `high` and defaults to `none`.
-- Supported xAI models can be used with vision and tool/function calling. Grok 4.5 vision support is enabled so image chat can be validated directly in the React basic sample.
+- Supported models: `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`
+- `reasoning_effort` is sent only for models that support it. `grok-4.6` supports `low`, `medium`, `high`, and `xhigh`; `grok-4.5` supports `low`, `medium`, and `high`. Both default to `low` for chat-style responses. `grok-4.3` supports `none`, `low`, `medium`, and `high` and defaults to `none`.
+- Supported xAI models can be used with vision and tool/function calling. Grok 4.6 vision support is enabled so image chat can be validated directly in the React basic sample.
 
 #### Kimi (Moonshot)
 
@@ -1297,7 +1297,7 @@ Currently, the following AI providers are built-in:
 - **Claude**: Supports current Claude API model IDs including Claude Opus 5, Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5, plus deprecated-but-still-available Claude 4 Opus, Claude 4 Sonnet, and Claude 3 Haiku. Adjustable `reasoning_effort` is sent as `output_config.effort` only for models that support it
 - **OpenRouter**: Supports a curated OpenRouter model list (OpenAI/Claude/Gemini/Z.ai/xAI/Kimi/DeepSeek/Kwaipilot). See the OpenRouter section for model IDs.
 - **Z.ai**: Supports GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo (text), GLM-4.7/4.6 (text), and GLM-5V-Turbo/GLM-4.6V family (vision)
-- **xAI**: Supports Grok 4.5 with `reasoning_effort: 'low'` by default for chat-style responses, plus Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, and Grok 4-1 Fast Reasoning/Non-Reasoning, all with vision support.
+- **xAI**: Supports Grok 4.6 and Grok 4.5 with `reasoning_effort: 'low'` by default for chat-style responses, plus Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, and Grok 4-1 Fast Reasoning/Non-Reasoning, all with vision support.
 - **Kimi**: Supports Kimi K3 (`kimi-k3`, `low` / `high` / `max` reasoning with `max` as the default), Kimi K2.7 Code (`kimi-k2.7-code`), Kimi K2.7 Code HighSpeed (`kimi-k2.7-code-highspeed`), Kimi K2.6 (`kimi-k2.6`, default), and Kimi K2.5 (`kimi-k2.5`) with vision support
 - **DeepSeek**: Supports DeepSeek V4 Flash (`deepseek-v4-flash`) and DeepSeek V4 Pro (`deepseek-v4-pro`) via OpenAI-compatible Chat Completions. Thinking defaults to disabled for low-latency chat and can be enabled with model-aware `reasoning_effort`. Legacy aliases `deepseek-chat` and `deepseek-reasoner` are deprecated by DeepSeek.
 - **Mistral**: Supports the Ministral 3 family (`ministral-3b-2512`, `ministral-8b-2512`, `ministral-14b-2512`) and current Mistral generalist models, with streaming and vision support. Adjustable `reasoning_effort` is only sent for supported models.

--- a/packages/chat/examples/react-basic/README.md
+++ b/packages/chat/examples/react-basic/README.md
@@ -165,10 +165,10 @@ built-in model status is `available`.
 - Best for: OpenAI-compatible GLM integration
 
 **xAI**
-- Models: Grok 4.5, Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, Grok 4-1 Fast Reasoning/Non-Reasoning
+- Models: Grok 4.6, Grok 4.5, Grok 4.3, Grok 4.20 Reasoning/Non-Reasoning, Grok 4-1 Fast Reasoning/Non-Reasoning
 - Vision: Supported
 - Best for: Grok models with OpenAI-compatible API
-- Grok 4.5 exposes `reasoning_effort` and defaults to `low` for chat-style responses; Grok 4.3 defaults to `none` for lower latency
+- Grok 4.6 exposes Low/Medium/High/XHigh `reasoning_effort`; Grok 4.6 and 4.5 default to `low` for chat-style responses, while Grok 4.3 defaults to `none` for lower latency
 
 **Kimi**
 - Models: Kimi K3, Kimi K2.7 Code, Kimi K2.7 Code HighSpeed, Kimi K2.6, Kimi K2.5

--- a/packages/chat/examples/react-basic/src/App.tsx
+++ b/packages/chat/examples/react-basic/src/App.tsx
@@ -33,6 +33,7 @@ import {
   type KimiReasoningEffort,
   type DeepSeekReasoningEffort,
   type OpenRouterReasoningEffort,
+  type XaiReasoningEffort,
   type ChatCompletionAssistantMessage,
 } from '@aituber-onair/chat';
 import './App.css';
@@ -76,8 +77,6 @@ type ReasoningEffortLevel =
   | 'high'
   | 'xhigh'
   | 'max';
-type XaiReasoningEffortLevel = 'none' | 'low' | 'medium' | 'high';
-
 const KIMI_OFFICIAL_BASE_URL = 'https://api.moonshot.ai/v1';
 const DEFAULT_OPENAI_COMPAT_ENDPOINT =
   'http://127.0.0.1:18080/v1/chat/completions';
@@ -208,12 +207,14 @@ function App() {
     selectedModel,
     requestedGeminiReasoningEffort,
   );
-  const xaiReasoningEffort: XaiReasoningEffortLevel =
+  const xaiReasoningEffort: XaiReasoningEffort =
     normalizeXaiReasoningEffort(
       selectedModel,
-      reasoning_effort === 'low' ||
+      reasoning_effort === 'none' ||
+        reasoning_effort === 'low' ||
         reasoning_effort === 'medium' ||
-        reasoning_effort === 'high'
+        reasoning_effort === 'high' ||
+        reasoning_effort === 'xhigh'
         ? reasoning_effort
         : 'none',
     ) ?? 'none';

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -13,21 +13,22 @@ import {
   getClaudeSupportedReasoningEfforts,
   getDefaultReasoningEffortForGPT5Model,
   getDefaultXaiReasoningEffort,
+  getXaiSupportedReasoningEfforts,
   getGeminiSupportedReasoningEfforts,
   getDeepSeekSupportedReasoningEfforts,
   getOpenRouterSupportedReasoningEfforts,
   isGPT5Model,
-  isXaiReasoningEffortModel,
-  isXaiReasoningEffortNoneModel,
   isResponsesOnlyGPT5Model,
   isOpenRouterFreeModel,
   refreshOpenRouterFreeModels,
   normalizeClaudeReasoningEffort,
   normalizeGeminiReasoningEffort,
+  normalizeXaiReasoningEffort,
   type ClaudeReasoningEffort,
   type GeminiReasoningEffort,
   type DeepSeekReasoningEffort,
   type OpenRouterReasoningEffort,
+  type XaiReasoningEffort,
   // OpenAI models
   MODEL_GPT_5_NANO,
   MODEL_GPT_5_MINI,
@@ -140,6 +141,7 @@ import {
   MODEL_GLM_4_6V_FLASHX,
   MODEL_GLM_4_6V_FLASH,
   // xAI models
+  MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
@@ -1130,6 +1132,12 @@ export const allModels: ProviderModel[] = [
 
   // xAI models
   {
+    id: MODEL_GROK_4_6,
+    name: 'Grok 4.6',
+    provider: 'xai',
+    default: false,
+  },
+  {
     id: MODEL_GROK_4_5,
     name: 'Grok 4.5',
     provider: 'xai',
@@ -1411,10 +1419,9 @@ export default function ProviderSelector({
   const allowsXHigh =
     provider === 'openai' && allowsReasoningXHigh(selectedModel);
   const allowsMax = provider === 'openai' && allowsReasoningMax(selectedModel);
-  const isXaiReasoningModel =
-    provider === 'xai' && isXaiReasoningEffortModel(selectedModel);
-  const isXaiReasoningNoneModelSelected =
-    provider === 'xai' && isXaiReasoningEffortNoneModel(selectedModel);
+  const xaiSupportedReasoningEfforts =
+    provider === 'xai' ? getXaiSupportedReasoningEfforts(selectedModel) : [];
+  const isXaiReasoningModel = xaiSupportedReasoningEfforts.length > 0;
   const isKimiReasoningModel =
     provider === 'kimi' && isKimiReasoningEffortModel(selectedModel);
   const claudeSupportedReasoningEfforts =
@@ -1460,12 +1467,18 @@ export default function ProviderSelector({
     provider === 'openrouter'
       ? getOpenRouterSupportedReasoningEfforts(selectedModel)
       : [];
-  const xaiReasoningEffort =
+  const requestedXaiReasoningEffort: XaiReasoningEffort | undefined =
+    reasoning_effort === 'none' ||
     reasoning_effort === 'low' ||
     reasoning_effort === 'medium' ||
-    reasoning_effort === 'high'
+    reasoning_effort === 'high' ||
+    reasoning_effort === 'xhigh'
       ? reasoning_effort
-      : (getDefaultXaiReasoningEffort(selectedModel) ?? 'none');
+      : undefined;
+  const xaiReasoningEffort =
+    normalizeXaiReasoningEffort(selectedModel, requestedXaiReasoningEffort) ??
+    getDefaultXaiReasoningEffort(selectedModel) ??
+    'none';
   const baseModelsForProvider = useMemo(
     () => allModels.filter((model) => model.provider === provider),
     [provider],
@@ -2058,23 +2071,26 @@ export default function ProviderSelector({
                 value={xaiReasoningEffort}
                 onChange={(e) =>
                   onReasoningEffortChange?.(
-                    e.target.value as 'none' | 'low' | 'medium' | 'high',
+                    e.target.value as XaiReasoningEffort,
                   )
                 }
                 disabled={disabled || !isXaiReasoningModel}
                 className="select-input"
               >
-                {isXaiReasoningNoneModelSelected && (
+                {xaiSupportedReasoningEfforts.includes('none') && (
                   <option value="none">None (fastest)</option>
                 )}
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
+                {xaiSupportedReasoningEfforts.includes('xhigh') && (
+                  <option value="xhigh">XHigh</option>
+                )}
               </select>
               {!isXaiReasoningModel && (
                 <span className="helper-text">
-                  Available only for Grok 4.5 and Grok 4.3; omitted for other
-                  xAI models.
+                  Available only for Grok 4.6, Grok 4.5, and Grok 4.3; omitted
+                  for other xAI models.
                 </span>
               )}
             </div>

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/chat",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Chat and LLM API integration library for AITuber OnAir",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/chat/src/constants/xai.ts
+++ b/packages/chat/src/constants/xai.ts
@@ -2,6 +2,7 @@ export const ENDPOINT_XAI_CHAT_COMPLETIONS_API =
   'https://api.x.ai/v1/chat/completions';
 
 // xAI Grok models
+export const MODEL_GROK_4_6 = 'grok-4.6';
 export const MODEL_GROK_4_5 = 'grok-4.5';
 export const MODEL_GROK_4_3 = 'grok-4.3';
 export const MODEL_GROK_4_20_REASONING = 'grok-4.20-0309-reasoning';
@@ -9,10 +10,11 @@ export const MODEL_GROK_4_20_NON_REASONING = 'grok-4.20-0309-non-reasoning';
 export const MODEL_GROK_4_1_FAST_REASONING = 'grok-4-1-fast-reasoning';
 export const MODEL_GROK_4_1_FAST_NON_REASONING = 'grok-4-1-fast-non-reasoning';
 
-export type XaiReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+export type XaiReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 
 // Vision support for models
 export const XAI_VISION_SUPPORTED_MODELS = [
+  MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
@@ -32,14 +34,35 @@ export function isXaiVisionModel(model: string): boolean {
  * Check if a model supports the xAI reasoning_effort parameter
  */
 export function isXaiReasoningEffortModel(model: string): boolean {
-  return model === MODEL_GROK_4_5 || model === MODEL_GROK_4_3;
+  return getXaiSupportedReasoningEfforts(model).length > 0;
+}
+
+/**
+ * Get documented reasoning_effort values for an xAI model
+ */
+export function getXaiSupportedReasoningEfforts(
+  model: string,
+): readonly XaiReasoningEffort[] {
+  if (model === MODEL_GROK_4_6) {
+    return ['low', 'medium', 'high', 'xhigh'];
+  }
+
+  if (model === MODEL_GROK_4_5) {
+    return ['low', 'medium', 'high'];
+  }
+
+  if (model === MODEL_GROK_4_3) {
+    return ['none', 'low', 'medium', 'high'];
+  }
+
+  return [];
 }
 
 /**
  * Check if a model supports disabling reasoning with reasoning_effort none
  */
 export function isXaiReasoningEffortNoneModel(model: string): boolean {
-  return model === MODEL_GROK_4_3;
+  return getXaiSupportedReasoningEfforts(model).includes('none');
 }
 
 /**
@@ -48,7 +71,7 @@ export function isXaiReasoningEffortNoneModel(model: string): boolean {
 export function getDefaultXaiReasoningEffort(
   model: string,
 ): XaiReasoningEffort | undefined {
-  if (model === MODEL_GROK_4_5) {
+  if (model === MODEL_GROK_4_6 || model === MODEL_GROK_4_5) {
     return 'low';
   }
 
@@ -66,9 +89,14 @@ export function normalizeXaiReasoningEffort(
     return undefined;
   }
 
-  if (reasoningEffort === 'none' && !isXaiReasoningEffortNoneModel(model)) {
-    return 'low';
+  if (reasoningEffort === undefined) {
+    return getDefaultXaiReasoningEffort(model);
   }
 
-  return reasoningEffort ?? getDefaultXaiReasoningEffort(model);
+  const supported = getXaiSupportedReasoningEfforts(model);
+  if (supported.includes(reasoningEffort)) {
+    return reasoningEffort;
+  }
+
+  return reasoningEffort === 'none' ? 'low' : 'high';
 }

--- a/packages/chat/src/services/ChatServiceFactory.ts
+++ b/packages/chat/src/services/ChatServiceFactory.ts
@@ -12,6 +12,7 @@ import { getClaudeSupportedReasoningEfforts } from '../constants/claude';
 import { getKimiSupportedReasoningEfforts } from '../constants/kimi';
 import { getDeepSeekSupportedReasoningEfforts } from '../constants/deepseek';
 import { getOpenRouterSupportedReasoningEfforts } from '../constants/openrouter';
+import { getXaiSupportedReasoningEfforts } from '../constants/xai';
 import { getChatBackendProviderCapabilities } from '../backend';
 
 const MCP_SUPPORTED_PROVIDERS = new Set<string>(['openai', 'gemini', 'claude']);
@@ -31,7 +32,7 @@ const REASONING_EFFORT_BY_PROVIDER: Record<string, string[]> = {
   kimi: ['low', 'high', 'max'],
   mistral: ['low', 'medium', 'high'],
   plamo: ['none', 'medium'],
-  xai: ['none', 'low', 'medium', 'high'],
+  xai: ['none', 'low', 'medium', 'high', 'xhigh'],
   deepseek: ['none', 'low', 'high', 'max'],
 };
 
@@ -139,7 +140,9 @@ export class ChatServiceFactory {
               ? [...getDeepSeekSupportedReasoningEfforts(model)]
               : providerName === 'openrouter' && model
                 ? [...getOpenRouterSupportedReasoningEfforts(model)]
-                : (REASONING_EFFORT_BY_PROVIDER[providerName] ?? []),
+                : providerName === 'xai' && model
+                  ? [...getXaiSupportedReasoningEfforts(model)]
+                  : (REASONING_EFFORT_BY_PROVIDER[providerName] ?? []),
     };
   }
 

--- a/packages/chat/src/services/providers/xai/XAIChatServiceProvider.ts
+++ b/packages/chat/src/services/providers/xai/XAIChatServiceProvider.ts
@@ -1,5 +1,6 @@
 import {
   ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+  MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
@@ -69,6 +70,7 @@ export class XAIChatServiceProvider
    */
   getSupportedModels(): string[] {
     return [
+      MODEL_GROK_4_6,
       MODEL_GROK_4_5,
       MODEL_GROK_4_3,
       MODEL_GROK_4_20_REASONING,

--- a/packages/chat/tests/ChatServiceFactory.test.ts
+++ b/packages/chat/tests/ChatServiceFactory.test.ts
@@ -15,6 +15,9 @@ import {
   MODEL_DEEPSEEK_V4_PRO,
   MODEL_OPENROUTER_DEEPSEEK_V4_FLASH,
   MODEL_OPENROUTER_DEEPSEEK_V4_FLASH_0731,
+  MODEL_GROK_4_6,
+  MODEL_GROK_4_5,
+  MODEL_GROK_4_3,
 } from '../src/constants';
 
 // Mock provider for testing
@@ -380,7 +383,21 @@ describe('ChatServiceFactory', () => {
         'low',
         'medium',
         'high',
+        'xhigh',
       ]);
+
+      expect(
+        ChatServiceFactory.getProviderCapabilities('xai', MODEL_GROK_4_6)
+          ?.reasoningEffort,
+      ).toEqual(['low', 'medium', 'high', 'xhigh']);
+      expect(
+        ChatServiceFactory.getProviderCapabilities('xai', MODEL_GROK_4_5)
+          ?.reasoningEffort,
+      ).toEqual(['low', 'medium', 'high']);
+      expect(
+        ChatServiceFactory.getProviderCapabilities('xai', MODEL_GROK_4_3)
+          ?.reasoningEffort,
+      ).toEqual(['none', 'low', 'medium', 'high']);
     });
 
     it('returns Gemini reasoning effort capabilities', () => {

--- a/packages/chat/tests/providers/XAIChatService.test.ts
+++ b/packages/chat/tests/providers/XAIChatService.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+  MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
   MODEL_GROK_4_1_FAST_NON_REASONING,
   getDefaultXaiReasoningEffort,
+  getXaiSupportedReasoningEfforts,
   isXaiReasoningEffortModel,
+  normalizeXaiReasoningEffort,
 } from '../../src/constants';
 import { XAIChatService } from '../../src/services/providers/xai/XAIChatService';
 import { ChatServiceHttpClient } from '../../src/utils/chatServiceHttpClient';
@@ -37,6 +40,24 @@ const createOkResponse = () =>
     text: async () =>
       JSON.stringify({ choices: [{ message: { content: 'ok' } }] }),
   }) as Response;
+
+const createStreamResponse = (chunks: string[]): Response => {
+  let index = 0;
+  const body = {
+    getReader: () => ({
+      read: async () => {
+        if (index >= chunks.length) {
+          return { done: true, value: undefined };
+        }
+        const value = new Uint8Array(Buffer.from(chunks[index], 'utf-8'));
+        index += 1;
+        return { done: false, value };
+      },
+    }),
+  };
+
+  return { body } as Response;
+};
 
 describe('XAIChatService', () => {
   beforeEach(() => {
@@ -158,18 +179,31 @@ describe('XAIChatService', () => {
     expect(body.reasoning_effort).toBeUndefined();
   });
 
-  it('reports reasoning_effort support for Grok 4.5 and Grok 4.3', () => {
+  it('reports reasoning_effort support for Grok 4.6, 4.5, and 4.3', () => {
+    expect(isXaiReasoningEffortModel(MODEL_GROK_4_6)).toBe(true);
     expect(isXaiReasoningEffortModel(MODEL_GROK_4_5)).toBe(true);
     expect(isXaiReasoningEffortModel(MODEL_GROK_4_3)).toBe(true);
     expect(isXaiReasoningEffortModel(MODEL_GROK_4_20_REASONING)).toBe(false);
   });
 
   it('defaults xAI reasoning_effort to none only for supported models', () => {
+    expect(getDefaultXaiReasoningEffort(MODEL_GROK_4_6)).toBe('low');
     expect(getDefaultXaiReasoningEffort(MODEL_GROK_4_5)).toBe('low');
     expect(getDefaultXaiReasoningEffort(MODEL_GROK_4_3)).toBe('none');
     expect(
       getDefaultXaiReasoningEffort(MODEL_GROK_4_1_FAST_NON_REASONING),
     ).toBeUndefined();
+  });
+
+  it('reports and normalizes model-specific xAI reasoning efforts', () => {
+    expect(getXaiSupportedReasoningEfforts(MODEL_GROK_4_6)).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+    expect(normalizeXaiReasoningEffort(MODEL_GROK_4_5, 'xhigh')).toBe('high');
+    expect(normalizeXaiReasoningEffort(MODEL_GROK_4_6, 'none')).toBe('low');
   });
 
   it('sends requests to the xAI chat completions endpoint', async () => {
@@ -221,6 +255,88 @@ describe('XAIChatService', () => {
       }),
       { Authorization: 'Bearer test-key' },
     );
+  });
+
+  it('sends Grok 4.6 requests through xAI chat completions and parses the response', async () => {
+    const postSpy = vi
+      .spyOn(ChatServiceHttpClient, 'post')
+      .mockResolvedValue(createOkResponse());
+    const service = new XAIChatService(
+      'test-key',
+      MODEL_GROK_4_6,
+      MODEL_GROK_4_6,
+      undefined,
+      ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+      undefined,
+      'xhigh',
+    );
+
+    const result = await service.chatOnce(messages, false);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+      expect.objectContaining({
+        model: MODEL_GROK_4_6,
+        stream: false,
+        messages,
+        reasoning_effort: 'xhigh',
+      }),
+      { Authorization: 'Bearer test-key' },
+    );
+    expect(result.blocks).toEqual([{ type: 'text', text: 'ok' }]);
+  });
+
+  it('sends Grok 4.6 vision requests through xAI chat completions', async () => {
+    const postSpy = vi
+      .spyOn(ChatServiceHttpClient, 'post')
+      .mockResolvedValue(createOkResponse());
+    const service = new XAIChatService(
+      'test-key',
+      MODEL_GROK_4_6,
+      MODEL_GROK_4_6,
+      undefined,
+      ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+      undefined,
+      'low',
+    );
+
+    await service.visionChatOnce(visionMessages, false);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+      expect.objectContaining({
+        model: MODEL_GROK_4_6,
+        messages: visionMessages,
+        reasoning_effort: 'low',
+      }),
+      { Authorization: 'Bearer test-key' },
+    );
+  });
+
+  it('parses Grok 4.6 chat completion streams', async () => {
+    vi.spyOn(ChatServiceHttpClient, 'post').mockResolvedValue(
+      createStreamResponse([
+        'data: {"choices":[{"delta":{"content":"Grok "}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"4.6"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    );
+    const service = new XAIChatService(
+      'test-key',
+      MODEL_GROK_4_6,
+      MODEL_GROK_4_6,
+      undefined,
+      ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+      undefined,
+      'low',
+    );
+    const onPartial = vi.fn();
+
+    const result = await service.chatOnce(messages, true, onPartial);
+
+    expect(onPartial).toHaveBeenNthCalledWith(1, 'Grok ');
+    expect(onPartial).toHaveBeenNthCalledWith(2, '4.6');
+    expect(result.blocks).toEqual([{ type: 'text', text: 'Grok 4.6' }]);
   });
 
   it('sends Grok 4.5 vision requests through the xAI chat completions endpoint', async () => {

--- a/packages/chat/tests/providers/XAIChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/XAIChatServiceProvider.test.ts
@@ -3,6 +3,7 @@ import { XAIChatServiceProvider } from '../../src/services/providers/xai/XAIChat
 import type { XAIChatServiceOptions } from '../../src/services/providers/ChatServiceProvider';
 import {
   ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+  MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
   MODEL_GROK_4_20_REASONING,
@@ -32,6 +33,7 @@ describe('XAIChatServiceProvider', () => {
     it('should return array of supported models', () => {
       const models = provider.getSupportedModels();
       expect(models).toEqual([
+        MODEL_GROK_4_6,
         MODEL_GROK_4_5,
         MODEL_GROK_4_3,
         MODEL_GROK_4_20_REASONING,
@@ -59,6 +61,7 @@ describe('XAIChatServiceProvider', () => {
 
   describe('supportsVisionForModel', () => {
     it('should return true for supported vision models', () => {
+      expect(provider.supportsVisionForModel(MODEL_GROK_4_6)).toBe(true);
       expect(provider.supportsVisionForModel(MODEL_GROK_4_3)).toBe(true);
       expect(provider.supportsVisionForModel(MODEL_GROK_4_20_REASONING)).toBe(
         true,
@@ -137,6 +140,45 @@ describe('XAIChatServiceProvider', () => {
         ENDPOINT_XAI_CHAT_COMPLETIONS_API,
         undefined,
         'low',
+      );
+    });
+
+    it('should default Grok 4.6 reasoning effort to low for chat use', () => {
+      const options: XAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GROK_4_6,
+      };
+
+      provider.createChatService(options);
+
+      expect(XAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GROK_4_6,
+        MODEL_GROK_4_6,
+        undefined,
+        ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+        undefined,
+        'low',
+      );
+    });
+
+    it('should forward Grok 4.6 xhigh reasoning effort', () => {
+      const options: XAIChatServiceOptions = {
+        apiKey: 'test-api-key',
+        model: MODEL_GROK_4_6,
+        reasoning_effort: 'xhigh',
+      };
+
+      provider.createChatService(options);
+
+      expect(XAIChatService).toHaveBeenCalledWith(
+        'test-api-key',
+        MODEL_GROK_4_6,
+        MODEL_GROK_4_6,
+        undefined,
+        ENDPOINT_XAI_CHAT_COMPLETIONS_API,
+        undefined,
+        'xhigh',
       );
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   "author": "shinshin86 (https://github.com/shinshin86)",
   "license": "MIT",
   "dependencies": {
-    "@aituber-onair/chat": "^0.50.0",
+    "@aituber-onair/chat": "^0.51.0",
     "@aituber-onair/voice": "^0.19.0"
   },
   "peerDependencies": {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -74,7 +74,7 @@
     "directory": "packages/noise"
   },
   "dependencies": {
-    "@aituber-onair/chat": "^0.50.0"
+    "@aituber-onair/chat": "^0.51.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary

- add xAI Grok 4.6 (`grok-4.6`) as an explicit Chat Completions model
- add model-aware reasoning effort support for `low`, `medium`, `high`, and `xhigh`
- enable Grok 4.6 vision support and keep the existing xAI default model unchanged
- update the React basic example and English/Japanese documentation
- prepare `@aituber-onair/chat` v0.51.0 while only aligning dependent package ranges

## User impact

Users can select Grok 4.6 from the chat package and React basic example, use image inputs, and configure the reasoning effort up to `xhigh`. Grok 4.6 defaults to `low` for responsive character chat.

## Validation

- `npm ci`
- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`
- React basic example production build
- `npm pack --dry-run` for `@aituber-onair/chat@0.51.0`
- manual browser verification of the Grok 4.6 model and reasoning selectors
- public release check: Block 0 / Warn 0 / Info 0

## Notes

- The live xAI API smoke test was not run because no API key was used.
- Core behavior and Core examples are intentionally unchanged.