### PR TITLE
feat(agent): relax the Codex app-server version pin

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,9 +10,9 @@
   isolated per Session.
 - Adds separate package entry points for the base runtime, Chat integration, and
   Codex app-server integration.
-- Adds a Node.js Codex app-server backend pinned to Codex CLI 0.145.0 with
-  streamed Turns, resume support, approvals, safe artifacts, and compatibility
-  checks.
+- Adds a Node.js Codex app-server backend for Codex CLI 0.136.0 or later,
+  verified against 0.145.0, with streamed Turns, resume support, approvals,
+  safe artifacts, and compatibility checks without an exact version pin.
 - Adds a live-stream operations staff example backed by a real Codex app-server,
   server-side comment preprocessing, validated generated artifacts, and an
   HTTP/SSE dashboard client.

--- a/packages/agent/README.ja.md
+++ b/packages/agent/README.ja.md
@@ -354,31 +354,25 @@ JSONL stdioで起動し、そのCLIの認証状態を利用します。`codex lo
 おけば、AgentへOpenAI API keyを渡さずに、Codexが対応するChatGPTプランの利用枠を
 使用できます。
 
-現在の統合はCodex CLI `0.145.0`に固定されています。アプリを起動する前に、
-同じバージョンをインストールしてログインしてください。異なるCLIバージョンは、
-app-serverを起動する前に拒否されます。
+下限以上のCodex環境であれば利用でき、特定のCLIバージョンをインストールする
+必要はありません。必要なapp-serverスキーマ要素はCodex CLI `0.136.0`で確認済み
+で、この統合の検証済みバージョンは `0.145.0` です。この下限はスキーマ上の確認で
+あり、実接続での検証ではありません。下限未満の場合、または必要なメソッドが
+インストール済みCLIに存在しない場合のみエラーになります。
 
 ```bash
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
 ```ts
 import { createAgent } from '@aituber-onair/agent';
-import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
-  createCodexAppServerBackend,
-} from '@aituber-onair/agent/codex-app-server';
+import { createCodexAppServerBackend } from '@aituber-onair/agent/codex-app-server';
 
 const backend = createCodexAppServerBackend({
   // PATH検索は暗黙に行いません。代わりに絶対パスのcodexPathも指定できます。
   allowPathLookup: true,
   workingDirectory: '/absolute/path/to/character-workspace',
-  compatibility: {
-    expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-    schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
-  },
   sandbox: 'read-only',
   approvalPolicy: 'on-request',
 });
@@ -412,6 +406,10 @@ try {
 }
 ```
 
+検証済みバージョンとの完全一致を必要とするホストは、
+`compatibility: { onMismatch: 'reject' }` を指定できます。global環境を変更せずに
+特定バージョンを使う場合は、PATH検索を有効にせず、`codexPath`へ絶対パスを渡します。
+
 `read-only`と`on-request`は省略時の既定値でもあります。ホストの`allow-once`は
 Codexの`accept`へ、`deny`は`decline`へ対応します。中断、timeout、終了時は
 `cancel`を返します。1回のホスト判断より権限を広げるため、
@@ -424,7 +422,7 @@ Agent briefは、新規Threadと再開ThreadのCodex developer instructionsと�
 再開する場合は、`session.backendSessionId`をホスト側で保存し、
 `agent.resumeSession(...)`へ渡してください。
 
-このentry pointが対応するのは、固定バージョンのstable protocol subsetだけです。
+このentry pointが対応するのは、検証済みのstable protocol subsetだけです。
 
 - Node.jsのローカルstdio transport。remote WebSocket transportには非対応
 - Threadのstart/resumeとTurnのstart/interrupt。Turn steerはCodexバックエンドの

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -365,31 +365,26 @@ installed Codex CLI over JSONL stdio and uses that CLI's existing
 authentication. After signing in with `codex login`, this can use the ChatGPT
 plan access supported by Codex without passing an OpenAI API key to Agent.
 
-The current integration is pinned to Codex CLI `0.145.0`. Install that exact
-version and sign in before starting the application. The backend rejects a different CLI
-version before starting app-server.
+Any Codex environment at or above the minimum version can be used; installing
+one exact CLI version is not required. The required app-server schema elements
+were confirmed in Codex CLI `0.136.0`, while this integration was verified
+against `0.145.0`. The minimum records a schema check, not a live connection
+test. The backend errors only below the minimum or when a method it needs is
+unavailable in the installed CLI.
 
 ```bash
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
 ```ts
 import { createAgent } from '@aituber-onair/agent';
-import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
-  createCodexAppServerBackend,
-} from '@aituber-onair/agent/codex-app-server';
+import { createCodexAppServerBackend } from '@aituber-onair/agent/codex-app-server';
 
 const backend = createCodexAppServerBackend({
   // PATH lookup is never implicit. Alternatively, provide an absolute codexPath.
   allowPathLookup: true,
   workingDirectory: '/absolute/path/to/character-workspace',
-  compatibility: {
-    expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-    schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
-  },
   sandbox: 'read-only',
   approvalPolicy: 'on-request',
 });
@@ -423,6 +418,11 @@ try {
 }
 ```
 
+Hosts that require the verified version can set
+`compatibility: { onMismatch: 'reject' }`. To use a specific CLI version
+without changing the global installation, pass its absolute path as
+`codexPath` instead of enabling PATH lookup.
+
 `read-only` and `on-request` are also the defaults. A host decision of
 `allow-once` maps to Codex `accept`; `deny` maps to `decline`; interruption,
 timeout, and shutdown map to `cancel`. The backend never grants Codex
@@ -436,7 +436,8 @@ in [openai/codex#19045](https://github.com/openai/codex/issues/19045). Persist
 `session.backendSessionId` in host-owned state and pass it to
 `agent.resumeSession(...)` when resuming.
 
-The entry point intentionally supports only the pinned stable protocol subset:
+The entry point intentionally supports only the verified stable protocol
+subset:
 
 - local stdio transport on Node.js; no remote WebSocket transport
 - Thread start/resume and Turn start/interrupt; Turn steering exists on the

--- a/packages/agent/examples/codex-workspace-server/README.ja.md
+++ b/packages/agent/examples/codex-workspace-server/README.ja.md
@@ -13,18 +13,19 @@ Server-Sent Eventsで `AgentEvent` を受信し、`message.delta` を逐次表�
 ## 前提条件
 
 - Node.js 18以上
-- ローカルにインストールしたCodex CLI `0.145.0`
+- ローカルにインストールしたCodex CLI `0.136.0`以上
 - `codex login` の完了
 
-固定バージョンのCLIをインストールしてログインします。
+Codex CLIをインストールしてログインします。完全一致のバージョン固定は不要です。
 
 ```sh
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
-app-serverのプロトコルはバージョン依存のため、backendは異なるCLI
-バージョンを拒否します。
+必要なapp-serverスキーマ要素はCodex CLI `0.136.0`で確認済みで、この統合の
+検証済みバージョンは `0.145.0` です。下限以上の別バージョンでは警告を出して
+続行します。
 
 ## 起動
 
@@ -51,7 +52,7 @@ CODEX_PATH=/absolute/path/to/codex npm start
 | 変数 | 既定値 | 説明 |
 | --- | --- | --- |
 | `PORT` | `4517` | ローカルHTTPポート。必ず `127.0.0.1` にbindします。 |
-| `CODEX_PATH` | `PATH` 上の `codex` | 固定バージョンのCodex実行ファイルへの絶対パスです。 |
+| `CODEX_PATH` | `PATH` 上の `codex` | 特定のCodex実行ファイルへの絶対パスです。 |
 | `CODEX_SANDBOX` | `read-only` | `workspace-write` と完全一致する場合だけworkspaceへの変更を許可します。それ以外はread-onlyです。 |
 | `AGENT_WORKSPACE_DIR` | `./workspace` | 隔離workspaceです。相対パスはプロセスの作業ディレクトリから解決します。 |
 

--- a/packages/agent/examples/codex-workspace-server/README.md
+++ b/packages/agent/examples/codex-workspace-server/README.md
@@ -14,18 +14,19 @@ receives `AgentEvent` objects over Server-Sent Events, renders
 ## Requirements
 
 - Node.js 18 or later
-- Codex CLI `0.145.0`, installed locally
+- Codex CLI `0.136.0` or later, installed locally
 - A completed `codex login`
 
-Install the pinned CLI and sign in:
+Install Codex CLI and sign in. No exact version pin is required:
 
 ```sh
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
-The backend deliberately rejects other Codex CLI versions because the
-app-server protocol is version-sensitive.
+The required app-server schema elements were confirmed in Codex CLI `0.136.0`;
+the integration was verified against `0.145.0`. The backend warns but continues
+with other versions at or above the minimum.
 
 ## Start
 
@@ -52,7 +53,7 @@ CODEX_PATH=/absolute/path/to/codex npm start
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PORT` | `4517` | Local HTTP port. The server always binds to `127.0.0.1`. |
-| `CODEX_PATH` | `codex` on `PATH` | Absolute path to the pinned Codex executable. |
+| `CODEX_PATH` | `codex` on `PATH` | Absolute path to a specific Codex executable. |
 | `CODEX_SANDBOX` | `read-only` | Set exactly to `workspace-write` to let Codex modify the workspace. Other values remain read-only. |
 | `AGENT_WORKSPACE_DIR` | `./workspace` | Isolated workspace directory. Relative paths resolve from the process working directory. |
 

--- a/packages/agent/examples/codex-workspace-server/src/server.ts
+++ b/packages/agent/examples/codex-workspace-server/src/server.ts
@@ -1,11 +1,7 @@
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createAgent } from '@aituber-onair/agent';
-import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
-  createCodexAppServerBackend,
-} from '@aituber-onair/agent/codex-app-server';
+import { createCodexAppServerBackend } from '@aituber-onair/agent/codex-app-server';
 import type {
   Agent,
   AgentSession,
@@ -44,10 +40,6 @@ async function main(): Promise<void> {
   const backend = createCodexAppServerBackend({
     ...(codexPath ? { codexPath } : { allowPathLookup: true as const }),
     workingDirectory: workspaceDir,
-    compatibility: {
-      expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-      schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
-    },
     sandbox,
     approvalPolicy: 'on-request',
     onDiagnostic: (message) => console.error(`[codex] ${message}`),

--- a/packages/agent/examples/stream-operations-staff/README.ja.md
+++ b/packages/agent/examples/stream-operations-staff/README.ja.md
@@ -14,18 +14,19 @@ Codexへ渡すのは構造化した観測だけです。中央のブリーフィ
 ## 前提条件
 
 - Node.js 18以上
-- ローカルにインストールしたCodex CLI `0.145.0`
+- ローカルにインストールしたCodex CLI `0.136.0`以上
 - `codex login` の完了
 
-固定バージョンのCLIをインストールしてログインします。
+Codex CLIをインストールしてログインします。完全一致のバージョン固定は不要です。
 
 ```sh
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
-app-serverプロトコルはバージョン依存のため、backendは異なるCLIバージョンを
-拒否します。
+必要なapp-serverスキーマ要素はCodex CLI `0.136.0`で確認済みで、この統合の
+検証済みバージョンは `0.145.0` です。下限以上の別バージョンでは警告を出して
+続行します。
 
 ## 起動
 
@@ -114,7 +115,7 @@ HTTP server processが動いている間だけ保持します。Mikoのbriefで�
 | 変数 | 既定値 | 説明 |
 | --- | --- | --- |
 | `PORT` | `4518` | local HTTP port。必ず `127.0.0.1` にbindします。 |
-| `CODEX_PATH` | `PATH` 上の `codex` | 固定バージョンのCodex実行ファイルへの絶対パスです。 |
+| `CODEX_PATH` | `PATH` 上の `codex` | 特定のCodex実行ファイルへの絶対パスです。 |
 | `CODEX_SANDBOX` | `read-only` | `workspace-write` と完全一致する場合だけ、隔離workspace内の変更を許可します。 |
 | `AGENT_WORKSPACE_DIR` | `./workspace` | 隔離Codex working directoryとSession記録の保存場所です。 |
 

--- a/packages/agent/examples/stream-operations-staff/README.md
+++ b/packages/agent/examples/stream-operations-staff/README.md
@@ -15,18 +15,19 @@ external streaming service.
 ## Requirements
 
 - Node.js 18 or later
-- Codex CLI `0.145.0`, installed locally
+- Codex CLI `0.136.0` or later, installed locally
 - A completed `codex login`
 
-Install the pinned CLI and sign in:
+Install Codex CLI and sign in. No exact version pin is required:
 
 ```sh
-npm install --global @openai/codex@0.145.0
+npm install --global @openai/codex
 codex login
 ```
 
-The backend rejects other Codex CLI versions because the app-server protocol
-is version-sensitive.
+The required app-server schema elements were confirmed in Codex CLI `0.136.0`;
+the integration was verified against `0.145.0`. The backend warns but continues
+with other versions at or above the minimum.
 
 ## Start
 
@@ -121,7 +122,7 @@ current HTTP server process. The Miko brief tells Codex not to read or modify
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PORT` | `4518` | Local HTTP port. The server always binds to `127.0.0.1`. |
-| `CODEX_PATH` | `codex` on `PATH` | Absolute path to the pinned Codex executable. |
+| `CODEX_PATH` | `codex` on `PATH` | Absolute path to a specific Codex executable. |
 | `CODEX_SANDBOX` | `read-only` | Set exactly to `workspace-write` to allow changes inside the isolated workspace. |
 | `AGENT_WORKSPACE_DIR` | `./workspace` | Isolated Codex working directory and Session record location. |
 

--- a/packages/agent/examples/stream-operations-staff/server/server.ts
+++ b/packages/agent/examples/stream-operations-staff/server/server.ts
@@ -1,10 +1,6 @@
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
-  createCodexAppServerBackend,
-} from '@aituber-onair/agent/codex-app-server';
+import { createCodexAppServerBackend } from '@aituber-onair/agent/codex-app-server';
 import { createStreamOperationsServer } from './app.js';
 import { createStreamOperationsController } from './controller.js';
 import { readStoredSession, writeStoredSession } from './sessionStore.js';
@@ -33,10 +29,6 @@ async function main(): Promise<void> {
   const backend = createCodexAppServerBackend({
     ...(codexPath ? { codexPath } : { allowPathLookup: true as const }),
     workingDirectory: workspaceDir,
-    compatibility: {
-      expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-      schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
-    },
     sandbox,
     approvalPolicy: 'on-request',
     onDiagnostic: (message) => console.error(`[codex] ${message}`),

--- a/packages/agent/src/backends/codex/CodexAppServerBackend.ts
+++ b/packages/agent/src/backends/codex/CodexAppServerBackend.ts
@@ -133,7 +133,9 @@ class CodexAppServerBackendRuntime implements CodexAppServerBackend {
     }
     this.options = Object.freeze({
       ...options,
-      compatibility: Object.freeze({ ...options.compatibility }),
+      ...(options.compatibility
+        ? { compatibility: Object.freeze({ ...options.compatibility }) }
+        : {}),
       ...(options.environment
         ? { environment: Object.freeze({ ...options.environment }) }
         : {}),
@@ -585,14 +587,43 @@ function validateOptions(options: CodexAppServerBackendOptions): string[] {
   } else if (options.allowPathLookup !== true) {
     issues.push('allowPathLookup must be true when codexPath is omitted');
   }
-  if (
-    !isRecord(options.compatibility) ||
-    typeof options.compatibility.expectedVersion !== 'string' ||
-    typeof options.compatibility.schemaVersion !== 'string'
-  ) {
-    issues.push(
-      'compatibility must contain expectedVersion and schemaVersion strings'
-    );
+  if (options.compatibility !== undefined) {
+    if (!isRecord(options.compatibility)) {
+      issues.push('compatibility must be an object');
+    } else {
+      const compatibilityKeys = new Set([
+        'accept',
+        'minimumVersion',
+        'onMismatch',
+      ]);
+      for (const key of Object.keys(options.compatibility)) {
+        if (!compatibilityKeys.has(key)) {
+          issues.push(`compatibility contains unsupported field "${key}"`);
+        }
+      }
+      if (
+        options.compatibility.minimumVersion !== undefined &&
+        typeof options.compatibility.minimumVersion !== 'string'
+      ) {
+        issues.push('compatibility.minimumVersion must be a string');
+      }
+      if (
+        options.compatibility.onMismatch !== undefined &&
+        !['reject', 'warn', 'allow'].includes(
+          options.compatibility.onMismatch as string
+        )
+      ) {
+        issues.push(
+          'compatibility.onMismatch must be "reject", "warn", or "allow"'
+        );
+      }
+      if (
+        options.compatibility.accept !== undefined &&
+        typeof options.compatibility.accept !== 'function'
+      ) {
+        issues.push('compatibility.accept must be a function');
+      }
+    }
   }
   for (const [name, value] of [
     ['requestTimeoutMs', options.requestTimeoutMs],

--- a/packages/agent/src/backends/codex/client.ts
+++ b/packages/agent/src/backends/codex/client.ts
@@ -9,8 +9,8 @@ import type {
 } from './process.js';
 import { nodeCodexAppServerProcessFactory } from './process.js';
 import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
+  CODEX_APP_SERVER_MINIMUM_VERSION,
+  CODEX_APP_SERVER_VERIFIED_VERSION,
 } from './protocol.js';
 import type {
   CodexAppServerAccountReadResult,
@@ -31,15 +31,16 @@ export type CodexAppServerSandboxMode = 'read-only' | 'workspace-write';
 export type CodexAppServerApprovalPolicy = 'untrusted' | 'on-request' | 'never';
 
 export interface CodexAppServerClientCompatibility {
-  readonly expectedVersion: string;
-  readonly schemaVersion: string;
+  readonly minimumVersion?: string;
+  readonly onMismatch?: 'reject' | 'warn' | 'allow';
+  readonly accept?: (actual: string, verified: string) => boolean;
 }
 
 export interface CodexAppServerClientOptions {
   readonly executable: string;
   readonly workingDirectory: string;
   readonly environment: NodeJS.ProcessEnv;
-  readonly compatibility: CodexAppServerClientCompatibility;
+  readonly compatibility?: CodexAppServerClientCompatibility;
   readonly requestTimeoutMs?: number;
   readonly shutdownTimeoutMs?: number;
   readonly maxLineBytes?: number;
@@ -69,6 +70,7 @@ export interface CodexAppServerClientDependencies {
 export class CodexAppServerClient {
   private readonly transport: CodexAppServerTransport;
   private readonly experimentalApi: boolean;
+  private readonly actualVersion: string;
   private readonly notificationListeners = new Set<
     (notification: CodexAppServerNotification) => void
   >();
@@ -80,17 +82,18 @@ export class CodexAppServerClient {
 
   private constructor(
     transport: CodexAppServerTransport,
-    experimentalApi: boolean
+    experimentalApi: boolean,
+    actualVersion: string
   ) {
     this.transport = transport;
     this.experimentalApi = experimentalApi;
+    this.actualVersion = actualVersion;
   }
 
   static async connect(
     options: CodexAppServerClientOptions,
     dependencies: CodexAppServerClientDependencies = {}
   ): Promise<CodexAppServerClient> {
-    assertCompatibility(options.compatibility);
     const processFactory =
       dependencies.processFactory ?? nodeCodexAppServerProcessFactory;
     let versionOutput: string;
@@ -106,17 +109,11 @@ export class CodexAppServerClient {
       );
     }
     const actualVersion = parseCodexVersion(versionOutput);
-    if (actualVersion !== options.compatibility.expectedVersion) {
-      throw new AgentBackendCompatibilityError(
-        `Codex CLI ${actualVersion} is not compatible with the pinned app-server version ${options.compatibility.expectedVersion}.`,
-        {
-          details: {
-            actualVersion,
-            expectedVersion: options.compatibility.expectedVersion,
-          },
-        }
-      );
-    }
+    checkCompatibility(
+      actualVersion,
+      options.compatibility,
+      options.onDiagnostic
+    );
 
     let client: CodexAppServerClient | undefined;
     let process: CodexAppServerProcess;
@@ -152,7 +149,8 @@ export class CodexAppServerClient {
     });
     client = new CodexAppServerClient(
       transport,
-      options.enableExperimentalApi ?? false
+      options.enableExperimentalApi ?? false,
+      actualVersion
     );
     try {
       await client.initialize();
@@ -185,7 +183,7 @@ export class CodexAppServerClient {
     refreshToken = false
   ): Promise<CodexAppServerAccountReadResult> {
     this.assertInitialized();
-    const result = await this.transport.request<unknown>('account/read', {
+    const result = await this.request<unknown>('account/read', {
       refreshToken,
     });
     assertAccountReadResult(result);
@@ -200,7 +198,7 @@ export class CodexAppServerClient {
     } = {}
   ): Promise<CodexAppServerModelListResult> {
     this.assertInitialized();
-    const result = await this.transport.request<unknown>('model/list', input);
+    const result = await this.request<unknown>('model/list', input);
     return normalizeModelListResult(result);
   }
 
@@ -208,10 +206,7 @@ export class CodexAppServerClient {
     configuration: CodexThreadConfiguration
   ): Promise<CodexAppServerThreadResult> {
     this.assertInitialized();
-    return this.transport.request(
-      'thread/start',
-      buildThreadParams(configuration, true)
-    );
+    return this.request('thread/start', buildThreadParams(configuration, true));
   }
 
   resumeThread(
@@ -219,7 +214,7 @@ export class CodexAppServerClient {
     configuration: CodexThreadConfiguration
   ): Promise<CodexAppServerThreadResult> {
     this.assertInitialized();
-    return this.transport.request('thread/resume', {
+    return this.request('thread/resume', {
       threadId,
       ...buildThreadParams(configuration, false),
     });
@@ -230,7 +225,7 @@ export class CodexAppServerClient {
     configuration: CodexThreadConfiguration
   ): Promise<CodexAppServerThreadResult> {
     this.assertInitialized();
-    return this.transport.request('thread/fork', {
+    return this.request('thread/fork', {
       threadId,
       ...buildThreadParams(configuration, true),
     });
@@ -241,7 +236,7 @@ export class CodexAppServerClient {
     input: readonly CodexTurnInput[]
   ): Promise<CodexAppServerTurnStartResult> {
     this.assertInitialized();
-    return this.transport.request('turn/start', { threadId, input });
+    return this.request('turn/start', { threadId, input });
   }
 
   async steerTurn(
@@ -250,7 +245,7 @@ export class CodexAppServerClient {
     input: readonly CodexTurnInput[]
   ): Promise<CodexAppServerTurnSteerResult> {
     this.assertInitialized();
-    const result = await this.transport.request<unknown>('turn/steer', {
+    const result = await this.request<unknown>('turn/steer', {
       threadId,
       expectedTurnId: turnId,
       input,
@@ -265,7 +260,7 @@ export class CodexAppServerClient {
 
   interruptTurn(threadId: string, turnId: string): Promise<void> {
     this.assertInitialized();
-    return this.transport.request('turn/interrupt', { threadId, turnId });
+    return this.request('turn/interrupt', { threadId, turnId });
   }
 
   close(): Promise<void> {
@@ -278,21 +273,20 @@ export class CodexAppServerClient {
         'Codex app-server client was initialized more than once.'
       );
     }
-    const response =
-      await this.transport.request<CodexAppServerInitializeResponse>(
-        'initialize',
-        {
-          clientInfo: {
-            name: 'aituber_onair_agent',
-            title: 'AITuber OnAir Agent',
-            version: '0.0.0',
-          },
-          capabilities: {
-            experimentalApi: this.experimentalApi,
-            requestAttestation: false,
-          },
-        }
-      );
+    const response = await this.request<CodexAppServerInitializeResponse>(
+      'initialize',
+      {
+        clientInfo: {
+          name: 'aituber_onair_agent',
+          title: 'AITuber OnAir Agent',
+          version: '0.0.0',
+        },
+        capabilities: {
+          experimentalApi: this.experimentalApi,
+          requestAttestation: false,
+        },
+      }
+    );
     assertInitializeResponse(response);
     this.transport.notify('initialized');
     this.initialized = true;
@@ -306,6 +300,33 @@ export class CodexAppServerClient {
     }
   }
 
+  private async request<Result>(
+    method: string,
+    params?: unknown
+  ): Promise<Result> {
+    try {
+      return await this.transport.request<Result>(method, params);
+    } catch (error) {
+      if (
+        error instanceof AgentBackendProtocolError &&
+        error.details?.code === -32601
+      ) {
+        throw new AgentBackendCompatibilityError(
+          `Codex app-server method "${method}" is unavailable in CLI ${this.actualVersion}; this package was verified against CLI ${CODEX_APP_SERVER_VERIFIED_VERSION}.`,
+          {
+            cause: error,
+            details: {
+              method,
+              actualVersion: this.actualVersion,
+              verifiedVersion: CODEX_APP_SERVER_VERIFIED_VERSION,
+            },
+          }
+        );
+      }
+      throw error;
+    }
+  }
+
   private dispatchNotification(notification: CodexAppServerNotification): void {
     for (const listener of this.notificationListeners) listener(notification);
   }
@@ -315,30 +336,74 @@ export class CodexAppServerClient {
   }
 }
 
-function assertCompatibility(
-  compatibility: CodexAppServerClientCompatibility
+function checkCompatibility(
+  actualVersion: string,
+  compatibility: CodexAppServerClientCompatibility | undefined,
+  onDiagnostic: ((message: string) => void) | undefined
 ): void {
-  const issues: string[] = [];
-  if (compatibility.expectedVersion !== CODEX_APP_SERVER_SUPPORTED_VERSION) {
-    issues.push(
-      `compatibility.expectedVersion must be "${CODEX_APP_SERVER_SUPPORTED_VERSION}"`
-    );
+  if (compatibility?.accept) {
+    if (
+      !compatibility.accept(actualVersion, CODEX_APP_SERVER_VERIFIED_VERSION)
+    ) {
+      throw new AgentBackendCompatibilityError(
+        `Codex CLI ${actualVersion} was rejected by the custom compatibility policy for verified version ${CODEX_APP_SERVER_VERIFIED_VERSION}.`,
+        {
+          details: {
+            actualVersion,
+            verifiedVersion: CODEX_APP_SERVER_VERIFIED_VERSION,
+          },
+        }
+      );
+    }
+    return;
   }
-  if (compatibility.schemaVersion !== CODEX_APP_SERVER_SCHEMA_VERSION) {
-    issues.push(
-      `compatibility.schemaVersion must be "${CODEX_APP_SERVER_SCHEMA_VERSION}"`
-    );
-  }
-  if (issues.length > 0) {
+
+  const minimumVersion =
+    compatibility?.minimumVersion ?? CODEX_APP_SERVER_MINIMUM_VERSION;
+  if (compareCodexVersions(actualVersion, minimumVersion) < 0) {
     throw new AgentBackendCompatibilityError(
-      'Codex app-server compatibility declaration is unsupported.',
-      { details: { issues } }
+      `Codex CLI ${actualVersion} is older than the minimum supported version ${minimumVersion}.`,
+      { details: { actualVersion, minimumVersion } }
+    );
+  }
+
+  if (actualVersion === CODEX_APP_SERVER_VERIFIED_VERSION) return;
+
+  const onMismatch = compatibility?.onMismatch ?? 'warn';
+  if (onMismatch === 'reject') {
+    throw new AgentBackendCompatibilityError(
+      `Codex CLI ${actualVersion} does not match the verified version ${CODEX_APP_SERVER_VERIFIED_VERSION}.`,
+      {
+        details: {
+          actualVersion,
+          verifiedVersion: CODEX_APP_SERVER_VERIFIED_VERSION,
+        },
+      }
+    );
+  }
+  if (onMismatch === 'warn') {
+    emitDiagnostic(
+      onDiagnostic,
+      `Codex CLI ${actualVersion} differs from the verified version ${CODEX_APP_SERVER_VERIFIED_VERSION}; continuing.`
     );
   }
 }
 
+function emitDiagnostic(
+  onDiagnostic: ((message: string) => void) | undefined,
+  message: string
+): void {
+  try {
+    onDiagnostic?.(message);
+  } catch {
+    // Diagnostics are observational and must not prevent a connection.
+  }
+}
+
 function parseCodexVersion(output: string): string {
-  const match = /^codex-cli\s+(\d+\.\d+\.\d+)$/.exec(output.trim());
+  const match = /^codex-cli\s+(\d+\.\d+\.\d+)(?:[-+][0-9A-Za-z.-]+)?$/.exec(
+    output.trim()
+  );
   if (!match) {
     throw new AgentBackendCompatibilityError(
       'Codex CLI returned an unrecognized version string.',
@@ -346,6 +411,27 @@ function parseCodexVersion(output: string): string {
     );
   }
   return match[1];
+}
+
+export function compareCodexVersions(left: string, right: string): number {
+  const leftParts = parseComparableVersion(left);
+  const rightParts = parseComparableVersion(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) return Math.sign(difference);
+  }
+  return 0;
+}
+
+function parseComparableVersion(version: string): readonly number[] {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/.exec(version);
+  if (!match) {
+    throw new AgentBackendCompatibilityError(
+      `Codex CLI compatibility version "${version}" is invalid.`,
+      { details: { version } }
+    );
+  }
+  return match.slice(1, 4).map(Number);
 }
 
 function buildThreadParams(

--- a/packages/agent/src/backends/codex/protocol.ts
+++ b/packages/agent/src/backends/codex/protocol.ts
@@ -1,9 +1,11 @@
-/**
- * Stable protocol subset generated and reconciled against codex-cli 0.145.0.
- * The complete generated schema is intentionally not exposed by this package.
- */
-export const CODEX_APP_SERVER_SUPPORTED_VERSION = '0.145.0';
-export const CODEX_APP_SERVER_SCHEMA_VERSION = 'v2@0.145.0';
+/** Codex CLI version against which this package was verified. */
+export const CODEX_APP_SERVER_VERIFIED_VERSION = '0.145.0';
+
+/** Oldest Codex CLI version whose schema contains all required elements. */
+export const CODEX_APP_SERVER_MINIMUM_VERSION = '0.136.0';
+
+/** app-server protocol generation used by this package. */
+export const CODEX_APP_SERVER_PROTOCOL_GENERATION = 'v2';
 
 export type CodexAppServerRequestId = string | number;
 

--- a/packages/agent/src/backends/codex/types.ts
+++ b/packages/agent/src/backends/codex/types.ts
@@ -26,13 +26,17 @@ export interface CodexAppServerBackendCapabilities
 }
 
 export interface CodexAppServerCompatibility {
-  readonly expectedVersion: string;
-  readonly schemaVersion: string;
+  /** Defaults to CODEX_APP_SERVER_MINIMUM_VERSION. */
+  readonly minimumVersion?: string;
+  /** Defaults to warning when the CLI differs from the verified version. */
+  readonly onMismatch?: 'reject' | 'warn' | 'allow';
+  /** Overrides minimumVersion and onMismatch when provided. */
+  readonly accept?: (actual: string, verified: string) => boolean;
 }
 
 export interface CodexAppServerCommonOptions {
   readonly workingDirectory: string;
-  readonly compatibility: CodexAppServerCompatibility;
+  readonly compatibility?: CodexAppServerCompatibility;
   readonly environment?: Readonly<Record<string, string>>;
   readonly requestTimeoutMs?: number;
   readonly shutdownTimeoutMs?: number;

--- a/packages/agent/src/codex-app-server.ts
+++ b/packages/agent/src/codex-app-server.ts
@@ -1,7 +1,8 @@
 export { createCodexAppServerBackend } from './backends/codex/CodexAppServerBackend.js';
 export {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
+  CODEX_APP_SERVER_MINIMUM_VERSION,
+  CODEX_APP_SERVER_PROTOCOL_GENERATION,
+  CODEX_APP_SERVER_VERIFIED_VERSION,
 } from './backends/codex/protocol.js';
 export type {
   CodexAppServerAccount,

--- a/packages/agent/test/dist-smoke.mjs
+++ b/packages/agent/test/dist-smoke.mjs
@@ -19,8 +19,13 @@ assert.equal(typeof esmChat.createChatServiceBackend, 'function');
 assert.equal(typeof cjsChat.createChatServiceBackend, 'function');
 assert.equal(typeof esmCodex.createCodexAppServerBackend, 'function');
 assert.equal(typeof cjsCodex.createCodexAppServerBackend, 'function');
-assert.equal(esmCodex.CODEX_APP_SERVER_SUPPORTED_VERSION, '0.145.0');
-assert.equal(cjsCodex.CODEX_APP_SERVER_SCHEMA_VERSION, 'v2@0.145.0');
+for (const codex of [esmCodex, cjsCodex]) {
+  assert.equal(codex.CODEX_APP_SERVER_VERIFIED_VERSION, '0.145.0');
+  assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
+  assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
+  assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
+  assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
+}
 
 const browserOutputFiles = [
   '../dist/esm/index.js',

--- a/packages/agent/test/package-smoke.mjs
+++ b/packages/agent/test/package-smoke.mjs
@@ -123,8 +123,11 @@ assert.equal(typeof agent.createAgent, 'function');
 assert.equal(typeof agent.defineAgentTool, 'function');
 assert.equal(typeof chat.createChatServiceBackend, 'function');
 assert.equal(typeof codex.createCodexAppServerBackend, 'function');
-assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, '0.145.0');
-assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, 'v2@0.145.0');
+assert.equal(codex.CODEX_APP_SERVER_VERIFIED_VERSION, '0.145.0');
+assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
+assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
+assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
+assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
 `
   );
   await writeFile(
@@ -139,8 +142,11 @@ assert.equal(typeof agent.createAgent, 'function');
 assert.equal(typeof agent.defineAgentTool, 'function');
 assert.equal(typeof chat.createChatServiceBackend, 'function');
 assert.equal(typeof codex.createCodexAppServerBackend, 'function');
-assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, '0.145.0');
-assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, 'v2@0.145.0');
+assert.equal(codex.CODEX_APP_SERVER_VERIFIED_VERSION, '0.145.0');
+assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
+assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
+assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
+assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
 `
   );
 
@@ -160,11 +166,7 @@ import {
   type AgentWorkspaceMetadataStore,
 } from '@aituber-onair/agent';
 import { createChatServiceBackend } from '@aituber-onair/agent/chat';
-import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
-  createCodexAppServerBackend,
-} from '@aituber-onair/agent/codex-app-server';
+import { createCodexAppServerBackend } from '@aituber-onair/agent/codex-app-server';
 
 const analyzeComments = defineAgentTool({
   id: 'comments.analyze',
@@ -289,10 +291,6 @@ const bootstrap = workspaceAgent.bootstrap({
 const codexBackend = createCodexAppServerBackend({
   allowPathLookup: true,
   workingDirectory: '/path/to/character-workspace',
-  compatibility: {
-    expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-    schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
-  },
   sandbox: 'read-only',
   approvalPolicy: 'on-request',
 });

--- a/packages/agent/tests/CodexAppServerBackend.test.ts
+++ b/packages/agent/tests/CodexAppServerBackend.test.ts
@@ -668,16 +668,10 @@ describe('CodexAppServerBackend', () => {
   });
 
   it('rejects unsafe or malformed runtime options', () => {
-    const compatibility = {
-      expectedVersion: '0.145.0',
-      schemaVersion: 'v2@0.145.0',
-    };
-
     expect(() =>
       createCodexAppServerBackendRuntime({
         codexPath: '/path/to/codex',
         workingDirectory: workspace,
-        compatibility,
         sandbox: 'danger-full-access' as never,
       })
     ).toThrow(AgentConfigurationError);
@@ -686,14 +680,24 @@ describe('CodexAppServerBackend', () => {
         codexPath: '/path/to/codex',
         allowPathLookup: true,
         workingDirectory: workspace,
-        compatibility,
       } as never)
     ).toThrow(AgentConfigurationError);
     expect(() =>
       createCodexAppServerBackendRuntime({
         allowPathLookup: true,
         workingDirectory: workspace,
-        compatibility: undefined,
+        compatibility: { expectedVersion: '0.145.0' },
+      } as never)
+    ).toThrow(AgentConfigurationError);
+    expect(() =>
+      createCodexAppServerBackendRuntime({
+        allowPathLookup: true,
+        workingDirectory: workspace,
+        compatibility: {
+          minimumVersion: 136,
+          onMismatch: 'continue',
+          accept: true,
+        },
       } as never)
     ).toThrow(AgentConfigurationError);
   });
@@ -724,10 +728,6 @@ function createBackend(overrides: Record<string, unknown> = {}): {
     {
       codexPath: '/path/to/codex',
       workingDirectory: workspace,
-      compatibility: {
-        expectedVersion: '0.145.0',
-        schemaVersion: 'v2@0.145.0',
-      },
       shutdownTimeoutMs: 1,
       ...overrides,
     },

--- a/packages/agent/tests/CodexAppServerClient.test.ts
+++ b/packages/agent/tests/CodexAppServerClient.test.ts
@@ -3,7 +3,10 @@ import {
   AgentBackendProcessError,
   AgentBackendProtocolError,
 } from '../src/errors.js';
-import { CodexAppServerClient } from '../src/backends/codex/client.js';
+import {
+  CodexAppServerClient,
+  compareCodexVersions,
+} from '../src/backends/codex/client.js';
 import type { CodexAppServerClientOptions } from '../src/backends/codex/client.js';
 import { FakeCodexProcessFactory } from './helpers/fakeCodexProcess.js';
 
@@ -11,10 +14,6 @@ const options: CodexAppServerClientOptions = {
   executable: '/path/to/codex',
   workingDirectory: '/path/to/workspace',
   environment: {},
-  compatibility: {
-    expectedVersion: '0.145.0',
-    schemaVersion: 'v2@0.145.0',
-  },
 };
 
 describe('CodexAppServerClient', () => {
@@ -243,28 +242,159 @@ describe('CodexAppServerClient', () => {
     await process.finish(() => client.close());
   });
 
-  it('rejects unsupported declarations and installed versions before spawn', async () => {
-    const declarationFactory = new FakeCodexProcessFactory();
+  it.each([
+    ['0.147.0', 'newer'],
+    ['0.140.0', 'older but supported'],
+  ])('starts with %s and warns for a %s CLI', async (version) => {
+    const diagnostics: string[] = [];
+    const factory = new FakeCodexProcessFactory();
+    factory.version = `codex-cli ${version}`;
+    const { client, process } = await connectClient(factory, {
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    expect(diagnostics).toEqual([
+      expect.stringContaining(`Codex CLI ${version}`),
+    ]);
+    await process.finish(() => client.close());
+  });
+
+  it('starts without diagnostics for the verified CLI', async () => {
+    const diagnostics: string[] = [];
+    const factory = new FakeCodexProcessFactory();
+    const { client, process } = await connectClient(factory, {
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    expect(diagnostics).toEqual([]);
+    await process.finish(() => client.close());
+  });
+
+  it('does not let a mismatch diagnostic failure prevent startup', async () => {
+    const factory = new FakeCodexProcessFactory();
+    factory.version = 'codex-cli 0.147.0';
+    const { client, process } = await connectClient(factory, {
+      onDiagnostic: () => {
+        throw new Error('observer failed');
+      },
+    });
+
+    await process.finish(() => client.close());
+  });
+
+  it('rejects a CLI below the default minimum before spawn', async () => {
+    const factory = new FakeCodexProcessFactory();
+    factory.version = 'codex-cli 0.130.0';
+    const connecting = CodexAppServerClient.connect(options, {
+      processFactory: factory,
+    });
+
+    await expect(connecting).rejects.toMatchObject({
+      message: expect.stringMatching(/0\.130\.0.*0\.136\.0/),
+    });
+    await expect(connecting).rejects.toBeInstanceOf(
+      AgentBackendCompatibilityError
+    );
+    expect(factory.processes).toHaveLength(0);
+  });
+
+  it('supports reject and allow mismatch policies', async () => {
+    const rejectFactory = new FakeCodexProcessFactory();
+    rejectFactory.version = 'codex-cli 0.147.0';
     await expect(
       CodexAppServerClient.connect(
-        {
-          ...options,
-          compatibility: {
-            expectedVersion: '0.145.0',
-            schemaVersion: 'wrong-schema',
-          },
-        },
-        { processFactory: declarationFactory }
+        { ...options, compatibility: { onMismatch: 'reject' } },
+        { processFactory: rejectFactory }
       )
     ).rejects.toBeInstanceOf(AgentBackendCompatibilityError);
-    expect(declarationFactory.processes).toHaveLength(0);
+    expect(rejectFactory.processes).toHaveLength(0);
 
-    const versionFactory = new FakeCodexProcessFactory();
-    versionFactory.version = 'codex-cli 0.144.0';
+    const diagnostics: string[] = [];
+    const allowFactory = new FakeCodexProcessFactory();
+    allowFactory.version = 'codex-cli 0.147.0';
+    const { client, process } = await connectClient(allowFactory, {
+      compatibility: { onMismatch: 'allow' },
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+    expect(diagnostics).toEqual([]);
+    await process.finish(() => client.close());
+  });
+
+  it('gives a custom accept policy precedence over all default checks', async () => {
+    const allowFactory = new FakeCodexProcessFactory();
+    allowFactory.version = 'codex-cli 0.130.0';
+    const accept = vi.fn(() => true);
+    const { client, process } = await connectClient(allowFactory, {
+      compatibility: {
+        minimumVersion: '9.0.0',
+        onMismatch: 'reject',
+        accept,
+      },
+    });
+    expect(accept).toHaveBeenCalledWith('0.130.0', '0.145.0');
+    await process.finish(() => client.close());
+
+    const rejectFactory = new FakeCodexProcessFactory();
+    const reject = vi.fn(() => false);
     await expect(
-      CodexAppServerClient.connect(options, { processFactory: versionFactory })
+      CodexAppServerClient.connect(
+        { ...options, compatibility: { accept: reject } },
+        { processFactory: rejectFactory }
+      )
     ).rejects.toBeInstanceOf(AgentBackendCompatibilityError);
-    expect(versionFactory.processes).toHaveLength(0);
+    expect(reject).toHaveBeenCalledWith('0.145.0', '0.145.0');
+    expect(rejectFactory.processes).toHaveLength(0);
+  });
+
+  it('parses pre-release versions and compares their numeric core', async () => {
+    const diagnostics: string[] = [];
+    const factory = new FakeCodexProcessFactory();
+    factory.version = 'codex-cli 0.148.0-alpha.9';
+    const { client, process } = await connectClient(factory, {
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    expect(diagnostics).toEqual([expect.stringContaining('0.148.0')]);
+    await process.finish(() => client.close());
+  });
+
+  it('rejects unrecognized version output before spawn', async () => {
+    const factory = new FakeCodexProcessFactory();
+    factory.version = 'codex 0.145.0';
+
+    await expect(
+      CodexAppServerClient.connect(options, { processFactory: factory })
+    ).rejects.toBeInstanceOf(AgentBackendCompatibilityError);
+    expect(factory.processes).toHaveLength(0);
+  });
+
+  it('maps method-not-found responses to compatibility errors', async () => {
+    const { client, process } = await connectClient();
+    const account = client.readAccount();
+    process.send({
+      id: 2,
+      error: { code: -32601, message: 'Method not found' },
+    });
+
+    await expect(account).rejects.toBeInstanceOf(
+      AgentBackendCompatibilityError
+    );
+    await expect(account).rejects.toMatchObject({
+      message: expect.stringMatching(/account\/read.*0\.145\.0.*0\.145\.0/),
+    });
+    await process.finish(() => client.close());
+  });
+
+  it('keeps other JSON-RPC failures as protocol errors', async () => {
+    const { client, process } = await connectClient();
+    const account = client.readAccount();
+    process.send({
+      id: 2,
+      error: { code: -32602, message: 'Invalid params' },
+    });
+
+    await expect(account).rejects.toBeInstanceOf(AgentBackendProtocolError);
+    await process.finish(() => client.close());
   });
 
   it('wraps executable lookup failures', async () => {
@@ -283,11 +413,32 @@ describe('CodexAppServerClient', () => {
   });
 });
 
-async function connectClient() {
-  const factory = new FakeCodexProcessFactory();
-  const connecting = CodexAppServerClient.connect(options, {
-    processFactory: factory,
+describe('compareCodexVersions', () => {
+  it('compares each numeric version component', () => {
+    expect(compareCodexVersions('0.136.0', '0.140.0')).toBeLessThan(0);
+    expect(compareCodexVersions('0.9.0', '0.10.0')).toBeLessThan(0);
+    expect(compareCodexVersions('1.0.0', '0.147.0')).toBeGreaterThan(0);
   });
+
+  it('returns zero for identical versions', () => {
+    expect(compareCodexVersions('0.145.0', '0.145.0')).toBe(0);
+  });
+
+  it('ignores pre-release suffixes', () => {
+    expect(compareCodexVersions('0.148.0-alpha.9', '0.148.0')).toBe(0);
+  });
+});
+
+async function connectClient(
+  factory = new FakeCodexProcessFactory(),
+  overrides: Partial<CodexAppServerClientOptions> = {}
+) {
+  const connecting = CodexAppServerClient.connect(
+    { ...options, ...overrides },
+    {
+      processFactory: factory,
+    }
+  );
   await waitUntil(() => factory.processes.length === 1);
   const process = factory.processes[0];
   process.send({

--- a/packages/agent/tests/type-contracts.test.ts
+++ b/packages/agent/tests/type-contracts.test.ts
@@ -43,8 +43,9 @@ import type {
   CodexAppServerCompatibility,
 } from '../src/codex-app-server.js';
 import {
-  CODEX_APP_SERVER_SCHEMA_VERSION,
-  CODEX_APP_SERVER_SUPPORTED_VERSION,
+  CODEX_APP_SERVER_MINIMUM_VERSION,
+  CODEX_APP_SERVER_PROTOCOL_GENERATION,
+  CODEX_APP_SERVER_VERIFIED_VERSION,
   createCodexAppServerBackend,
 } from '../src/codex-app-server.js';
 
@@ -153,8 +154,9 @@ describe('public type surface', () => {
 
   it('requires an explicit Codex executable path or PATH opt-in', () => {
     const compatibility: CodexAppServerCompatibility = {
-      expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-      schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
+      minimumVersion: CODEX_APP_SERVER_MINIMUM_VERSION,
+      onMismatch: 'warn',
+      accept: (actual, verified) => actual === verified,
     };
     const explicitPath: CodexAppServerBackendOptions = {
       codexPath: '/path/to/codex',
@@ -186,5 +188,25 @@ describe('public type surface', () => {
     expectTypeOf(createCodexAppServerBackend).toBeFunction();
     expectTypeOf<CodexAppServerBackend>().toBeObject();
     expectTypeOf<CodexAppServerBackendCapabilities>().toBeObject();
+    expectTypeOf<
+      CodexAppServerBackendCapabilities['sessionResume']
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      CodexAppServerBackendCapabilities['approvals']
+    >().toEqualTypeOf<true>();
+    expect(CODEX_APP_SERVER_VERIFIED_VERSION).toBe('0.145.0');
+    expect(CODEX_APP_SERVER_PROTOCOL_GENERATION).toBe('v2');
+
+    const defaults: CodexAppServerBackendOptions = {
+      codexPath: '/path/to/codex',
+      workingDirectory: '/path/to/workspace',
+    };
+    expect(defaults.compatibility).toBeUndefined();
+
+    const legacy: CodexAppServerCompatibility = {
+      // @ts-expect-error expectedVersion was removed from the public contract.
+      expectedVersion: '0.145.0',
+    };
+    expect(legacy).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

`CodexAppServerBackend` required Codex CLI **exactly** `0.145.0` and refused to start
otherwise. Any user whose Codex CLI is a different version could not use the backend
without downgrading their global installation.

This replaces the exact-version gate with a minimum version plus a host-controlled
policy, so any current Codex environment works by default.

```diff
- compatibility: {
-   expectedVersion: CODEX_APP_SERVER_SUPPORTED_VERSION,
-   schemaVersion: CODEX_APP_SERVER_SCHEMA_VERSION,
- }
+ // compatibility is optional; the default accepts any CLI at or above the minimum
```

## Why the pin was wrong for this package

`@aituber-onair/agent` is documented as an embeddable runtime where *the host
application always owns the Agent's lifecycle and authority*. A library that is
embedded into someone else's product should not dictate which CLI version that
product's machine has installed. Codex CLI's semver also moves for reasons
unrelated to the app-server protocol, so it is a poor compatibility signal.

## Evidence

Protocol definitions were generated from six Codex CLI releases
(`codex app-server generate-json-schema`) and compared.

| version | requests | notifications | type defs | required 14 elements |
| --- | ---: | ---: | ---: | :---: |
| 0.136.0 | 79 | 59 | 468 | all present |
| 0.140.0 | 81 | 61 | 486 | all present |
| 0.143.0 | 84 | 63 | 515 | all present |
| 0.145.0 (old pin) | 86 | 65 | 532 | all present |
| 0.146.1 | 87 | 65 | 537 | all present |
| 0.147.0 | 92 | 65 | 557 | all present |

Deletions between consecutive releases: **0 methods, 0 notifications, 2 types**
(neither used by this package). Across 11 minor versions the protocol was purely
additive, and every element this backend needs already existed in `0.136.0` —
nine minor versions below the old pin.

## Changes

**Constants** (`src/backends/codex/protocol.ts`)

| removed | added |
| --- | --- |
| `CODEX_APP_SERVER_SUPPORTED_VERSION` | `CODEX_APP_SERVER_VERIFIED_VERSION` (`0.145.0`) |
| `CODEX_APP_SERVER_SCHEMA_VERSION` | `CODEX_APP_SERVER_MINIMUM_VERSION` (`0.136.0`) |
| | `CODEX_APP_SERVER_PROTOCOL_GENERATION` (`v2`) |

The old constants are removed rather than deprecated: the package is unpublished
(`private: true`, `version 0.0.0`), and `'v2@0.145.0'` conflated a protocol
generation with a CLI release.

**Compatibility option** — now optional:

```ts
compatibility?: {
  minimumVersion?: string;                 // default 0.136.0
  onMismatch?: 'reject' | 'warn' | 'allow'; // default 'warn'
  accept?: (actual: string, verified: string) => boolean;
}
```

**Connect flow** — `accept` (if given) decides; otherwise reject below the minimum,
then apply `onMismatch` when the CLI differs from the verified version.

**Late compatibility detection** — JSON-RPC `-32601` (method not found) is mapped to
`AgentBackendCompatibilityError` with the method name, the installed CLI version and
the verified version. A CLI missing a method this backend needs therefore produces a
clear error at the call site instead of a generic protocol error.

**Version parsing** — pre-release suffixes are accepted
(`codex-cli 0.148.0-alpha.9` parses as `0.148.0`).

**Existing examples** — `stream-operations-staff` and `codex-workspace-server` no
longer import or pass the removed constants. Their READMEs no longer instruct a
global install of one exact CLI version.

## Explicitly out of scope

Two ideas were considered and rejected during review:

- **Schema probing at connect time** — running `generate-json-schema` and checking
  required elements. It would not change the outcome for any version measured above,
  and costs an extra subprocess per connection. The `-32601` mapping covers the same
  failure without it.
- **Dynamic capability computation** (e.g. `sessionResume: false` when
  `thread/resume` is absent) — `AgentRuntime` snapshots `backend.capabilities` in its
  constructor, while the Codex connection happens inside `startSession()`. A value
  computed after connecting can never reach the runtime, so this would silently
  disagree with what the runtime believes.

## Tests

`packages/agent/tests/CodexAppServerClient.test.ts`

- verified version starts with no diagnostic
- a diagnostic callback that throws does not prevent startup
- CLI below the default minimum is rejected before spawn
- `onMismatch: 'reject'` and `'allow'` policies
- a custom `accept` policy takes precedence over the default checks
- pre-release versions parse and compare on their numeric core
- unrecognized version output is rejected before spawn
- `-32601` responses map to compatibility errors
- `compareCodexVersions` component ordering, equality, and suffix handling

`packages/agent/tests/type-contracts.test.ts` pins the new public contract and asserts
via `@ts-expect-error` that `expectedVersion` is gone.

`packages/agent/test/{dist,package}-smoke.mjs` assert the new constants and that the
removed ones are `undefined` in both ESM and CJS builds.

## Verification

```
npm run fmt     PASS
npm run lint    PASS
npm run test    PASS   (agent: 20 files / 197 tests, plus ESM/CJS/package smoke)
npm run build   PASS
```

## Follow-up (not in this PR)

A CI job that installs the latest Codex CLI, regenerates the protocol schema and
verifies the 14 required elements still exist. That turns the version pin from a
runtime gate into a maintainer-side test.
