### PR TITLE
Fix Release workspace build order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,7 @@ jobs:
         run: npm ci
 
       - name: Build packages in dependency order
-        run: |
-          npm -w @aituber-onair/chat run build
-          npm -w @aituber-onair/voice run build
-          npm -w @aituber-onair/core run build
+        run: npm run build
 
       - name: Run Tests
         run: npm run test --workspaces


### PR DESCRIPTION
## Summary

- replace the Release workflow's manually maintained package build list with the repository's dependency-aware workspace build
- ensure `@aituber-onair/comment-intelligence` is built before Agent workspace tests
- prevent future workspace additions from being omitted from Release builds

## Root cause

The regular CI workflow built `@aituber-onair/comment-intelligence` before running workspace tests, but the Release workflow only built Chat, Voice, and Core. On a clean runner, the Agent stream operations example could not resolve `@aituber-onair/comment-intelligence` because its `dist/index.js` entry point had not been generated.

## Impact

After this change, the Release workflow uses `npm run build`, which invokes the existing dependency-order workspace builder. Merging this fix should allow the pending `@aituber-onair/chat@0.51.0` release flow to proceed past the test step.

## Validation

- reproduced the original failure after removing the local `comment-intelligence/dist` output
- confirmed `npm run build` regenerated `comment-intelligence/dist/index.js`
- confirmed the previously failing controller test passed: 6 tests
- `npm run fmt`
- `npm run build`
- `npm run test`
- `npm run lint`
- public release check: Block 0 / Warn 0 / Info 0

## Notes

- `actionlint` was not available locally; GitHub Actions will provide the final workflow validation.