### PR TITLE
feat(transcription): add local Whisper provider with progress events and model sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -601,6 +601,17 @@
                 "prettier": "^2.7.1"
             }
         },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1043,6 +1054,527 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@huggingface/jinja": {
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+            "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@huggingface/tokenizers": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+            "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@huggingface/transformers": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+            "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@huggingface/jinja": "^0.5.6",
+                "@huggingface/tokenizers": "^0.1.3",
+                "onnxruntime-node": "1.24.3",
+                "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+                "sharp": "^0.34.5"
+            }
+        },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.7.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1413,6 +1945,72 @@
             "engines": {
                 "node": ">=14"
             }
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.44.2",
@@ -2045,6 +2643,16 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/adm-zip": {
+            "version": "0.5.18",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+            "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0"
+            }
+        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2164,6 +2772,14 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/boolean": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -2503,6 +3119,42 @@
                 "node": ">=6"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2533,6 +3185,23 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -2700,6 +3369,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esbuild": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -2737,6 +3413,19 @@
                 "@esbuild/win32-arm64": "0.21.5",
                 "@esbuild/win32-ia32": "0.21.5",
                 "@esbuild/win32-x64": "0.21.5"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/esprima": {
@@ -2891,6 +3580,13 @@
                 "mlly": "^1.7.4",
                 "rollup": "^4.34.8"
             }
+        },
+        "node_modules/flatbuffers": {
+            "version": "25.9.23",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+            "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
@@ -3070,6 +3766,41 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/global-agent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "es6-error": "^4.1.1",
+                "matcher": "^3.0.0",
+                "roarr": "^2.15.3",
+                "semver": "^7.3.2",
+                "serialize-error": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3111,6 +3842,13 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/guid-typescript": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+            "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3119,6 +3857,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -3521,6 +4272,13 @@
                 }
             }
         },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3619,6 +4377,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/loupe": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -3683,6 +4448,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/matcher": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/math-intrinsics": {
@@ -3955,6 +4733,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3980,6 +4768,53 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/onnxruntime-common": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+            "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/onnxruntime-node": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+            "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "os": [
+                "win32",
+                "darwin",
+                "linux"
+            ],
+            "dependencies": {
+                "adm-zip": "^0.5.16",
+                "global-agent": "^3.0.0",
+                "onnxruntime-common": "1.24.3"
+            }
+        },
+        "node_modules/onnxruntime-web": {
+            "version": "1.26.0-dev.20260416-b7804b056c",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+            "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatbuffers": "^25.1.24",
+                "guid-typescript": "^1.0.9",
+                "long": "^5.2.3",
+                "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+                "platform": "^1.3.6",
+                "protobufjs": "^7.2.4"
+            }
+        },
+        "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+            "version": "1.24.0-dev.20251116-b39e144322",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+            "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",
@@ -4223,6 +5058,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/platform": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+            "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/postcss": {
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -4325,6 +5167,47 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
+        },
+        "node_modules/protobufjs": {
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
+                "@types/node": ">=13.7.0",
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/protobufjs/node_modules/@types/node": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+            "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
+        },
+        "node_modules/protobufjs/node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/psl": {
             "version": "1.15.0",
@@ -4496,6 +5379,31 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/roarr": {
+            "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/roarr/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/rollup": {
             "version": "4.44.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
@@ -4595,9 +5503,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4605,6 +5513,74 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serialize-error": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/sharp": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/shebang-command": {
@@ -5213,6 +6189,14 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/tsup": {
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
@@ -5707,6 +6691,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typescript": {
@@ -7798,6 +8795,7 @@
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
+                "@huggingface/transformers": "4.2.0",
                 "@types/node": "^18.15.0",
                 "@vitest/coverage-v8": "^1.3.1",
                 "jsdom": "^22.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8791,7 +8791,7 @@
         },
         "packages/transcription": {
             "name": "@aituber-onair/transcription",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @aituber-onair/transcription
 
+## Unreleased
+
+### Added
+
+- Added browser-local Whisper Tiny transcription through a bundled module
+  worker, Transformers.js, and WebGPU, with no API key or microphone audio
+  upload.
+- Added browser PCM capture with AudioWorklet batching, voice activity
+  detection, pre-roll, 16 kHz resampling, 30-second turn splitting, and
+  configurable end-of-utterance silence.
+- Added typed Local Whisper options, browser capability detection, language
+  normalization, sequential inference, lifecycle cleanup, and guards for short
+  noise and common Whisper hallucinations.
+- Added Local Whisper controls and English/Japanese guidance to the browser
+  example.
+
 ## 0.0.1
 
 ### Added

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @aituber-onair/transcription
 
-## Unreleased
+## 0.0.2
 
 ### Added
 

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -15,6 +15,9 @@
   noise and common Whisper hallucinations.
 - Added Local Whisper controls and English/Japanese guidance to the browser
   example.
+- Added provider-neutral initialization progress events, normalized Local
+  Whisper download/initialization phases, and aggregated loading progress in
+  the browser example.
 
 ## 0.0.1
 

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Added provider-neutral initialization progress events, normalized Local
   Whisper download/initialization phases, and aggregated loading progress in
   the browser example.
+- Added selectable Tiny, Base, and Small Local Whisper models with size-specific
+  worker caching, browser example guidance, and measured download and inference
+  comparisons.
 
 ## 0.0.1
 

--- a/packages/transcription/README.ja.md
+++ b/packages/transcription/README.ja.md
@@ -10,9 +10,10 @@ AITuber OnAir 向けの、プロバイダーに依存しないリアルタイム
 > あります。
 
 Web Speech、ブラウザ WebRTC を利用する OpenAI Realtime、WebGPU でローカル推論する
-Whisper Tiny に対応しています。すべてのプロバイダーが、発話ごとに同じ形式の
-スナップショットイベントを発行します。ファイルの文字起こし、サーバー WebSocket
-入力、チャットへの自動送信、プロバイダーのフォールバックは、意図的に対象外です。
+Whisper Tiny、Base、Small に対応しています。すべてのプロバイダーが、発話ごとに
+同じ形式のスナップショットイベントを発行します。ファイルの文字起こし、サーバー
+WebSocket入力、チャットへの自動送信、プロバイダーのフォールバックは、意図的に
+対象外です。
 
 ## ブラウザサンプル
 
@@ -65,13 +66,15 @@ await session.dispose();
 
 ### Local Whisper
 
-Local Whisper は Whisper Tiny をモジュールWorker内で実行し、確定結果のみを発行します。
+Local Whisper は選択した Whisper モデルをモジュールWorker内で実行し、確定結果のみを
+発行します。
 
 ```ts
 import { createRealtimeTranscriptionSession } from '@aituber-onair/transcription';
 
 const session = createRealtimeTranscriptionSession({
   provider: 'local-whisper',
+  model: 'tiny',
   language: 'ja-JP',
   silenceDurationMs: 500,
 });
@@ -97,19 +100,37 @@ await session.stop();
 await session.dispose();
 ```
 
+Local Whisper の認識精度は Web Speech / OpenAI Realtime より劣ります。APIキーが
+不要で、マイク音声を外部サービスへ送信しないことを優先する用途向けです。認識品質が
+必要な場合は `small` を選択してください。
+
+| モデル | 進捗で報告された初回DL量 | 品質の目安 | 推論（日本語 / 英語） |
+| --- | ---: | --- | ---: |
+| `tiny`（既定） | 約122 MB | 低め | 237.3 ms / 203.0 ms |
+| `base` | 約209 MB | 中間 | 255.9 ms / 311.2 ms |
+| `small` | 約589 MB | 実用品質 | 574.7 ms / 551.6 ms |
+
+Chrome/WebGPUで、同じ短い日本語・英語マイククリップを使って計測しました。推論時間は
+音声取得/VADを含まず、GPUによって変わります。初回ダウンロード時間はネットワーク速度に
+依存し、数百MBでは数分かかる場合があります。キャッシュ後の初期化は、Tinyで約0.9秒、
+Baseで約1.2秒、Smallで約2.5秒でした。ダウンロード量はモデルファイルごとに最後に報告された
+`totalBytes` の合計で、進捗を報告しない資産は含みません。
+
 要件と動作は次のとおりです。
 
 - 安全なブラウザコンテキスト（HTTPS または localhost）、マイク権限、Web Audio、
   AudioWorklet、モジュールWorker、WebGPU が必要です。
 - API キーは不要です。WebGPU の初期化に失敗しても、リモートプロバイダーや WASM
   推論へ自動的にフォールバックしません。
-- 初回利用時に、モデル資産を Hugging Face Hub から、ONNX Runtime WebAssembly
-  ファイルを jsDelivr からダウンロードし、ブラウザにキャッシュします。初回の
-  ダウンロード量は約120MBです。
+- 初回利用時に、選択したモデル資産を Hugging Face Hub から、ONNX Runtime
+  WebAssemblyファイルを jsDelivr からダウンロードし、ブラウザにキャッシュします。
+  初回のダウンロードと推論は、大きいモデルほど時間がかかります。
 - マイク音声はブラウザ内で処理され、ブラウザ外へ送信されません。このパッケージは
   音声や文字起こし結果を永続化しません。
 - `language` には BCP 47 形式のヒントを任意指定できます。発話終了を判定する
   `silenceDurationMs` の既定値は500msで、最小150msまで下げられます。
+- `model` には `tiny`、`base`、`small` を指定でき、既定値は `tiny` です。すべての
+  サイズで、モデルのdtypeはfp32 encoderとq4 merged decoderに固定されています。
 - ダウンロード進捗には、`file`、`loadedBytes`、`totalBytes` と、0〜1に正規化した
   `progress` が含まれる場合があります。初期化・準備完了フェーズにバイト数は
   必須ではありません。

--- a/packages/transcription/README.ja.md
+++ b/packages/transcription/README.ja.md
@@ -59,6 +59,10 @@ await session.stop();
 await session.dispose();
 ```
 
+進捗イベントを発行するのは、時間のかかる初期化を伴うプロバイダーだけです。現在は
+`local-whisper` のみが `onProgress` を発行し、Web Speech と OpenAI Realtime は
+発行しません。
+
 ### Local Whisper
 
 Local Whisper は Whisper Tiny をモジュールWorker内で実行し、確定結果のみを発行します。
@@ -76,6 +80,10 @@ session.onTranscript(({ text, isFinal }) => {
   if (isFinal) {
     console.log(text);
   }
+});
+
+session.onProgress(({ phase, progress }) => {
+  updateLoadingIndicator(phase, progress);
 });
 
 session.onError((error) => {
@@ -102,6 +110,9 @@ await session.dispose();
   音声や文字起こし結果を永続化しません。
 - `language` には BCP 47 形式のヒントを任意指定できます。発話終了を判定する
   `silenceDurationMs` の既定値は500msで、最小150msまで下げられます。
+- ダウンロード進捗には、`file`、`loadedBytes`、`totalBytes` と、0〜1に正規化した
+  `progress` が含まれる場合があります。初期化・準備完了フェーズにバイト数は
+  必須ではありません。
 
 通常は ESM エントリからの相対URLで `dist/local-whisper.worker.js` を解決します。
 パッケージを事前バンドルする環境でこの資産を解決できない場合は、高度な設定である

--- a/packages/transcription/README.ja.md
+++ b/packages/transcription/README.ja.md
@@ -9,15 +9,14 @@ AITuber OnAir 向けの、プロバイダーに依存しないリアルタイム
 > このパッケージはα版です。安定版になるまでに公開 API が変更される可能性が
 > あります。
 
-初期実装では Web Speech と、ブラウザ WebRTC を利用する OpenAI Realtime の
-文字起こしに対応しています。どちらのプロバイダーも、発話ごとに同じ形式の
+Web Speech、ブラウザ WebRTC を利用する OpenAI Realtime、WebGPU でローカル推論する
+Whisper Tiny に対応しています。すべてのプロバイダーが、発話ごとに同じ形式の
 スナップショットイベントを発行します。ファイルの文字起こし、サーバー WebSocket
-入力、チャットへの自動送信、プロバイダーのフォールバックは、意図的に対象外と
-しています。
+入力、チャットへの自動送信、プロバイダーのフォールバックは、意図的に対象外です。
 
 ## ブラウザサンプル
 
-AITuber OnAir Core に依存せず、両方のプロバイダーを試せるフレームワーク非依存の
+AITuber OnAir Core に依存せず、3つのプロバイダーを試せるフレームワーク非依存の
 ブラウザサンプルが含まれています。
 
 ```sh
@@ -25,10 +24,12 @@ npm -w @aituber-onair/transcription run example:dev
 ```
 
 表示された localhost の URL を開き、セッション開始時にマイクの使用を許可して
-ください。Web Speech にキーは不要です。OpenAI を利用する場合は、エンドユーザー
-自身が所有する API キーを画面に入力します。サンプルはブラウザから OpenAI へ直接
-接続するため、共有端末での利用は避けてください。画面は日本語・英語を切り替えられ、
-初期表示にはブラウザの言語設定が使われます。詳細は
+ください。Web Speech と Local Whisper にキーは不要です。OpenAI を利用する場合は、
+エンドユーザー自身が所有する API キーを画面に入力します。サンプルはブラウザから
+OpenAI へ直接接続するため、共有端末での利用は避けてください。Local Whisper には
+WebGPU が必要で、初回開始時にモデルとランタイムをダウンロードしてブラウザに
+キャッシュします。画面は日本語・英語を切り替えられ、初期表示にはブラウザの言語
+設定が使われます。詳細は
 [サンプルの README](https://github.com/shinshin86/aituber-onair/blob/main/packages/transcription/examples/browser-basic/README.md)
 を参照してください。
 
@@ -57,6 +58,57 @@ await session.start();
 await session.stop();
 await session.dispose();
 ```
+
+### Local Whisper
+
+Local Whisper は Whisper Tiny をモジュールWorker内で実行し、確定結果のみを発行します。
+
+```ts
+import { createRealtimeTranscriptionSession } from '@aituber-onair/transcription';
+
+const session = createRealtimeTranscriptionSession({
+  provider: 'local-whisper',
+  language: 'ja-JP',
+  silenceDurationMs: 500,
+});
+
+session.onTranscript(({ text, isFinal }) => {
+  if (isFinal) {
+    console.log(text);
+  }
+});
+
+session.onError((error) => {
+  console.error(error.code, error.message);
+});
+
+await session.start();
+
+// Later:
+await session.stop();
+await session.dispose();
+```
+
+要件と動作は次のとおりです。
+
+- 安全なブラウザコンテキスト（HTTPS または localhost）、マイク権限、Web Audio、
+  AudioWorklet、モジュールWorker、WebGPU が必要です。
+- API キーは不要です。WebGPU の初期化に失敗しても、リモートプロバイダーや WASM
+  推論へ自動的にフォールバックしません。
+- 初回利用時に、モデル資産を Hugging Face Hub から、ONNX Runtime WebAssembly
+  ファイルを jsDelivr からダウンロードし、ブラウザにキャッシュします。初回の
+  ダウンロード量は約120MBです。
+- マイク音声はブラウザ内で処理され、ブラウザ外へ送信されません。このパッケージは
+  音声や文字起こし結果を永続化しません。
+- `language` には BCP 47 形式のヒントを任意指定できます。発話終了を判定する
+  `silenceDurationMs` の既定値は500msで、最小150msまで下げられます。
+
+通常は ESM エントリからの相対URLで `dist/local-whisper.worker.js` を解決します。
+パッケージを事前バンドルする環境でこの資産を解決できない場合は、高度な設定である
+`workerUrl` に同じモジュールWorker資産または同等のビルドを指定してください。この
+ブラウザサンプルでは、そのために Vite の `?worker&url` import を使っています。
+
+### OpenAI Realtime
 
 OpenAI Realtime は `gpt-live-transcribe` とブラウザ WebRTC を使用します。この
 文字起こしモデルはサーバー側のターン検出を受け付けないため、ブラウザの Web Audio
@@ -118,16 +170,17 @@ OpenAI は、標準 API キーをサーバーに保管し、有効期間の短�
 
 ## プロバイダーの違い
 
-| 機能 | Web Speech | OpenAI Realtime |
-| --- | --- | --- |
-| 途中経過のスナップショット | 対応 | 対応 |
-| 複数の想定言語 | 非対応 | 対応 |
-| キーワードと文脈プロンプト | 非対応 | 対応 |
-| 遅延の設定 | 非対応 | 対応 |
-| 発話境界の判定 | ブラウザ実装 | ブラウザの音量検出 |
+| 機能 | Web Speech | OpenAI Realtime | Local Whisper |
+| --- | --- | --- | --- |
+| 途中経過のスナップショット | 対応 | 対応 | 非対応 |
+| 複数の想定言語 | 非対応 | 対応 | 非対応 |
+| キーワードと文脈プロンプト | 非対応 | 対応 | 非対応 |
+| 遅延の設定 | 非対応 | 対応 | 対応 |
+| 発話境界の判定 | ブラウザ実装 | ブラウザの音量検出 | ブラウザのPCM/VAD |
 
-どちらのプロバイダーにも、対応ブラウザとマイクの使用許可が必要です。OpenAI
-WebRTC では、Web Audio API と HTTPS または localhost も必要です。Web Speech の
-利用可否と動作はブラウザによって異なります。無音中でも待機によって OpenAI の
-利用料金が発生する可能性があるため、アプリケーションでは状態を明確に表示し、
-未使用時にはセッションを停止してください。
+すべてのプロバイダーに、対応ブラウザとマイクの使用許可が必要です。OpenAI WebRTC と
+Local Whisper では Web Audio API と HTTPS または localhost も必要で、Local
+Whisper はさらに WebGPU を必要とします。Web Speech の利用可否と動作はブラウザに
+よって異なります。無音中でも待機によって OpenAI の利用料金が発生する可能性がある
+ため、アプリケーションでは状態を明確に表示し、未使用時にはセッションを停止して
+ください。

--- a/packages/transcription/README.md
+++ b/packages/transcription/README.md
@@ -9,14 +9,15 @@ Provider-neutral realtime microphone transcription for AITuber OnAir.
 > This package is an alpha release. Its public API may change before a stable
 > release.
 
-The initial implementation supports Web Speech and OpenAI Realtime
-transcription over browser WebRTC. Both providers emit the same per-utterance
-snapshot events. File transcription, server WebSocket input, automatic chat
-submission, and provider fallback are intentionally out of scope.
+The package supports Web Speech, OpenAI Realtime transcription over browser
+WebRTC, and local Whisper Tiny inference through WebGPU. All providers emit the
+same per-utterance snapshot events. File transcription, server WebSocket input,
+automatic chat submission, and provider fallback are intentionally out of
+scope.
 
 ## Browser example
 
-The package includes a framework-free browser example that exercises both
+The package includes a framework-free browser example that exercises all three
 providers without depending on AITuber OnAir Core:
 
 ```sh
@@ -24,10 +25,12 @@ npm -w @aituber-onair/transcription run example:dev
 ```
 
 Open the displayed localhost URL and grant microphone permission when starting
-a session. Web Speech needs no key. For OpenAI, enter an end-user-owned API key
-in the page. The sample connects to OpenAI directly from the browser, so avoid
-using it on a shared device. The interface supports English and Japanese and
-selects the initial display from the browser language. See the
+a session. Web Speech and Local Whisper need no key. For OpenAI, enter an
+end-user-owned API key in the page. The sample connects to OpenAI directly from
+the browser, so avoid using it on a shared device. Local Whisper requires
+WebGPU; its first start downloads model/runtime assets and caches them in the
+browser. The interface supports English and Japanese and selects the initial
+display from the browser language. See the
 [example README](https://github.com/shinshin86/aituber-onair/blob/main/packages/transcription/examples/browser-basic/README.md)
 for details.
 
@@ -56,6 +59,60 @@ await session.start();
 await session.stop();
 await session.dispose();
 ```
+
+### Local Whisper
+
+Local Whisper runs Whisper Tiny in a module worker and emits final transcripts
+only:
+
+```ts
+import { createRealtimeTranscriptionSession } from '@aituber-onair/transcription';
+
+const session = createRealtimeTranscriptionSession({
+  provider: 'local-whisper',
+  language: 'ja-JP',
+  silenceDurationMs: 500,
+});
+
+session.onTranscript(({ text, isFinal }) => {
+  if (isFinal) {
+    console.log(text);
+  }
+});
+
+session.onError((error) => {
+  console.error(error.code, error.message);
+});
+
+await session.start();
+
+// Later:
+await session.stop();
+await session.dispose();
+```
+
+Requirements and behavior:
+
+- A secure browser context (HTTPS or localhost), microphone access, Web Audio,
+  AudioWorklet, module workers, and WebGPU are required.
+- No API key is required. There is no automatic fallback to a remote provider
+  or WASM inference when WebGPU initialization fails.
+- On first use, model assets are downloaded from the Hugging Face Hub and ONNX
+  Runtime WebAssembly files are downloaded from jsDelivr. These assets are
+  cached by the browser. The initial download is approximately 120 MB.
+- Microphone audio is processed in the browser and never leaves the browser.
+  The package does not persist audio or transcripts.
+- `language` accepts a BCP 47-style hint and is optional. The default 500 ms
+  `silenceDurationMs` can be reduced to a minimum of 150 ms for faster turn
+  completion.
+
+The package normally resolves `dist/local-whisper.worker.js` relative to its
+ESM entry. If a bundler pre-bundles the package and cannot resolve that asset,
+set the advanced `workerUrl` option to the same module worker asset or an
+equivalent build. This browser example uses Vite's `?worker&url` import for that
+reason.
+
+### OpenAI Realtime
 
 OpenAI Realtime uses `gpt-live-transcribe` and browser WebRTC. Because this
 transcription model does not accept server turn detection, the package detects
@@ -114,16 +171,17 @@ are returned as typed errors and never trigger an authentication fallback.
 
 ## Provider differences
 
-| Capability | Web Speech | OpenAI Realtime |
-| --- | --- | --- |
-| Interim snapshots | Yes | Yes |
-| Multiple expected languages | No | Yes |
-| Keywords and context prompt | No | Yes |
-| Configurable delay | No | Yes |
-| Utterance boundary | Browser implementation | Browser audio-level detection |
+| Capability | Web Speech | OpenAI Realtime | Local Whisper |
+| --- | --- | --- | --- |
+| Interim snapshots | Yes | Yes | No |
+| Multiple expected languages | No | Yes | No |
+| Keywords and context prompt | No | Yes | No |
+| Configurable delay | No | Yes | Yes |
+| Utterance boundary | Browser implementation | Browser audio-level detection | Browser PCM/VAD |
 
-Both providers require a supported browser and microphone permission. OpenAI
-WebRTC also requires the Web Audio API and HTTPS or localhost. Web Speech
-availability and behavior vary by browser. Listening can incur OpenAI usage
-charges even during silence, so applications should expose state clearly and
-stop sessions when unused.
+All providers require a supported browser and microphone permission. OpenAI
+WebRTC and Local Whisper also require the Web Audio API and HTTPS or localhost;
+Local Whisper additionally requires WebGPU. Web Speech availability and
+behavior vary by browser. Listening can incur OpenAI usage charges even during
+silence, so applications should expose state clearly and stop sessions when
+unused.

--- a/packages/transcription/README.md
+++ b/packages/transcription/README.md
@@ -10,10 +10,10 @@ Provider-neutral realtime microphone transcription for AITuber OnAir.
 > release.
 
 The package supports Web Speech, OpenAI Realtime transcription over browser
-WebRTC, and local Whisper Tiny inference through WebGPU. All providers emit the
-same per-utterance snapshot events. File transcription, server WebSocket input,
-automatic chat submission, and provider fallback are intentionally out of
-scope.
+WebRTC, and local Whisper Tiny, Base, and Small inference through WebGPU. All
+providers emit the same per-utterance snapshot events. File transcription,
+server WebSocket input, automatic chat submission, and provider fallback are
+intentionally out of scope.
 
 ## Browser example
 
@@ -66,14 +66,15 @@ not.
 
 ### Local Whisper
 
-Local Whisper runs Whisper Tiny in a module worker and emits final transcripts
-only:
+Local Whisper runs the selected Whisper model in a module worker and emits
+final transcripts only:
 
 ```ts
 import { createRealtimeTranscriptionSession } from '@aituber-onair/transcription';
 
 const session = createRealtimeTranscriptionSession({
   provider: 'local-whisper',
+  model: 'tiny',
   language: 'ja-JP',
   silenceDurationMs: 500,
 });
@@ -99,20 +100,42 @@ await session.stop();
 await session.dispose();
 ```
 
+Local Whisper is less accurate than Web Speech or OpenAI Realtime. It is
+intended for use cases that prioritize requiring no API key and not sending
+microphone audio to a remote service. Choose `small` when recognition quality
+is important.
+
+| Model | First download reported by progress | Quality guide | Inference (Japanese / English) |
+| --- | ---: | --- | ---: |
+| `tiny` (default) | About 122 MB | Lower | 237.3 ms / 203.0 ms |
+| `base` | About 209 MB | Middle | 255.9 ms / 311.2 ms |
+| `small` | About 589 MB | Practical | 574.7 ms / 551.6 ms |
+
+These measurements were taken in Chrome with WebGPU using the same short
+Japanese and English microphone clips. Inference excludes capture/VAD time and
+varies by GPU. First-use download time depends on network speed and can take
+several minutes for hundreds of MB. After caching, initialization measured
+about 0.9 s for Tiny, 1.2 s for Base, and 2.5 s for Small. Download sizes are
+the sum of the latest `totalBytes` reported for each model file and do not
+include assets that do not report progress.
+
 Requirements and behavior:
 
 - A secure browser context (HTTPS or localhost), microphone access, Web Audio,
   AudioWorklet, module workers, and WebGPU are required.
 - No API key is required. There is no automatic fallback to a remote provider
   or WASM inference when WebGPU initialization fails.
-- On first use, model assets are downloaded from the Hugging Face Hub and ONNX
-  Runtime WebAssembly files are downloaded from jsDelivr. These assets are
-  cached by the browser. The initial download is approximately 120 MB.
+- On first use, the selected model assets are downloaded from the Hugging Face
+  Hub and ONNX Runtime WebAssembly files are downloaded from jsDelivr. These
+  assets are cached by the browser. Larger models take longer to download and
+  infer.
 - Microphone audio is processed in the browser and never leaves the browser.
   The package does not persist audio or transcripts.
 - `language` accepts a BCP 47-style hint and is optional. The default 500 ms
   `silenceDurationMs` can be reduced to a minimum of 150 ms for faster turn
   completion.
+- `model` accepts `tiny`, `base`, or `small` and defaults to `tiny`. Model dtype
+  is fixed to an fp32 encoder and q4 merged decoder for every size.
 - Download progress can include `file`, `loadedBytes`, `totalBytes`, and a
   normalized `progress` value from 0 to 1. Initialization and ready phases do
   not require byte totals.

--- a/packages/transcription/README.md
+++ b/packages/transcription/README.md
@@ -60,6 +60,10 @@ await session.stop();
 await session.dispose();
 ```
 
+Only providers with potentially long initialization emit `onProgress` events.
+Currently, only `local-whisper` emits them; Web Speech and OpenAI Realtime do
+not.
+
 ### Local Whisper
 
 Local Whisper runs Whisper Tiny in a module worker and emits final transcripts
@@ -78,6 +82,10 @@ session.onTranscript(({ text, isFinal }) => {
   if (isFinal) {
     console.log(text);
   }
+});
+
+session.onProgress(({ phase, progress }) => {
+  updateLoadingIndicator(phase, progress);
 });
 
 session.onError((error) => {
@@ -105,6 +113,9 @@ Requirements and behavior:
 - `language` accepts a BCP 47-style hint and is optional. The default 500 ms
   `silenceDurationMs` can be reduced to a minimum of 150 ms for faster turn
   completion.
+- Download progress can include `file`, `loadedBytes`, `totalBytes`, and a
+  normalized `progress` value from 0 to 1. Initialization and ready phases do
+  not require byte totals.
 
 The package normally resolves `dist/local-whisper.worker.js` relative to its
 ESM entry. If a bundler pre-bundles the package and cannot resolve that asset,

--- a/packages/transcription/examples/browser-basic/README.md
+++ b/packages/transcription/examples/browser-basic/README.md
@@ -16,11 +16,12 @@ Realtime and enter an API key from your own OpenAI account. The example connects
 to OpenAI directly from the browser, so avoid using it on a shared device.
 
 Use localhost or HTTPS and grant microphone access when prompted. Local Whisper
-requires WebGPU. Its first start downloads about 120 MB of model/runtime assets
-and caches them in the browser. The example aggregates known per-file totals to
-show overall download progress, then shows model initialization and hides the
-progress row when listening starts. Microphone audio stays in the browser.
-OpenAI usage may incur charges while a session is listening.
+requires WebGPU. Select Tiny (about 122 MB), Base (about 209 MB), or Small
+(about 589 MB); larger models take longer to download and infer. The default is
+Tiny. Assets are cached in the browser. The example aggregates known per-file
+totals to show overall download progress, then shows model initialization and
+hides the progress row when listening starts. Microphone audio stays in the
+browser. OpenAI usage may incur charges while a session is listening.
 
 ## Local Whisper worker URL
 

--- a/packages/transcription/examples/browser-basic/README.md
+++ b/packages/transcription/examples/browser-basic/README.md
@@ -11,9 +11,23 @@ From the repository root:
 npm -w @aituber-onair/transcription run example:dev
 ```
 
-Web Speech requires no API key. To use OpenAI, select OpenAI Realtime and enter
-an API key from your own OpenAI account. The example connects to OpenAI directly
-from the browser, so avoid using it on a shared device.
+Web Speech and Local Whisper require no API key. To use OpenAI, select OpenAI
+Realtime and enter an API key from your own OpenAI account. The example connects
+to OpenAI directly from the browser, so avoid using it on a shared device.
 
-Use localhost or HTTPS and grant microphone access when prompted. OpenAI usage
-may incur charges while a session is listening.
+Use localhost or HTTPS and grant microphone access when prompted. Local Whisper
+requires WebGPU. Its first start downloads about 120 MB of model/runtime assets
+and caches them in the browser; microphone audio stays in the browser. OpenAI
+usage may incur charges while a session is listening.
+
+## Local Whisper worker URL
+
+This example aliases the package entry to `src/index.ts`, so the published
+`dist/local-whisper.worker.js` asset is not available during local development.
+It therefore imports the source worker with Vite's `?worker&url` query and
+passes that URL to the Local Whisper session through `workerUrl`. The session
+creates the module worker only when Local Whisper is started; loading the page
+or selecting another provider does not initialize Transformers.js. Vite handles
+the same import during development and emits a dedicated worker chunk in
+production builds. The Vite worker output format is set to `es`; no dependency
+optimization exclusion is required.

--- a/packages/transcription/examples/browser-basic/README.md
+++ b/packages/transcription/examples/browser-basic/README.md
@@ -17,8 +17,10 @@ to OpenAI directly from the browser, so avoid using it on a shared device.
 
 Use localhost or HTTPS and grant microphone access when prompted. Local Whisper
 requires WebGPU. Its first start downloads about 120 MB of model/runtime assets
-and caches them in the browser; microphone audio stays in the browser. OpenAI
-usage may incur charges while a session is listening.
+and caches them in the browser. The example aggregates known per-file totals to
+show overall download progress, then shows model initialization and hides the
+progress row when listening starts. Microphone audio stays in the browser.
+OpenAI usage may incur charges while a session is listening.
 
 ## Local Whisper worker URL
 

--- a/packages/transcription/examples/browser-basic/index.html
+++ b/packages/transcription/examples/browser-basic/index.html
@@ -135,7 +135,16 @@ An English conversation recorded through a microphone.</textarea
         </div>
 
         <div id="local-whisper-fields" hidden>
-          <div class="field-grid">
+          <div class="field-grid local-whisper-grid">
+            <label class="field">
+              <span data-i18n="localWhisperModel">Model</span>
+              <select id="local-whisper-model">
+                <option value="tiny" selected>Tiny</option>
+                <option value="base">Base</option>
+                <option value="small">Small</option>
+              </select>
+              <small id="local-whisper-model-hint"></small>
+            </label>
             <label class="field">
               <span data-i18n="localWhisperLanguage">Language hint</span>
               <input id="local-whisper-language" value="ja-JP" />
@@ -159,8 +168,8 @@ An English conversation recorded through a microphone.</textarea
             </label>
           </div>
           <p class="notice info" data-i18n="localWhisperNotice">
-            WebGPU is required. The first start downloads about 120 MB and
-            caches it in the browser. Microphone audio stays in this browser.
+            WebGPU is required. Larger models download more data on first use
+            and infer more slowly. Microphone audio stays in this browser.
           </p>
         </div>
       </section>

--- a/packages/transcription/examples/browser-basic/index.html
+++ b/packages/transcription/examples/browser-basic/index.html
@@ -176,6 +176,15 @@ An English conversation recorded through a microphone.</textarea
           <span id="state-badge" class="badge state-idle">Idle</span>
         </div>
 
+        <p
+          id="progress-message"
+          class="initialization-progress"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          hidden
+        ></p>
+
         <div class="actions">
           <button id="start-button" class="primary" type="button">
             <span data-i18n="startMicrophone">Start transcription</span>

--- a/packages/transcription/examples/browser-basic/index.html
+++ b/packages/transcription/examples/browser-basic/index.html
@@ -7,6 +7,7 @@
       name="description"
       content="Minimal browser example for @aituber-onair/transcription"
     />
+    <link rel="icon" href="data:," />
     <title>AITuber OnAir Transcription</title>
   </head>
   <body>
@@ -24,8 +25,9 @@
         </div>
         <h1 data-i18n="heroTitle">Try realtime transcription</h1>
         <p class="hero-copy" data-i18n="heroCopy">
-          Transcribe microphone audio with Web Speech or OpenAI Realtime.
-          Results are not submitted as chat messages automatically.
+          Transcribe microphone audio with Web Speech, OpenAI Realtime, or
+          Local Whisper. Results are not submitted as chat messages
+          automatically.
         </p>
       </header>
 
@@ -47,6 +49,7 @@
           <select id="provider">
             <option value="web-speech">Web Speech</option>
             <option value="openai-realtime">OpenAI Realtime</option>
+            <option value="local-whisper">Local Whisper</option>
           </select>
         </label>
 
@@ -128,6 +131,36 @@ An English conversation recorded through a microphone.</textarea
           <p class="notice cost" data-i18n="openAICost">
             OpenAI usage may be billed while transcription is running,
             including during silence.
+          </p>
+        </div>
+
+        <div id="local-whisper-fields" hidden>
+          <div class="field-grid">
+            <label class="field">
+              <span data-i18n="localWhisperLanguage">Language hint</span>
+              <input id="local-whisper-language" value="ja-JP" />
+              <small data-i18n="localWhisperLanguageHint">
+                Optional BCP 47 language code. Leave blank for automatic
+                detection.
+              </small>
+            </label>
+            <label class="field">
+              <span data-i18n="localWhisperSilence">End silence (ms)</span>
+              <input
+                id="local-whisper-silence"
+                type="number"
+                min="150"
+                step="50"
+                value="500"
+              />
+              <small data-i18n="localWhisperSilenceHint">
+                Minimum 150 ms. Lower values finalize speech sooner.
+              </small>
+            </label>
+          </div>
+          <p class="notice info" data-i18n="localWhisperNotice">
+            WebGPU is required. The first start downloads about 120 MB and
+            caches it in the browser. Microphone audio stays in this browser.
           </p>
         </div>
       </section>

--- a/packages/transcription/examples/browser-basic/src/i18n.test.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.test.ts
@@ -26,6 +26,13 @@ describe('browser example i18n', () => {
       'マイクから入力された日本語の会話です。',
     ]);
     expect(translate('ja', 'localWhisperNotice')).toContain('約120MB');
+    expect(translate('ja', 'progressDownloadModel')).toBe(
+      'モデルをダウンロード中(初回のみ・約120MB)'
+    );
+    expect(translate('ja', 'progressInitializeModel')).toBe('モデルを初期化中');
+    expect(translate('en', 'progressDownloadModel')).toContain(
+      'first use only'
+    );
     expect(translate('en', 'localWhisperNotice')).toContain(
       'Microphone audio stays in this browser.'
     );

--- a/packages/transcription/examples/browser-basic/src/i18n.test.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.test.ts
@@ -25,16 +25,25 @@ describe('browser example i18n', () => {
       'An English conversation recorded through a microphone.',
       'マイクから入力された日本語の会話です。',
     ]);
-    expect(translate('ja', 'localWhisperNotice')).toContain('約120MB');
-    expect(translate('ja', 'progressDownloadModel')).toBe(
-      'モデルをダウンロード中(初回のみ・約120MB)'
-    );
+    expect(translate('ja', 'localWhisperModelTinyHint')).toContain('約122MB');
+    expect(translate('ja', 'localWhisperModelBaseHint')).toContain('約209MB');
+    expect(translate('ja', 'localWhisperModelSmallHint')).toContain('約589MB');
+    expect(translate('ja', 'progressDownloadModel')).toContain('初回のみ');
     expect(translate('ja', 'progressInitializeModel')).toBe('モデルを初期化中');
     expect(translate('en', 'progressDownloadModel')).toContain(
       'first use only'
     );
     expect(translate('en', 'localWhisperNotice')).toContain(
       'Microphone audio stays in this browser.'
+    );
+    expect(translate('en', 'localWhisperModelTinyHint')).toContain(
+      'lower recognition quality'
+    );
+    expect(translate('en', 'localWhisperModelBaseHint')).toContain(
+      'balancing recognition quality and speed'
+    );
+    expect(translate('en', 'localWhisperModelSmallHint')).toContain(
+      'inference can be slow'
     );
   });
 });

--- a/packages/transcription/examples/browser-basic/src/i18n.test.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.test.ts
@@ -25,5 +25,9 @@ describe('browser example i18n', () => {
       'An English conversation recorded through a microphone.',
       'マイクから入力された日本語の会話です。',
     ]);
+    expect(translate('ja', 'localWhisperNotice')).toContain('約120MB');
+    expect(translate('en', 'localWhisperNotice')).toContain(
+      'Microphone audio stays in this browser.'
+    );
   });
 });

--- a/packages/transcription/examples/browser-basic/src/i18n.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.ts
@@ -60,6 +60,8 @@ const englishMessages = {
   stateStopping: 'Stopping',
   stateError: 'Error',
   stateDisposed: 'Disposed',
+  progressDownloadModel: 'Downloading model (first use only, about 120 MB)',
+  progressInitializeModel: 'Initializing model',
   errorUnsupportedProvider:
     'The selected transcription provider is unavailable in this browser.',
   errorInsecureContext: 'Microphone transcription requires HTTPS or localhost.',
@@ -134,6 +136,8 @@ const japaneseMessages: Messages = {
   stateStopping: '停止中',
   stateError: 'エラー',
   stateDisposed: '終了済み',
+  progressDownloadModel: 'モデルをダウンロード中(初回のみ・約120MB)',
+  progressInitializeModel: 'モデルを初期化中',
   errorUnsupportedProvider:
     '選択した文字起こし方式は、このブラウザでは利用できません。',
   errorInsecureContext:

--- a/packages/transcription/examples/browser-basic/src/i18n.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.ts
@@ -44,8 +44,15 @@ const englishMessages = {
   localWhisperSilence: 'End silence (ms)',
   localWhisperSilenceHint:
     'Minimum 150 ms. Lower values finalize speech sooner.',
+  localWhisperModel: 'Model',
+  localWhisperModelTinyHint:
+    'Lightweight, about 122 MB, with lower recognition quality.',
+  localWhisperModelBaseHint:
+    'About 209 MB, balancing recognition quality and speed.',
+  localWhisperModelSmallHint:
+    'About 589 MB, practical recognition quality; inference can be slow depending on the GPU.',
   localWhisperNotice:
-    'WebGPU is required. The first start downloads about 120 MB and caches it in the browser. Microphone audio stays in this browser.',
+    'WebGPU is required. Larger models download more data on first use and infer more slowly. Microphone audio stays in this browser.',
   liveOutput: 'Transcription results',
   startMicrophone: 'Start transcription',
   stop: 'Stop',
@@ -60,7 +67,7 @@ const englishMessages = {
   stateStopping: 'Stopping',
   stateError: 'Error',
   stateDisposed: 'Disposed',
-  progressDownloadModel: 'Downloading model (first use only, about 120 MB)',
+  progressDownloadModel: 'Downloading selected model (first use only)',
   progressInitializeModel: 'Initializing model',
   errorUnsupportedProvider:
     'The selected transcription provider is unavailable in this browser.',
@@ -120,8 +127,13 @@ const japaneseMessages: Messages = {
     '任意のBCP 47言語コードです。空欄にすると自動判定します。',
   localWhisperSilence: '発話終了の無音（ms）',
   localWhisperSilenceHint: '最小150msです。小さくすると発話を早く確定します。',
+  localWhisperModel: 'モデル',
+  localWhisperModelTinyHint: '軽量・約122MB・認識品質は低めです。',
+  localWhisperModelBaseHint: '約209MB・認識品質と速度の中間です。',
+  localWhisperModelSmallHint:
+    '約589MB・実用品質ですが、GPUによっては推論が遅くなります。',
   localWhisperNotice:
-    'WebGPUが必要です。初回開始時に約120MBをダウンロードし、ブラウザにキャッシュします。マイク音声がブラウザ外へ送信されることはありません。',
+    'WebGPUが必要です。大きいモデルほど初回ダウンロード量が増え、推論も遅くなります。マイク音声がブラウザ外へ送信されることはありません。',
   liveOutput: '文字起こし結果',
   startMicrophone: '文字起こしを開始',
   stop: '停止',
@@ -136,7 +148,7 @@ const japaneseMessages: Messages = {
   stateStopping: '停止中',
   stateError: 'エラー',
   stateDisposed: '終了済み',
-  progressDownloadModel: 'モデルをダウンロード中(初回のみ・約120MB)',
+  progressDownloadModel: '選択したモデルをダウンロード中（初回のみ）',
   progressInitializeModel: 'モデルを初期化中',
   errorUnsupportedProvider:
     '選択した文字起こし方式は、このブラウザでは利用できません。',

--- a/packages/transcription/examples/browser-basic/src/i18n.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.ts
@@ -8,7 +8,7 @@ const englishMessages = {
   displayLanguage: 'Language',
   heroTitle: 'Try realtime transcription',
   heroCopy:
-    'Transcribe microphone audio with Web Speech or OpenAI Realtime. Results are not submitted as chat messages automatically.',
+    'Transcribe microphone audio with Web Speech, OpenAI Realtime, or Local Whisper. Results are not submitted as chat messages automatically.',
   sessionSettings: 'Transcription settings',
   checkingSupport: 'Checking availability',
   browserSupported: 'Available',
@@ -38,6 +38,14 @@ const englishMessages = {
   contextPromptValue: 'An English conversation recorded through a microphone.',
   openAICost:
     'OpenAI usage may be billed while transcription is running, including during silence.',
+  localWhisperLanguage: 'Language hint',
+  localWhisperLanguageHint:
+    'Optional BCP 47 language code. Leave blank for automatic detection.',
+  localWhisperSilence: 'End silence (ms)',
+  localWhisperSilenceHint:
+    'Minimum 150 ms. Lower values finalize speech sooner.',
+  localWhisperNotice:
+    'WebGPU is required. The first start downloads about 120 MB and caches it in the browser. Microphone audio stays in this browser.',
   liveOutput: 'Transcription results',
   startMicrophone: 'Start transcription',
   stop: 'Stop',
@@ -54,8 +62,7 @@ const englishMessages = {
   stateDisposed: 'Disposed',
   errorUnsupportedProvider:
     'The selected transcription provider is unavailable in this browser.',
-  errorInsecureContext:
-    'OpenAI Realtime transcription requires HTTPS or localhost.',
+  errorInsecureContext: 'Microphone transcription requires HTTPS or localhost.',
   errorPermissionDenied: 'Microphone permission was denied.',
   errorNoSpeech: 'No speech was detected.',
   errorAuthenticationFailed:
@@ -78,7 +85,7 @@ const japaneseMessages: Messages = {
   displayLanguage: '表示言語',
   heroTitle: 'リアルタイム文字起こしを試す',
   heroCopy:
-    'Web SpeechまたはOpenAI Realtimeで、マイク音声をリアルタイムに文字起こしできます。結果がチャットへ自動送信されることはありません。',
+    'Web Speech、OpenAI Realtime、Local Whisperで、マイク音声をリアルタイムに文字起こしできます。結果がチャットへ自動送信されることはありません。',
   sessionSettings: '文字起こし設定',
   checkingSupport: '利用可否を確認中',
   browserSupported: '利用可能',
@@ -106,6 +113,13 @@ const japaneseMessages: Messages = {
   contextPromptValue: 'マイクから入力された日本語の会話です。',
   openAICost:
     '文字起こし中は、無音の時間を含めてOpenAIの利用料金が発生する場合があります。',
+  localWhisperLanguage: '言語ヒント',
+  localWhisperLanguageHint:
+    '任意のBCP 47言語コードです。空欄にすると自動判定します。',
+  localWhisperSilence: '発話終了の無音（ms）',
+  localWhisperSilenceHint: '最小150msです。小さくすると発話を早く確定します。',
+  localWhisperNotice:
+    'WebGPUが必要です。初回開始時に約120MBをダウンロードし、ブラウザにキャッシュします。マイク音声がブラウザ外へ送信されることはありません。',
   liveOutput: '文字起こし結果',
   startMicrophone: '文字起こしを開始',
   stop: '停止',
@@ -123,7 +137,7 @@ const japaneseMessages: Messages = {
   errorUnsupportedProvider:
     '選択した文字起こし方式は、このブラウザでは利用できません。',
   errorInsecureContext:
-    'OpenAI Realtimeを使うには、HTTPSまたはlocalhostでこのページを開いてください。',
+    'マイク文字起こしを使うには、HTTPSまたはlocalhostでこのページを開いてください。',
   errorPermissionDenied:
     'マイクを使用できません。ブラウザの権限設定を確認してください。',
   errorNoSpeech: '音声を検出できませんでした。',

--- a/packages/transcription/examples/browser-basic/src/main.ts
+++ b/packages/transcription/examples/browser-basic/src/main.ts
@@ -9,6 +9,7 @@ import {
   type TranscriptionProviderName,
   type TranscriptionState,
 } from '@aituber-onair/transcription';
+import localWhisperWorkerUrl from '../../../src/providers/local-whisper.worker.ts?worker&url';
 import {
   detectDisplayLanguage,
   isDisplayLanguage,
@@ -37,6 +38,11 @@ const openAILanguages = element<HTMLInputElement>('#openai-languages');
 const openAIKeywords = element<HTMLInputElement>('#openai-keywords');
 const openAIPrompt = element<HTMLTextAreaElement>('#openai-prompt');
 const openAIDelay = element<HTMLSelectElement>('#openai-delay');
+const localWhisperFields = element<HTMLDivElement>('#local-whisper-fields');
+const localWhisperLanguage = element<HTMLInputElement>(
+  '#local-whisper-language'
+);
+const localWhisperSilence = element<HTMLInputElement>('#local-whisper-silence');
 const stateBadge = element<HTMLSpanElement>('#state-badge');
 const startButton = element<HTMLButtonElement>('#start-button');
 const stopButton = element<HTMLButtonElement>('#stop-button');
@@ -180,26 +186,34 @@ function handleTranscript(update: TranscriptUpdate): void {
 }
 
 function createSession(): RealtimeTranscriptionSession {
-  if (selectedProvider() === 'web-speech') {
-    return createRealtimeTranscriptionSession({
-      provider: 'web-speech',
-      language: webSpeechLanguage.value.trim() || 'ja-JP',
-      continuous: true,
-    });
+  switch (selectedProvider()) {
+    case 'web-speech':
+      return createRealtimeTranscriptionSession({
+        provider: 'web-speech',
+        language: webSpeechLanguage.value.trim() || 'ja-JP',
+        continuous: true,
+      });
+    case 'openai-realtime':
+      return createRealtimeTranscriptionSession({
+        provider: 'openai-realtime',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => openAIApiKey.value,
+          acknowledgeBrowserKeyRisk: true,
+        },
+        languages: commaSeparated(openAILanguages.value),
+        keywords: commaSeparated(openAIKeywords.value),
+        prompt: openAIPrompt.value,
+        delay: openAIDelay.value as TranscriptionDelay,
+      });
+    case 'local-whisper':
+      return createRealtimeTranscriptionSession({
+        provider: 'local-whisper',
+        language: localWhisperLanguage.value.trim() || undefined,
+        silenceDurationMs: Number(localWhisperSilence.value),
+        workerUrl: localWhisperWorkerUrl,
+      });
   }
-
-  return createRealtimeTranscriptionSession({
-    provider: 'openai-realtime',
-    auth: {
-      type: 'browser-api-key',
-      getApiKey: async () => openAIApiKey.value,
-      acknowledgeBrowserKeyRisk: true,
-    },
-    languages: commaSeparated(openAILanguages.value),
-    keywords: commaSeparated(openAIKeywords.value),
-    prompt: openAIPrompt.value,
-    delay: openAIDelay.value as TranscriptionDelay,
-  });
 }
 
 async function disposeSession(): Promise<void> {
@@ -252,9 +266,11 @@ function clearTranscripts(): void {
 function syncSettings(): void {
   const provider = selectedProvider();
   const openAISelected = provider === 'openai-realtime';
+  const localWhisperSelected = provider === 'local-whisper';
 
-  webSpeechFields.hidden = openAISelected;
+  webSpeechFields.hidden = openAISelected || localWhisperSelected;
   openAIFields.hidden = !openAISelected;
+  localWhisperFields.hidden = !localWhisperSelected;
 
   const supported = isTranscriptionProviderSupported(provider);
   supportBadge.textContent = translate(

--- a/packages/transcription/examples/browser-basic/src/main.ts
+++ b/packages/transcription/examples/browser-basic/src/main.ts
@@ -7,6 +7,7 @@ import {
   type TranscriptionError,
   type TranscriptionErrorCode,
   type TranscriptionProviderName,
+  type TranscriptionProgress,
   type TranscriptionState,
 } from '@aituber-onair/transcription';
 import localWhisperWorkerUrl from '../../../src/providers/local-whisper.worker.ts?worker&url';
@@ -44,6 +45,7 @@ const localWhisperLanguage = element<HTMLInputElement>(
 );
 const localWhisperSilence = element<HTMLInputElement>('#local-whisper-silence');
 const stateBadge = element<HTMLSpanElement>('#state-badge');
+const progressMessage = element<HTMLParagraphElement>('#progress-message');
 const startButton = element<HTMLButtonElement>('#start-button');
 const stopButton = element<HTMLButtonElement>('#stop-button');
 const clearButton = element<HTMLButtonElement>('#clear-button');
@@ -55,6 +57,11 @@ let session: RealtimeTranscriptionSession | null = null;
 let displayLanguage: DisplayLanguage = 'en';
 let activeError: TranscriptionError | Error | null = null;
 const interimByUtterance = new Map<string, string>();
+const downloadProgressByFile = new Map<
+  string,
+  Pick<TranscriptionProgress, 'loadedBytes' | 'totalBytes' | 'progress'>
+>();
+let activeProgress: TranscriptionProgress | null = null;
 
 const stateTranslationKeys: Record<TranscriptionState, TranslationKey> = {
   idle: 'stateIdle',
@@ -147,6 +154,69 @@ function setError(error: TranscriptionError | Error | null): void {
   errorMessage.hidden = false;
 }
 
+function aggregateDownloadPercentage(): number | null {
+  let loadedBytes = 0;
+  let totalBytes = 0;
+
+  for (const fileProgress of downloadProgressByFile.values()) {
+    const fileTotal = fileProgress.totalBytes;
+    if (fileTotal === undefined || fileTotal <= 0) continue;
+    const fileLoaded =
+      fileProgress.loadedBytes ??
+      (fileProgress.progress !== undefined
+        ? fileProgress.progress * fileTotal
+        : 0);
+    loadedBytes += Math.min(fileTotal, Math.max(0, fileLoaded));
+    totalBytes += fileTotal;
+  }
+
+  return totalBytes > 0 ? Math.round((loadedBytes / totalBytes) * 100) : null;
+}
+
+function renderProgress(): void {
+  if (!activeProgress || activeProgress.phase === 'ready') {
+    progressMessage.hidden = true;
+    progressMessage.textContent = '';
+    return;
+  }
+
+  if (activeProgress.phase === 'initialize') {
+    progressMessage.textContent = translate(
+      displayLanguage,
+      'progressInitializeModel'
+    );
+    progressMessage.hidden = false;
+    return;
+  }
+
+  const percentage = aggregateDownloadPercentage();
+  const suffix = percentage === null ? '' : ` ${percentage}%`;
+  progressMessage.textContent = `${translate(
+    displayLanguage,
+    'progressDownloadModel'
+  )}${suffix}`;
+  progressMessage.hidden = false;
+}
+
+function handleProgress(progress: TranscriptionProgress): void {
+  activeProgress = progress;
+  if (progress.phase === 'download' && progress.file) {
+    const current = downloadProgressByFile.get(progress.file);
+    downloadProgressByFile.set(progress.file, {
+      loadedBytes: progress.loadedBytes ?? current?.loadedBytes,
+      totalBytes: progress.totalBytes ?? current?.totalBytes,
+      progress: progress.progress ?? current?.progress,
+    });
+  }
+  renderProgress();
+}
+
+function resetProgress(): void {
+  activeProgress = null;
+  downloadProgressByFile.clear();
+  renderProgress();
+}
+
 function renderState(state: TranscriptionState): void {
   stateBadge.textContent = translate(
     displayLanguage,
@@ -159,6 +229,7 @@ function renderState(state: TranscriptionState): void {
   startButton.disabled =
     busy || !isTranscriptionProviderSupported(selectedProvider());
   stopButton.disabled = !active;
+  if (state !== 'connecting') resetProgress();
 }
 
 function renderInterim(): void {
@@ -220,6 +291,7 @@ async function disposeSession(): Promise<void> {
   const current = session;
   session = null;
   if (current) await current.dispose();
+  resetProgress();
 }
 
 async function startSession(): Promise<void> {
@@ -231,6 +303,7 @@ async function startSession(): Promise<void> {
     nextSession = createSession();
     session = nextSession;
     nextSession.onTranscript(handleTranscript);
+    nextSession.onProgress(handleProgress);
     nextSession.onStateChange(renderState);
     nextSession.onError(setError);
     await nextSession.start();
@@ -291,6 +364,7 @@ function applyDisplayLanguage(language: DisplayLanguage): void {
     emptyTranscript.textContent = translate(language, 'noFinalTranscript');
   }
   syncSettings();
+  renderProgress();
   if (activeError) setError(activeError);
 }
 

--- a/packages/transcription/examples/browser-basic/src/main.ts
+++ b/packages/transcription/examples/browser-basic/src/main.ts
@@ -1,6 +1,7 @@
 import {
   createRealtimeTranscriptionSession,
   isTranscriptionProviderSupported,
+  type LocalWhisperModelSize,
   type RealtimeTranscriptionSession,
   type TranscriptUpdate,
   type TranscriptionDelay,
@@ -40,6 +41,8 @@ const openAIKeywords = element<HTMLInputElement>('#openai-keywords');
 const openAIPrompt = element<HTMLTextAreaElement>('#openai-prompt');
 const openAIDelay = element<HTMLSelectElement>('#openai-delay');
 const localWhisperFields = element<HTMLDivElement>('#local-whisper-fields');
+const localWhisperModel = element<HTMLSelectElement>('#local-whisper-model');
+const localWhisperModelHint = element<HTMLElement>('#local-whisper-model-hint');
 const localWhisperLanguage = element<HTMLInputElement>(
   '#local-whisper-language'
 );
@@ -85,6 +88,13 @@ const errorTranslationKeys: Record<TranscriptionErrorCode, TranslationKey> = {
   'session-disposed': 'errorSessionDisposed',
 };
 
+const localWhisperModelHintKeys: Record<LocalWhisperModelSize, TranslationKey> =
+  {
+    tiny: 'localWhisperModelTinyHint',
+    base: 'localWhisperModelBaseHint',
+    small: 'localWhisperModelSmallHint',
+  };
+
 function commaSeparated(value: string): string[] {
   return value
     .split(',')
@@ -94,6 +104,19 @@ function commaSeparated(value: string): string[] {
 
 function selectedProvider(): TranscriptionProviderName {
   return providerSelect.value as TranscriptionProviderName;
+}
+
+function selectedLocalWhisperModel(): LocalWhisperModelSize {
+  const model = localWhisperModel.value;
+  if (model === 'base' || model === 'small') return model;
+  return 'tiny';
+}
+
+function renderLocalWhisperModelHint(): void {
+  localWhisperModelHint.textContent = translate(
+    displayLanguage,
+    localWhisperModelHintKeys[selectedLocalWhisperModel()]
+  );
 }
 
 function translationKey(
@@ -229,6 +252,7 @@ function renderState(state: TranscriptionState): void {
   startButton.disabled =
     busy || !isTranscriptionProviderSupported(selectedProvider());
   stopButton.disabled = !active;
+  localWhisperModel.disabled = busy;
   if (state !== 'connecting') resetProgress();
 }
 
@@ -280,6 +304,7 @@ function createSession(): RealtimeTranscriptionSession {
     case 'local-whisper':
       return createRealtimeTranscriptionSession({
         provider: 'local-whisper',
+        model: selectedLocalWhisperModel(),
         language: localWhisperLanguage.value.trim() || undefined,
         silenceDurationMs: Number(localWhisperSilence.value),
         workerUrl: localWhisperWorkerUrl,
@@ -344,6 +369,7 @@ function syncSettings(): void {
   webSpeechFields.hidden = openAISelected || localWhisperSelected;
   openAIFields.hidden = !openAISelected;
   localWhisperFields.hidden = !localWhisperSelected;
+  renderLocalWhisperModelHint();
 
   const supported = isTranscriptionProviderSupported(provider);
   supportBadge.textContent = translate(
@@ -375,6 +401,7 @@ async function resetSessionForSettings(): Promise<void> {
 }
 
 providerSelect.addEventListener('change', () => void resetSessionForSettings());
+localWhisperModel.addEventListener('change', renderLocalWhisperModelHint);
 displayLanguageSelect.addEventListener('change', () => {
   if (isDisplayLanguage(displayLanguageSelect.value)) {
     applyDisplayLanguage(displayLanguageSelect.value);

--- a/packages/transcription/examples/browser-basic/src/style.css
+++ b/packages/transcription/examples/browser-basic/src/style.css
@@ -226,6 +226,10 @@ textarea:focus {
   gap: 14px;
 }
 
+.local-whisper-grid {
+  grid-template-columns: 0.85fr 1fr 0.8fr;
+}
+
 .field-grid > .field {
   align-content: start;
 }

--- a/packages/transcription/examples/browser-basic/src/style.css
+++ b/packages/transcription/examples/browser-basic/src/style.css
@@ -167,6 +167,17 @@ h3 {
   color: #92400e;
 }
 
+.initialization-progress {
+  margin: -8px 0 18px;
+  padding: 11px 13px;
+  border-radius: 10px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
 .field {
   display: grid;
   gap: 7px;

--- a/packages/transcription/examples/browser-basic/vite.config.ts
+++ b/packages/transcription/examples/browser-basic/vite.config.ts
@@ -8,6 +8,9 @@ const packageEntry = fileURLToPath(
 
 export default defineConfig({
   root: exampleRoot,
+  worker: {
+    format: 'es',
+  },
   resolve: {
     alias: {
       '@aituber-onair/transcription': packageEntry,

--- a/packages/transcription/package.json
+++ b/packages/transcription/package.json
@@ -18,7 +18,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "npm run build:package && npm run example:build",
-    "build:package": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean --out-dir dist",
+    "build:package": "tsup",
     "example:build": "tsc --project examples/browser-basic/tsconfig.json --noEmit && vite build --config examples/browser-basic/vite.config.ts",
     "example:dev": "vite --config examples/browser-basic/vite.config.ts",
     "typecheck": "tsc --noEmit && tsc --project examples/browser-basic/tsconfig.json --noEmit",
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@huggingface/transformers": "4.2.0",
     "@types/node": "^18.15.0",
     "@vitest/coverage-v8": "^1.3.1",
     "jsdom": "^22.1.0",

--- a/packages/transcription/package.json
+++ b/packages/transcription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/transcription",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Provider-neutral realtime transcription for AITuber OnAir",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/transcription/src/BaseRealtimeTranscriptionSession.ts
+++ b/packages/transcription/src/BaseRealtimeTranscriptionSession.ts
@@ -4,6 +4,7 @@ import type {
   TranscriptUpdate,
   TranscriptionCapabilities,
   TranscriptionError,
+  TranscriptionProgress,
   TranscriptionProviderName,
   TranscriptionState,
 } from './types';
@@ -17,6 +18,9 @@ export abstract class BaseRealtimeTranscriptionSession
   private currentState: TranscriptionState = 'idle';
   private readonly transcriptListeners = new Set<
     (update: TranscriptUpdate) => void
+  >();
+  private readonly progressListeners = new Set<
+    (progress: TranscriptionProgress) => void
   >();
   private readonly stateListeners = new Set<
     (state: TranscriptionState) => void
@@ -46,6 +50,11 @@ export abstract class BaseRealtimeTranscriptionSession
     return () => this.transcriptListeners.delete(listener);
   }
 
+  onProgress(listener: (progress: TranscriptionProgress) => void): () => void {
+    this.progressListeners.add(listener);
+    return () => this.progressListeners.delete(listener);
+  }
+
   onStateChange(listener: (state: TranscriptionState) => void): () => void {
     this.stateListeners.add(listener);
     return () => this.stateListeners.delete(listener);
@@ -67,6 +76,10 @@ export abstract class BaseRealtimeTranscriptionSession
     for (const listener of this.transcriptListeners) listener(update);
   }
 
+  protected emitProgress(progress: TranscriptionProgress): void {
+    for (const listener of this.progressListeners) listener(progress);
+  }
+
   protected emitError(error: TranscriptionError): void {
     for (const listener of this.errorListeners) listener(error);
   }
@@ -83,6 +96,7 @@ export abstract class BaseRealtimeTranscriptionSession
 
   protected clearListeners(): void {
     this.transcriptListeners.clear();
+    this.progressListeners.clear();
     this.stateListeners.clear();
     this.errorListeners.clear();
   }

--- a/packages/transcription/src/createRealtimeTranscriptionSession.ts
+++ b/packages/transcription/src/createRealtimeTranscriptionSession.ts
@@ -2,14 +2,25 @@ import type {
   RealtimeTranscriptionOptions,
   RealtimeTranscriptionSession,
 } from './types';
+import { LocalWhisperTranscriptionSession } from './providers/LocalWhisperTranscriptionSession';
 import { OpenAIRealtimeTranscriptionSession } from './providers/OpenAIRealtimeTranscriptionSession';
 import { WebSpeechTranscriptionSession } from './providers/WebSpeechTranscriptionSession';
 
 export function createRealtimeTranscriptionSession(
   options: RealtimeTranscriptionOptions
 ): RealtimeTranscriptionSession {
-  if (options.provider === 'web-speech') {
-    return new WebSpeechTranscriptionSession(options);
+  switch (options.provider) {
+    case 'web-speech':
+      return new WebSpeechTranscriptionSession(options);
+    case 'openai-realtime':
+      return new OpenAIRealtimeTranscriptionSession(options);
+    case 'local-whisper':
+      return new LocalWhisperTranscriptionSession(options);
+    default: {
+      const exhaustiveProvider: never = options;
+      throw new Error(
+        `Unsupported transcription options: ${exhaustiveProvider}`
+      );
+    }
   }
-  return new OpenAIRealtimeTranscriptionSession(options);
 }

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -2,6 +2,7 @@ export { createRealtimeTranscriptionSession } from './createRealtimeTranscriptio
 export { TranscriptionSessionError } from './errors';
 export { isTranscriptionProviderSupported } from './support';
 export type {
+  LocalWhisperTranscriptionOptions,
   OpenAIRealtimeAuth,
   OpenAIRealtimeTranscriptionOptions,
   RealtimeTranscriptionOptions,

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -13,6 +13,7 @@ export type {
   TranscriptionError,
   TranscriptionErrorCode,
   TranscriptionProviderName,
+  TranscriptionProgress,
   TranscriptionState,
   WebSpeechTranscriptionOptions,
 } from './types';

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -2,6 +2,7 @@ export { createRealtimeTranscriptionSession } from './createRealtimeTranscriptio
 export { TranscriptionSessionError } from './errors';
 export { isTranscriptionProviderSupported } from './support';
 export type {
+  LocalWhisperModelSize,
   LocalWhisperTranscriptionOptions,
   OpenAIRealtimeAuth,
   OpenAIRealtimeTranscriptionOptions,

--- a/packages/transcription/src/providers/BrowserPcmTurnCapture.ts
+++ b/packages/transcription/src/providers/BrowserPcmTurnCapture.ts
@@ -1,0 +1,197 @@
+import { PcmTurnAssembler, type CapturedAudioTurn } from './PcmTurnAssembler';
+
+const TARGET_SAMPLE_RATE = 16_000;
+const RMS_THRESHOLD = 0.015;
+const MIN_SPEECH_DURATION_MS = 150;
+const PRE_ROLL_MS = 200;
+const MAX_UTTERANCE_MS = 30_000;
+const WORKLET_PROCESSOR_NAME = 'aituber-pcm-capture';
+
+const WORKLET_SOURCE = `
+class AITuberPcmCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.targetSampleCount = Math.max(128, Math.round(sampleRate * 0.032));
+    this.buffer = new Float32Array(this.targetSampleCount);
+    this.bufferOffset = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    const channel = input && input[0];
+    if (channel && channel.length > 0) {
+      let sourceOffset = 0;
+      while (sourceOffset < channel.length) {
+        const copyCount = Math.min(
+          channel.length - sourceOffset,
+          this.targetSampleCount - this.bufferOffset
+        );
+        this.buffer.set(
+          channel.subarray(sourceOffset, sourceOffset + copyCount),
+          this.bufferOffset
+        );
+        sourceOffset += copyCount;
+        this.bufferOffset += copyCount;
+
+        if (this.bufferOffset === this.targetSampleCount) {
+          const chunk = this.buffer;
+          this.port.postMessage(chunk, [chunk.buffer]);
+          this.buffer = new Float32Array(this.targetSampleCount);
+          this.bufferOffset = 0;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor('${WORKLET_PROCESSOR_NAME}', AITuberPcmCaptureProcessor);
+`;
+
+type AudioContextConstructor = new (
+  contextOptions?: AudioContextOptions
+) => AudioContext;
+
+interface BrowserAudioWindow extends Window {
+  AudioContext?: AudioContextConstructor;
+  webkitAudioContext?: AudioContextConstructor;
+}
+
+export interface BrowserPcmTurnCaptureOptions {
+  silenceDurationMs: number;
+  onTurn: (turn: CapturedAudioTurn) => void;
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const browser = window as BrowserAudioWindow;
+  return browser.AudioContext ?? browser.webkitAudioContext;
+}
+
+function createAudioContext(
+  AudioContextClass: AudioContextConstructor
+): AudioContext {
+  try {
+    return new AudioContextClass({ sampleRate: TARGET_SAMPLE_RATE });
+  } catch {
+    return new AudioContextClass();
+  }
+}
+
+export class BrowserPcmTurnCapture {
+  private audioContext: AudioContext | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  private muteGainNode: GainNode | null = null;
+  private assembler: PcmTurnAssembler | null = null;
+  private acceptingSamples = false;
+
+  constructor(
+    private readonly stream: MediaStream,
+    private readonly options: BrowserPcmTurnCaptureOptions
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.acceptingSamples) return;
+    const AudioContextClass = getAudioContextConstructor();
+    if (!AudioContextClass) {
+      throw new Error('The Web Audio API is unavailable.');
+    }
+    if (typeof AudioWorkletNode === 'undefined') {
+      throw new Error('AudioWorkletNode is unavailable.');
+    }
+
+    try {
+      const audioContext = createAudioContext(AudioContextClass);
+      this.audioContext = audioContext;
+      if (!audioContext.audioWorklet) {
+        throw new Error('AudioWorklet is unavailable.');
+      }
+
+      const workletUrl = URL.createObjectURL(
+        new Blob([WORKLET_SOURCE], { type: 'text/javascript' })
+      );
+      try {
+        await audioContext.audioWorklet.addModule(workletUrl);
+      } finally {
+        URL.revokeObjectURL(workletUrl);
+      }
+
+      const sourceNode = audioContext.createMediaStreamSource(this.stream);
+      const workletNode = new AudioWorkletNode(
+        audioContext,
+        WORKLET_PROCESSOR_NAME,
+        {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          outputChannelCount: [1],
+          channelCount: 1,
+          channelCountMode: 'explicit',
+        }
+      );
+      const muteGainNode = audioContext.createGain();
+      muteGainNode.gain.value = 0;
+      sourceNode.connect(workletNode);
+      workletNode.connect(muteGainNode);
+      muteGainNode.connect(audioContext.destination);
+
+      this.sourceNode = sourceNode;
+      this.workletNode = workletNode;
+      this.muteGainNode = muteGainNode;
+      this.assembler = new PcmTurnAssembler({
+        sampleRate: audioContext.sampleRate,
+        rmsThreshold: RMS_THRESHOLD,
+        minSpeechDurationMs: MIN_SPEECH_DURATION_MS,
+        silenceDurationMs: this.options.silenceDurationMs,
+        preRollMs: PRE_ROLL_MS,
+        maxUtteranceMs: MAX_UTTERANCE_MS,
+      });
+      workletNode.port.onmessage = (event: MessageEvent<unknown>) => {
+        if (!this.acceptingSamples || !(event.data instanceof Float32Array)) {
+          return;
+        }
+        this.emitTurns(this.assembler?.pushChunk(event.data) ?? []);
+      };
+
+      if (audioContext.state === 'suspended') await audioContext.resume();
+      if (audioContext.state !== 'running') {
+        throw new Error('The Web Audio API could not start.');
+      }
+      this.acceptingSamples = true;
+    } catch (cause) {
+      await this.releaseResources();
+      throw cause;
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.acceptingSamples = false;
+    this.emitTurns(this.assembler?.flush() ?? []);
+    await this.releaseResources();
+  }
+
+  private emitTurns(turns: CapturedAudioTurn[]): void {
+    for (const turn of turns) this.options.onTurn(turn);
+  }
+
+  private async releaseResources(): Promise<void> {
+    this.acceptingSamples = false;
+    if (this.workletNode) this.workletNode.port.onmessage = null;
+    this.sourceNode?.disconnect();
+    this.workletNode?.disconnect();
+    this.muteGainNode?.disconnect();
+    this.sourceNode = null;
+    this.workletNode = null;
+    this.muteGainNode = null;
+    this.assembler?.reset();
+    this.assembler = null;
+
+    for (const track of this.stream.getTracks()) track.stop();
+
+    const audioContext = this.audioContext;
+    this.audioContext = null;
+    if (audioContext && audioContext.state !== 'closed') {
+      await audioContext.close().catch(() => undefined);
+    }
+  }
+}

--- a/packages/transcription/src/providers/BrowserVoiceActivityDetector.ts
+++ b/packages/transcription/src/providers/BrowserVoiceActivityDetector.ts
@@ -1,3 +1,5 @@
+import { VoiceActivityTracker } from './VoiceActivityTracker';
+
 const SAMPLE_INTERVAL_MS = 50;
 const RMS_THRESHOLD = 0.015;
 const MIN_SPEECH_DURATION_MS = 150;
@@ -26,15 +28,26 @@ export class BrowserVoiceActivityDetector {
   private analyserNode: AnalyserNode | null = null;
   private samples: Float32Array<ArrayBuffer> | null = null;
   private sampleTimer: ReturnType<typeof setInterval> | null = null;
-  private speechStartedAt: number | null = null;
-  private speechConfirmed = false;
-  private silenceStartedAt: number | null = null;
+  private lastSampleAtMs: number | null = null;
+  private readonly tracker: VoiceActivityTracker;
   private stopped = false;
 
   constructor(
     private readonly stream: MediaStream,
     private readonly onSpeechEnd: () => void
-  ) {}
+  ) {
+    this.tracker = new VoiceActivityTracker(
+      {
+        rmsThreshold: RMS_THRESHOLD,
+        minSpeechDurationMs: MIN_SPEECH_DURATION_MS,
+        silenceDurationMs: SILENCE_DURATION_MS,
+      },
+      {
+        onSpeechStart: () => undefined,
+        onSpeechEnd: this.onSpeechEnd,
+      }
+    );
+  }
 
   async start(): Promise<void> {
     if (this.sampleTimer) return;
@@ -78,14 +91,14 @@ export class BrowserVoiceActivityDetector {
   }
 
   hasPendingSpeech(): boolean {
-    return this.speechStartedAt !== null || this.speechConfirmed;
+    return this.tracker.hasPendingSpeech();
   }
 
   stop(): boolean {
     const hasPendingSpeech = this.hasPendingSpeech();
     this.stopped = true;
     this.releaseAudioResources();
-    this.resetTurn();
+    this.tracker.reset();
     return hasPendingSpeech;
   }
 
@@ -93,38 +106,17 @@ export class BrowserVoiceActivityDetector {
     if (!this.analyserNode || !this.samples) return;
     this.analyserNode.getFloatTimeDomainData(this.samples);
 
+    const sampledAtMs = Date.now();
+    const durationMs =
+      this.lastSampleAtMs === null
+        ? SAMPLE_INTERVAL_MS
+        : sampledAtMs - this.lastSampleAtMs;
+    this.lastSampleAtMs = sampledAtMs;
+
     let sumOfSquares = 0;
     for (const sample of this.samples) sumOfSquares += sample * sample;
     const rms = Math.sqrt(sumOfSquares / this.samples.length);
-    const now = Date.now();
-
-    if (rms >= RMS_THRESHOLD) {
-      if (this.speechStartedAt === null) this.speechStartedAt = now;
-      if (now - this.speechStartedAt >= MIN_SPEECH_DURATION_MS) {
-        this.speechConfirmed = true;
-      }
-      this.silenceStartedAt = null;
-      return;
-    }
-
-    if (!this.speechConfirmed) {
-      this.speechStartedAt = null;
-      return;
-    }
-    if (this.silenceStartedAt === null) {
-      this.silenceStartedAt = now;
-      return;
-    }
-    if (now - this.silenceStartedAt < SILENCE_DURATION_MS) return;
-
-    this.resetTurn();
-    this.onSpeechEnd();
-  }
-
-  private resetTurn(): void {
-    this.speechStartedAt = null;
-    this.speechConfirmed = false;
-    this.silenceStartedAt = null;
+    this.tracker.pushFrame(rms, durationMs);
   }
 
   private releaseAudioResources(): void {
@@ -137,6 +129,7 @@ export class BrowserVoiceActivityDetector {
     this.sourceNode = null;
     this.analyserNode = null;
     this.samples = null;
+    this.lastSampleAtMs = null;
 
     const audioContext = this.audioContext;
     this.audioContext = null;

--- a/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
+++ b/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
@@ -1,0 +1,454 @@
+import { BaseRealtimeTranscriptionSession } from '../BaseRealtimeTranscriptionSession';
+import { TranscriptionSessionError } from '../errors';
+import type { LocalWhisperTranscriptionOptions } from '../types';
+import {
+  BrowserPcmTurnCapture,
+  type BrowserPcmTurnCaptureOptions,
+} from './BrowserPcmTurnCapture';
+import { LocalWhisperWorkerClient } from './LocalWhisperWorkerClient';
+import type { CapturedAudioTurn } from './PcmTurnAssembler';
+import { resampleTo16k } from './resampleTo16k';
+
+const DEFAULT_SILENCE_DURATION_MS = 500;
+const MIN_SILENCE_DURATION_MS = 150;
+const MIN_UTTERANCE_MS = 300;
+
+const WHISPER_HALLUCINATIONS = [
+  'ご視聴ありがとうございました',
+  'ご視聴ありがとうございます',
+  'おやすみなさい',
+  'チャンネル登録お願いします',
+  'Thank you.',
+  'Thanks for watching.',
+  'Thank you for watching.',
+];
+
+const TRAILING_PUNCTUATION = /[。．.！!？?]+$/u;
+
+interface LocalWhisperWorker {
+  readonly hasFailed: boolean;
+  load(): Promise<void>;
+  transcribe(input: {
+    audio: Float32Array;
+    language?: string;
+  }): Promise<string>;
+  dispose(): void;
+}
+
+interface LocalWhisperCapture {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+interface LocalWhisperSessionDependencies {
+  createWorkerClient(workerUrl?: string | URL): LocalWhisperWorker;
+  createCapture(
+    stream: MediaStream,
+    options: BrowserPcmTurnCaptureOptions
+  ): LocalWhisperCapture;
+}
+
+interface LocalWhisperNavigator extends Navigator {
+  gpu?: unknown;
+}
+
+interface LocalWhisperWindow extends Window {
+  AudioContext?: typeof AudioContext;
+  webkitAudioContext?: typeof AudioContext;
+}
+
+class SessionOperationCancelled extends Error {}
+
+const DEFAULT_DEPENDENCIES: LocalWhisperSessionDependencies = {
+  createWorkerClient: (workerUrl) =>
+    workerUrl
+      ? new LocalWhisperWorkerClient(workerUrl)
+      : new LocalWhisperWorkerClient(),
+  createCapture: (stream, options) =>
+    new BrowserPcmTurnCapture(stream, options),
+};
+
+function normalizedHallucinationText(text: string): string {
+  return text
+    .trim()
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(TRAILING_PUNCTUATION, '')
+    .trim();
+}
+
+const NORMALIZED_WHISPER_HALLUCINATIONS = new Set(
+  WHISPER_HALLUCINATIONS.map(normalizedHallucinationText)
+);
+
+export function isLikelyWhisperHallucination(text: string): boolean {
+  return NORMALIZED_WHISPER_HALLUCINATIONS.has(
+    normalizedHallucinationText(text)
+  );
+}
+
+export function normalizeWhisperLanguage(
+  language: string | undefined
+): string | undefined {
+  return language?.trim().replace(/_/g, '-').toLowerCase().split('-')[0];
+}
+
+function validateOptions(options: LocalWhisperTranscriptionOptions): void {
+  if (options.language !== undefined && !options.language.trim()) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'local-whisper',
+      'The local Whisper language code cannot be empty.'
+    );
+  }
+
+  if (
+    options.silenceDurationMs !== undefined &&
+    (!Number.isFinite(options.silenceDurationMs) ||
+      options.silenceDurationMs < MIN_SILENCE_DURATION_MS)
+  ) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'local-whisper',
+      `Local Whisper silenceDurationMs must be at least ${MIN_SILENCE_DURATION_MS}.`
+    );
+  }
+}
+
+function isPermissionDenied(cause: unknown): boolean {
+  return (
+    cause instanceof DOMException &&
+    (cause.name === 'NotAllowedError' || cause.name === 'SecurityError')
+  );
+}
+
+export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionSession {
+  private readonly language: string | undefined;
+  private readonly silenceDurationMs: number;
+  private startPromise: Promise<void> | null = null;
+  private stopPromise: Promise<void> | null = null;
+  private operationId = 0;
+  private workerClient: LocalWhisperWorker | null = null;
+  private capture: LocalWhisperCapture | null = null;
+  private transcriptionQueue = Promise.resolve();
+  private utteranceSequence = 0;
+
+  constructor(
+    private readonly options: LocalWhisperTranscriptionOptions,
+    private readonly dependencies: LocalWhisperSessionDependencies = DEFAULT_DEPENDENCIES
+  ) {
+    super('local-whisper', {
+      interimResults: false,
+      multipleLanguages: false,
+      keywords: false,
+      configurableDelay: true,
+    });
+    validateOptions(options);
+    this.language = normalizeWhisperLanguage(options.language);
+    this.silenceDurationMs =
+      options.silenceDurationMs ?? DEFAULT_SILENCE_DURATION_MS;
+  }
+
+  start(): Promise<void> {
+    this.assertNotDisposed();
+    if (this.startPromise) return this.startPromise;
+    if (this.state === 'listening') return Promise.resolve();
+
+    const promise = this.startWhenReady();
+    this.startPromise = promise;
+    void promise.then(
+      () => {
+        if (this.startPromise === promise) this.startPromise = null;
+      },
+      () => {
+        if (this.startPromise === promise) this.startPromise = null;
+      }
+    );
+    return promise;
+  }
+
+  private async startWhenReady(): Promise<void> {
+    if (this.stopPromise) await this.stopPromise;
+    this.assertNotDisposed();
+    if (this.state === 'listening') return;
+
+    this.operationId += 1;
+    const operationId = this.operationId;
+    this.changeState('connecting');
+    await this.connect(operationId);
+  }
+
+  private async connect(operationId: number): Promise<void> {
+    let localStream: MediaStream | null = null;
+    let localCapture: LocalWhisperCapture | null = null;
+    let localWorkerClient: LocalWhisperWorker | null = null;
+
+    try {
+      this.assertBrowserSupport();
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            channelCount: 1,
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          },
+        });
+      } catch (cause) {
+        throw isPermissionDenied(cause)
+          ? new TranscriptionSessionError(
+              'permission-denied',
+              this.provider,
+              'Microphone permission was denied.',
+              { cause }
+            )
+          : new TranscriptionSessionError(
+              'provider-error',
+              this.provider,
+              'The microphone could not be opened for local Whisper.',
+              { cause }
+            );
+      }
+      this.assertOperation(operationId);
+
+      localWorkerClient =
+        this.workerClient ??
+        this.dependencies.createWorkerClient(this.options.workerUrl);
+      this.workerClient = localWorkerClient;
+      localCapture = this.dependencies.createCapture(localStream, {
+        silenceDurationMs: this.silenceDurationMs,
+        onTurn: (turn) => this.queueTurn(turn),
+      });
+      this.capture = localCapture;
+
+      try {
+        await localWorkerClient.load();
+      } catch (cause) {
+        throw new TranscriptionSessionError(
+          'provider-error',
+          this.provider,
+          'Failed to initialize the local Whisper model.',
+          { cause }
+        );
+      }
+      this.assertOperation(operationId);
+
+      try {
+        await localCapture.start();
+      } catch (cause) {
+        throw new TranscriptionSessionError(
+          'provider-error',
+          this.provider,
+          'Failed to start local Whisper audio capture.',
+          { cause }
+        );
+      }
+      this.assertOperation(operationId);
+      this.changeState('listening');
+    } catch (cause) {
+      if (localCapture) await localCapture.stop().catch(() => undefined);
+      else for (const track of localStream?.getTracks() ?? []) track.stop();
+      if (this.capture === localCapture) this.capture = null;
+
+      if (
+        cause instanceof SessionOperationCancelled ||
+        operationId !== this.operationId
+      ) {
+        if (this.state === 'disposed') {
+          throw new TranscriptionSessionError(
+            'session-disposed',
+            this.provider,
+            'The transcription session was disposed while connecting.'
+          );
+        }
+        return;
+      }
+
+      localWorkerClient?.dispose();
+      if (this.workerClient === localWorkerClient) this.workerClient = null;
+      const error =
+        cause instanceof TranscriptionSessionError
+          ? cause
+          : new TranscriptionSessionError(
+              'provider-error',
+              this.provider,
+              'Local Whisper transcription could not start.',
+              { cause }
+            );
+      this.changeState('error');
+      this.emitError(error);
+      throw error;
+    }
+  }
+
+  stop(): Promise<void> {
+    if (this.state === 'disposed' || this.state === 'idle') {
+      return Promise.resolve();
+    }
+    if (this.stopPromise) return this.stopPromise;
+
+    this.operationId += 1;
+    const pendingStart = this.startPromise;
+    this.changeState('stopping');
+    const promise = this.stopAndFlush(pendingStart);
+    this.stopPromise = promise;
+    void promise.then(
+      () => {
+        if (this.stopPromise === promise) this.stopPromise = null;
+      },
+      () => {
+        if (this.stopPromise === promise) this.stopPromise = null;
+      }
+    );
+    return promise;
+  }
+
+  private async stopAndFlush(
+    pendingStart: Promise<void> | null
+  ): Promise<void> {
+    const capture = this.capture;
+    this.capture = null;
+    await capture?.stop().catch(() => undefined);
+    await pendingStart?.catch(() => undefined);
+    await this.transcriptionQueue;
+    if (this.state === 'stopping') this.changeState('idle');
+  }
+
+  async dispose(): Promise<void> {
+    if (this.state === 'disposed') return;
+
+    this.operationId += 1;
+    this.changeState('disposed');
+    const capture = this.capture;
+    this.capture = null;
+    await capture?.stop().catch(() => undefined);
+
+    const workerClient = this.workerClient;
+    this.workerClient = null;
+    workerClient?.dispose();
+    await this.transcriptionQueue.catch(() => undefined);
+    this.clearListeners();
+  }
+
+  private queueTurn(turn: CapturedAudioTurn): void {
+    if (this.state !== 'listening' && this.state !== 'stopping') return;
+    if (turn.confirmedSpeechDurationMs < MIN_UTTERANCE_MS) return;
+
+    const workerClient = this.workerClient;
+    if (!workerClient) return;
+    const utteranceId = `local-whisper:${++this.utteranceSequence}`;
+    const audio = resampleTo16k(turn.audio, turn.sampleRate);
+    const operation = this.transcriptionQueue.then(async () => {
+      if (this.state === 'disposed') return;
+
+      let text: string;
+      try {
+        text = await workerClient.transcribe({
+          audio,
+          ...(this.language ? { language: this.language } : {}),
+        });
+      } catch (cause) {
+        this.handleInferenceFailure(workerClient, cause);
+        return;
+      }
+
+      const normalizedText = text.trim();
+      if (this.shouldSuppressTranscript(normalizedText)) return;
+      this.emitTranscript({
+        utteranceId,
+        text: normalizedText,
+        isFinal: true,
+      });
+    });
+    this.transcriptionQueue = operation.catch(() => undefined);
+  }
+
+  private shouldSuppressTranscript(text: string): boolean {
+    return (
+      this.state === 'disposed' || !text || isLikelyWhisperHallucination(text)
+    );
+  }
+
+  private handleInferenceFailure(
+    workerClient: LocalWhisperWorker,
+    cause: unknown
+  ): void {
+    if (this.state === 'disposed') return;
+
+    const error = new TranscriptionSessionError(
+      'provider-error',
+      this.provider,
+      'Local Whisper transcription failed.',
+      { cause }
+    );
+    if (workerClient.hasFailed && workerClient === this.workerClient) {
+      this.operationId += 1;
+      this.workerClient = null;
+      workerClient.dispose();
+      const capture = this.capture;
+      this.capture = null;
+      this.changeState('error');
+      void capture?.stop().catch(() => undefined);
+    }
+    this.emitError(error);
+  }
+
+  private assertBrowserSupport(): void {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires a browser.'
+      );
+    }
+    if (window.isSecureContext === false) {
+      throw new TranscriptionSessionError(
+        'insecure-context',
+        this.provider,
+        'Local Whisper transcription requires HTTPS or localhost.'
+      );
+    }
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires microphone access.'
+      );
+    }
+    const browser = window as LocalWhisperWindow;
+    if (!(browser.AudioContext ?? browser.webkitAudioContext)) {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires the Web Audio API.'
+      );
+    }
+    if (typeof AudioWorkletNode === 'undefined') {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires AudioWorklet support.'
+      );
+    }
+    if (typeof Worker === 'undefined') {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires Web Worker support.'
+      );
+    }
+    if (!(navigator as LocalWhisperNavigator).gpu) {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Local Whisper transcription requires WebGPU support.'
+      );
+    }
+  }
+
+  private assertOperation(operationId: number): void {
+    if (operationId !== this.operationId || this.state === 'disposed') {
+      throw new SessionOperationCancelled();
+    }
+  }
+}

--- a/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
+++ b/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
@@ -1,6 +1,9 @@
 import { BaseRealtimeTranscriptionSession } from '../BaseRealtimeTranscriptionSession';
 import { TranscriptionSessionError } from '../errors';
-import type { LocalWhisperTranscriptionOptions } from '../types';
+import type {
+  LocalWhisperTranscriptionOptions,
+  TranscriptionProgress,
+} from '../types';
 import {
   BrowserPcmTurnCapture,
   type BrowserPcmTurnCaptureOptions,
@@ -28,6 +31,7 @@ const TRAILING_PUNCTUATION = /[。．.！!？?]+$/u;
 interface LocalWhisperWorker {
   readonly hasFailed: boolean;
   load(): Promise<void>;
+  onProgress(listener: (progress: TranscriptionProgress) => void): () => void;
   transcribe(input: {
     audio: Float32Array;
     language?: string;
@@ -129,6 +133,7 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
   private stopPromise: Promise<void> | null = null;
   private operationId = 0;
   private workerClient: LocalWhisperWorker | null = null;
+  private workerProgressUnsubscribe: (() => void) | null = null;
   private capture: LocalWhisperCapture | null = null;
   private transcriptionQueue = Promise.resolve();
   private utteranceSequence = 0;
@@ -211,10 +216,19 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
       }
       this.assertOperation(operationId);
 
-      localWorkerClient =
-        this.workerClient ??
-        this.dependencies.createWorkerClient(this.options.workerUrl);
-      this.workerClient = localWorkerClient;
+      if (this.workerClient) {
+        localWorkerClient = this.workerClient;
+      } else {
+        localWorkerClient = this.dependencies.createWorkerClient(
+          this.options.workerUrl
+        );
+        this.workerClient = localWorkerClient;
+        this.workerProgressUnsubscribe = localWorkerClient.onProgress(
+          (progress) => {
+            if (this.state === 'connecting') this.emitProgress(progress);
+          }
+        );
+      }
       localCapture = this.dependencies.createCapture(localStream, {
         silenceDurationMs: this.silenceDurationMs,
         onTurn: (turn) => this.queueTurn(turn),
@@ -264,8 +278,12 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
         return;
       }
 
+      if (this.workerClient === localWorkerClient) {
+        this.workerProgressUnsubscribe?.();
+        this.workerProgressUnsubscribe = null;
+        this.workerClient = null;
+      }
       localWorkerClient?.dispose();
-      if (this.workerClient === localWorkerClient) this.workerClient = null;
       const error =
         cause instanceof TranscriptionSessionError
           ? cause
@@ -325,6 +343,8 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
 
     const workerClient = this.workerClient;
     this.workerClient = null;
+    this.workerProgressUnsubscribe?.();
+    this.workerProgressUnsubscribe = null;
     workerClient?.dispose();
     await this.transcriptionQueue.catch(() => undefined);
     this.clearListeners();
@@ -384,6 +404,8 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
     if (workerClient.hasFailed && workerClient === this.workerClient) {
       this.operationId += 1;
       this.workerClient = null;
+      this.workerProgressUnsubscribe?.();
+      this.workerProgressUnsubscribe = null;
       workerClient.dispose();
       const capture = this.capture;
       this.capture = null;

--- a/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
+++ b/packages/transcription/src/providers/LocalWhisperTranscriptionSession.ts
@@ -1,6 +1,7 @@
 import { BaseRealtimeTranscriptionSession } from '../BaseRealtimeTranscriptionSession';
 import { TranscriptionSessionError } from '../errors';
 import type {
+  LocalWhisperModelSize,
   LocalWhisperTranscriptionOptions,
   TranscriptionProgress,
 } from '../types';
@@ -15,6 +16,12 @@ import { resampleTo16k } from './resampleTo16k';
 const DEFAULT_SILENCE_DURATION_MS = 500;
 const MIN_SILENCE_DURATION_MS = 150;
 const MIN_UTTERANCE_MS = 300;
+const DEFAULT_MODEL: LocalWhisperModelSize = 'tiny';
+const LOCAL_WHISPER_MODEL_SIZES: readonly LocalWhisperModelSize[] = [
+  'tiny',
+  'base',
+  'small',
+];
 
 const WHISPER_HALLUCINATIONS = [
   'ご視聴ありがとうございました',
@@ -30,10 +37,11 @@ const TRAILING_PUNCTUATION = /[。．.！!？?]+$/u;
 
 interface LocalWhisperWorker {
   readonly hasFailed: boolean;
-  load(): Promise<void>;
+  load(model: LocalWhisperModelSize): Promise<void>;
   onProgress(listener: (progress: TranscriptionProgress) => void): () => void;
   transcribe(input: {
     audio: Float32Array;
+    model: LocalWhisperModelSize;
     language?: string;
   }): Promise<string>;
   dispose(): void;
@@ -98,6 +106,17 @@ export function normalizeWhisperLanguage(
 }
 
 function validateOptions(options: LocalWhisperTranscriptionOptions): void {
+  if (
+    options.model !== undefined &&
+    !LOCAL_WHISPER_MODEL_SIZES.includes(options.model)
+  ) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'local-whisper',
+      'Local Whisper model must be tiny, base, or small.'
+    );
+  }
+
   if (options.language !== undefined && !options.language.trim()) {
     throw new TranscriptionSessionError(
       'invalid-configuration',
@@ -127,6 +146,7 @@ function isPermissionDenied(cause: unknown): boolean {
 }
 
 export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionSession {
+  private readonly model: LocalWhisperModelSize;
   private readonly language: string | undefined;
   private readonly silenceDurationMs: number;
   private startPromise: Promise<void> | null = null;
@@ -149,6 +169,7 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
       configurableDelay: true,
     });
     validateOptions(options);
+    this.model = options.model ?? DEFAULT_MODEL;
     this.language = normalizeWhisperLanguage(options.language);
     this.silenceDurationMs =
       options.silenceDurationMs ?? DEFAULT_SILENCE_DURATION_MS;
@@ -236,7 +257,7 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
       this.capture = localCapture;
 
       try {
-        await localWorkerClient.load();
+        await localWorkerClient.load(this.model);
       } catch (cause) {
         throw new TranscriptionSessionError(
           'provider-error',
@@ -365,6 +386,7 @@ export class LocalWhisperTranscriptionSession extends BaseRealtimeTranscriptionS
       try {
         text = await workerClient.transcribe({
           audio,
+          model: this.model,
           ...(this.language ? { language: this.language } : {}),
         });
       } catch (cause) {

--- a/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
+++ b/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
@@ -2,10 +2,16 @@ import type {
   LocalWhisperWorkerRequest,
   LocalWhisperWorkerResponse,
 } from './localWhisperProtocol';
-import type { TranscriptionProgress } from '../types';
+import type { LocalWhisperModelSize, TranscriptionProgress } from '../types';
 
 interface PendingRequest {
   resolve: (text: string) => void;
+  reject: (cause: Error) => void;
+}
+
+interface PendingLoad {
+  promise: Promise<void>;
+  resolve: () => void;
   reject: (cause: Error) => void;
 }
 
@@ -26,14 +32,13 @@ function defaultWorkerUrl(): URL {
 
 export interface LocalWhisperTranscriptionInput {
   audio: Float32Array;
+  model: LocalWhisperModelSize;
   language?: string;
 }
 
 export class LocalWhisperWorkerClient {
   private readonly worker: Worker;
-  private loadPromise: Promise<void> | null = null;
-  private resolveLoad: (() => void) | null = null;
-  private rejectLoad: ((cause: Error) => void) | null = null;
+  private readonly pendingLoads = new Map<LocalWhisperModelSize, PendingLoad>();
   private inferenceQueue = Promise.resolve();
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly progressListeners = new Set<
@@ -64,17 +69,26 @@ export class LocalWhisperWorkerClient {
     return () => this.progressListeners.delete(listener);
   }
 
-  load(): Promise<void> {
+  load(model: LocalWhisperModelSize): Promise<void> {
     this.assertUsable();
-    if (this.loadPromise) return this.loadPromise;
+    const current = this.pendingLoads.get(model);
+    if (current) return current.promise;
 
-    this.loadPromise = new Promise<void>((resolve, reject) => {
-      this.resolveLoad = resolve;
-      this.rejectLoad = reject;
+    let resolveLoad!: () => void;
+    let rejectLoad!: (cause: Error) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
+    });
+    this.pendingLoads.set(model, {
+      promise,
+      resolve: resolveLoad,
+      reject: rejectLoad,
     });
     try {
       this.postMessage({
         type: 'load',
+        model,
         ...(isDebugEnabled() ? { debug: true } : {}),
       });
     } catch (cause) {
@@ -82,12 +96,12 @@ export class LocalWhisperWorkerClient {
         cause instanceof Error ? cause : new Error(String(cause))
       );
     }
-    return this.loadPromise;
+    return promise;
   }
 
   transcribe(input: LocalWhisperTranscriptionInput): Promise<string> {
     const operation = this.inferenceQueue.then(async () => {
-      await this.load();
+      await this.load(input.model);
       this.assertUsable();
       return this.sendTranscriptionRequest(input);
     });
@@ -118,6 +132,7 @@ export class LocalWhisperWorkerClient {
         type: 'transcribe',
         requestId,
         audio: input.audio,
+        model: input.model,
         ...(input.language ? { language: input.language } : {}),
         ...(isDebugEnabled() ? { debug: true } : {}),
       };
@@ -141,9 +156,7 @@ export class LocalWhisperWorkerClient {
     if (!this.isWorkerResponse(data)) return;
 
     if (data.type === 'ready') {
-      this.resolveLoad?.();
-      this.resolveLoad = null;
-      this.rejectLoad = null;
+      this.pendingLoads.get(data.model)?.resolve();
       return;
     }
     if (data.type === 'progress') {
@@ -169,6 +182,10 @@ export class LocalWhisperWorkerClient {
       pending.reject(error);
       return;
     }
+    if (data.model) {
+      this.pendingLoads.get(data.model)?.reject(error);
+      return;
+    }
     this.failWorker(error);
   }
 
@@ -187,9 +204,7 @@ export class LocalWhisperWorkerClient {
   }
 
   private rejectAll(error: Error): void {
-    this.rejectLoad?.(error);
-    this.resolveLoad = null;
-    this.rejectLoad = null;
+    for (const pending of this.pendingLoads.values()) pending.reject(error);
     for (const pending of this.pendingRequests.values()) pending.reject(error);
     this.pendingRequests.clear();
   }

--- a/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
+++ b/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
@@ -1,0 +1,188 @@
+import type {
+  LocalWhisperWorkerRequest,
+  LocalWhisperWorkerResponse,
+} from './localWhisperProtocol';
+
+interface PendingRequest {
+  resolve: (text: string) => void;
+  reject: (cause: Error) => void;
+}
+
+interface DebugGlobal {
+  __AITUBER_TRANSCRIPTION_DEBUG__?: boolean;
+}
+
+function isDebugEnabled(): boolean {
+  return (globalThis as DebugGlobal).__AITUBER_TRANSCRIPTION_DEBUG__ === true;
+}
+
+function defaultWorkerUrl(): URL {
+  return new URL(
+    /* @vite-ignore */ './local-whisper.worker.js',
+    import.meta.url
+  );
+}
+
+export interface LocalWhisperTranscriptionInput {
+  audio: Float32Array;
+  language?: string;
+}
+
+export class LocalWhisperWorkerClient {
+  private readonly worker: Worker;
+  private loadPromise: Promise<void> | null = null;
+  private resolveLoad: (() => void) | null = null;
+  private rejectLoad: ((cause: Error) => void) | null = null;
+  private inferenceQueue = Promise.resolve();
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private requestSequence = 0;
+  private workerFailure: Error | null = null;
+  private disposed = false;
+
+  constructor(workerUrl: string | URL = defaultWorkerUrl()) {
+    this.worker = new Worker(workerUrl, { type: 'module' });
+    this.worker.onmessage = (event: MessageEvent<unknown>) => {
+      this.handleMessage(event.data);
+    };
+    this.worker.onerror = (event: ErrorEvent) => {
+      this.failWorker(
+        new Error(event.message || 'The local Whisper worker failed.')
+      );
+    };
+  }
+
+  get hasFailed(): boolean {
+    return this.workerFailure !== null;
+  }
+
+  load(): Promise<void> {
+    this.assertUsable();
+    if (this.loadPromise) return this.loadPromise;
+
+    this.loadPromise = new Promise<void>((resolve, reject) => {
+      this.resolveLoad = resolve;
+      this.rejectLoad = reject;
+    });
+    try {
+      this.postMessage({
+        type: 'load',
+        ...(isDebugEnabled() ? { debug: true } : {}),
+      });
+    } catch (cause) {
+      this.failWorker(
+        cause instanceof Error ? cause : new Error(String(cause))
+      );
+    }
+    return this.loadPromise;
+  }
+
+  transcribe(input: LocalWhisperTranscriptionInput): Promise<string> {
+    const operation = this.inferenceQueue.then(async () => {
+      await this.load();
+      this.assertUsable();
+      return this.sendTranscriptionRequest(input);
+    });
+    this.inferenceQueue = operation.then(
+      () => undefined,
+      () => undefined
+    );
+    return operation;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.worker.onmessage = null;
+    this.worker.onerror = null;
+    this.worker.terminate();
+    this.rejectAll(new Error('The local Whisper worker was disposed.'));
+  }
+
+  private sendTranscriptionRequest(
+    input: LocalWhisperTranscriptionInput
+  ): Promise<string> {
+    const requestId = `local-whisper-${++this.requestSequence}`;
+    return new Promise<string>((resolve, reject) => {
+      this.pendingRequests.set(requestId, { resolve, reject });
+      const request: LocalWhisperWorkerRequest = {
+        type: 'transcribe',
+        requestId,
+        audio: input.audio,
+        ...(input.language ? { language: input.language } : {}),
+        ...(isDebugEnabled() ? { debug: true } : {}),
+      };
+      try {
+        this.postMessage(request, [input.audio.buffer as ArrayBuffer]);
+      } catch (cause) {
+        this.pendingRequests.delete(requestId);
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    });
+  }
+
+  private postMessage(
+    request: LocalWhisperWorkerRequest,
+    transfer: Transferable[] = []
+  ): void {
+    this.worker.postMessage(request, transfer);
+  }
+
+  private handleMessage(data: unknown): void {
+    if (!this.isWorkerResponse(data)) return;
+
+    if (data.type === 'ready') {
+      this.resolveLoad?.();
+      this.resolveLoad = null;
+      this.rejectLoad = null;
+      return;
+    }
+    if (data.type === 'progress') return;
+
+    if (data.type === 'result') {
+      const pending = this.pendingRequests.get(data.requestId);
+      if (!pending) return;
+      this.pendingRequests.delete(data.requestId);
+      pending.resolve(data.text);
+      return;
+    }
+
+    const error = new Error(data.message);
+    if (data.requestId) {
+      const pending = this.pendingRequests.get(data.requestId);
+      if (!pending) return;
+      this.pendingRequests.delete(data.requestId);
+      pending.reject(error);
+      return;
+    }
+    this.failWorker(error);
+  }
+
+  private isWorkerResponse(data: unknown): data is LocalWhisperWorkerResponse {
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'type' in data &&
+      typeof data.type === 'string'
+    );
+  }
+
+  private failWorker(error: Error): void {
+    this.workerFailure = error;
+    this.rejectAll(error);
+  }
+
+  private rejectAll(error: Error): void {
+    this.rejectLoad?.(error);
+    this.resolveLoad = null;
+    this.rejectLoad = null;
+    for (const pending of this.pendingRequests.values()) pending.reject(error);
+    this.pendingRequests.clear();
+  }
+
+  private assertUsable(): void {
+    if (this.disposed) {
+      throw new Error('The local Whisper worker was disposed.');
+    }
+    if (this.workerFailure) throw this.workerFailure;
+  }
+}

--- a/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
+++ b/packages/transcription/src/providers/LocalWhisperWorkerClient.ts
@@ -2,6 +2,7 @@ import type {
   LocalWhisperWorkerRequest,
   LocalWhisperWorkerResponse,
 } from './localWhisperProtocol';
+import type { TranscriptionProgress } from '../types';
 
 interface PendingRequest {
   resolve: (text: string) => void;
@@ -35,6 +36,9 @@ export class LocalWhisperWorkerClient {
   private rejectLoad: ((cause: Error) => void) | null = null;
   private inferenceQueue = Promise.resolve();
   private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly progressListeners = new Set<
+    (progress: TranscriptionProgress) => void
+  >();
   private requestSequence = 0;
   private workerFailure: Error | null = null;
   private disposed = false;
@@ -53,6 +57,11 @@ export class LocalWhisperWorkerClient {
 
   get hasFailed(): boolean {
     return this.workerFailure !== null;
+  }
+
+  onProgress(listener: (progress: TranscriptionProgress) => void): () => void {
+    this.progressListeners.add(listener);
+    return () => this.progressListeners.delete(listener);
   }
 
   load(): Promise<void> {
@@ -96,6 +105,7 @@ export class LocalWhisperWorkerClient {
     this.worker.onerror = null;
     this.worker.terminate();
     this.rejectAll(new Error('The local Whisper worker was disposed.'));
+    this.progressListeners.clear();
   }
 
   private sendTranscriptionRequest(
@@ -136,7 +146,12 @@ export class LocalWhisperWorkerClient {
       this.rejectLoad = null;
       return;
     }
-    if (data.type === 'progress') return;
+    if (data.type === 'progress') {
+      for (const listener of this.progressListeners) {
+        listener(data.progress);
+      }
+      return;
+    }
 
     if (data.type === 'result') {
       const pending = this.pendingRequests.get(data.requestId);

--- a/packages/transcription/src/providers/PcmTurnAssembler.ts
+++ b/packages/transcription/src/providers/PcmTurnAssembler.ts
@@ -1,0 +1,209 @@
+import {
+  VoiceActivityTracker,
+  type VoiceActivityTrackerOptions,
+} from './VoiceActivityTracker';
+
+interface PcmChunk {
+  audio: Float32Array;
+  aboveThreshold: boolean;
+  speechSamples: number;
+}
+
+export interface CapturedAudioTurn {
+  audio: Float32Array;
+  sampleRate: number;
+  confirmedSpeechDurationMs: number;
+}
+
+export interface PcmTurnAssemblerOptions extends VoiceActivityTrackerOptions {
+  sampleRate: number;
+  preRollMs: number;
+  maxUtteranceMs: number;
+}
+
+function calculateRms(audio: Float32Array): number {
+  if (audio.length === 0) return 0;
+
+  let sumOfSquares = 0;
+  for (const sample of audio) sumOfSquares += sample * sample;
+  return Math.sqrt(sumOfSquares / audio.length);
+}
+
+export class PcmTurnAssembler {
+  private readonly tracker: VoiceActivityTracker;
+  private readonly preRollSampleLimit: number;
+  private readonly maxUtteranceSamples: number;
+  private preRollChunks: PcmChunk[] = [];
+  private preRollSamples = 0;
+  private turnChunks: PcmChunk[] = [];
+  private turnSamples = 0;
+  private speechActive = false;
+  private pendingTurns: CapturedAudioTurn[] = [];
+
+  constructor(private readonly options: PcmTurnAssemblerOptions) {
+    this.preRollSampleLimit = Math.max(
+      0,
+      Math.floor((options.sampleRate * options.preRollMs) / 1000)
+    );
+    this.maxUtteranceSamples = Math.max(
+      1,
+      Math.floor((options.sampleRate * options.maxUtteranceMs) / 1000)
+    );
+    this.tracker = new VoiceActivityTracker(options, {
+      onSpeechStart: () => this.startTurn(),
+      onSpeechEnd: () => this.endTurn(),
+    });
+  }
+
+  pushChunk(audio: Float32Array): CapturedAudioTurn[] {
+    if (audio.length === 0) return [];
+
+    const rms = calculateRms(audio);
+    const durationMs = (audio.length / this.options.sampleRate) * 1000;
+    const isSpeech = Number.isFinite(rms) && rms >= this.options.rmsThreshold;
+    const chunk: PcmChunk = {
+      audio,
+      aboveThreshold: isSpeech,
+      speechSamples: this.speechActive && isSpeech ? audio.length : 0,
+    };
+
+    if (this.speechActive) {
+      this.appendTurnChunk(chunk);
+      this.drainMaximumTurns();
+    } else {
+      this.appendPreRollChunk(chunk);
+    }
+
+    this.tracker.pushFrame(rms, durationMs);
+    if (this.speechActive && isSpeech && chunk.speechSamples === 0) {
+      if (!this.turnChunks.includes(chunk)) this.appendTurnChunk(chunk);
+      chunk.speechSamples = chunk.audio.length;
+    }
+
+    this.drainMaximumTurns();
+
+    return this.takePendingTurns();
+  }
+
+  flush(): CapturedAudioTurn[] {
+    if (this.speechActive && this.turnSamples > 0) {
+      this.pendingTurns.push(this.takeTurn(this.turnSamples));
+    }
+    const turns = this.takePendingTurns();
+    this.reset();
+    return turns;
+  }
+
+  reset(): void {
+    this.tracker.reset();
+    this.preRollChunks = [];
+    this.preRollSamples = 0;
+    this.turnChunks = [];
+    this.turnSamples = 0;
+    this.speechActive = false;
+    this.pendingTurns = [];
+  }
+
+  hasConfirmedSpeech(): boolean {
+    return this.speechActive;
+  }
+
+  private startTurn(): void {
+    this.speechActive = true;
+    this.turnChunks = this.preRollChunks;
+    this.turnSamples = this.preRollSamples;
+    for (let index = this.turnChunks.length - 1; index >= 0; index -= 1) {
+      const chunk = this.turnChunks[index];
+      if (!chunk?.aboveThreshold) break;
+      chunk.speechSamples = chunk.audio.length;
+    }
+    this.preRollChunks = [];
+    this.preRollSamples = 0;
+  }
+
+  private endTurn(): void {
+    if (this.turnSamples > 0) {
+      this.pendingTurns.push(this.takeTurn(this.turnSamples));
+    }
+    this.speechActive = false;
+  }
+
+  private appendPreRollChunk(chunk: PcmChunk): void {
+    if (this.preRollSampleLimit === 0) return;
+
+    this.preRollChunks.push(chunk);
+    this.preRollSamples += chunk.audio.length;
+    let excessSamples = this.preRollSamples - this.preRollSampleLimit;
+
+    while (excessSamples > 0) {
+      const first = this.preRollChunks[0];
+      if (!first) break;
+      if (first.audio.length <= excessSamples) {
+        this.preRollChunks.shift();
+        this.preRollSamples -= first.audio.length;
+        excessSamples -= first.audio.length;
+        continue;
+      }
+
+      first.audio = first.audio.slice(excessSamples);
+      this.preRollSamples -= excessSamples;
+      excessSamples = 0;
+    }
+  }
+
+  private appendTurnChunk(chunk: PcmChunk): void {
+    this.turnChunks.push(chunk);
+    this.turnSamples += chunk.audio.length;
+  }
+
+  private drainMaximumTurns(): void {
+    while (this.speechActive && this.turnSamples >= this.maxUtteranceSamples) {
+      this.pendingTurns.push(this.takeTurn(this.maxUtteranceSamples));
+    }
+  }
+
+  private takeTurn(sampleCount: number): CapturedAudioTurn {
+    const audio = new Float32Array(sampleCount);
+    let outputOffset = 0;
+    let speechSamples = 0;
+
+    while (outputOffset < sampleCount) {
+      const chunk = this.turnChunks[0];
+      if (!chunk) break;
+
+      const takeCount = Math.min(
+        chunk.audio.length,
+        sampleCount - outputOffset
+      );
+      audio.set(chunk.audio.subarray(0, takeCount), outputOffset);
+      outputOffset += takeCount;
+
+      const takenSpeechSamples =
+        chunk.speechSamples === 0
+          ? 0
+          : Math.min(chunk.speechSamples, takeCount);
+      speechSamples += takenSpeechSamples;
+
+      if (takeCount === chunk.audio.length) {
+        this.turnChunks.shift();
+      } else {
+        chunk.audio = chunk.audio.slice(takeCount);
+        chunk.speechSamples -= takenSpeechSamples;
+      }
+    }
+
+    this.turnSamples -= sampleCount;
+    return {
+      audio,
+      sampleRate: this.options.sampleRate,
+      confirmedSpeechDurationMs:
+        (speechSamples / this.options.sampleRate) * 1000,
+    };
+  }
+
+  private takePendingTurns(): CapturedAudioTurn[] {
+    const turns = this.pendingTurns;
+    this.pendingTurns = [];
+    return turns;
+  }
+}

--- a/packages/transcription/src/providers/VoiceActivityTracker.ts
+++ b/packages/transcription/src/providers/VoiceActivityTracker.ts
@@ -1,0 +1,60 @@
+export interface VoiceActivityTrackerOptions {
+  rmsThreshold: number;
+  minSpeechDurationMs: number;
+  silenceDurationMs: number;
+}
+
+export interface VoiceActivityTrackerCallbacks {
+  onSpeechStart: () => void;
+  onSpeechEnd: () => void;
+}
+
+export class VoiceActivityTracker {
+  private candidateSpeechDurationMs = 0;
+  private confirmedSpeech = false;
+  private silenceDurationMs = 0;
+
+  constructor(
+    private readonly options: VoiceActivityTrackerOptions,
+    private readonly callbacks: VoiceActivityTrackerCallbacks
+  ) {}
+
+  pushFrame(rms: number, durationMs: number): void {
+    if (!Number.isFinite(durationMs) || durationMs <= 0) return;
+
+    if (Number.isFinite(rms) && rms >= this.options.rmsThreshold) {
+      this.candidateSpeechDurationMs += durationMs;
+      this.silenceDurationMs = 0;
+
+      if (
+        !this.confirmedSpeech &&
+        this.candidateSpeechDurationMs >= this.options.minSpeechDurationMs
+      ) {
+        this.confirmedSpeech = true;
+        this.callbacks.onSpeechStart();
+      }
+      return;
+    }
+
+    if (!this.confirmedSpeech) {
+      this.candidateSpeechDurationMs = 0;
+      return;
+    }
+
+    this.silenceDurationMs += durationMs;
+    if (this.silenceDurationMs < this.options.silenceDurationMs) return;
+
+    this.reset();
+    this.callbacks.onSpeechEnd();
+  }
+
+  reset(): void {
+    this.candidateSpeechDurationMs = 0;
+    this.confirmedSpeech = false;
+    this.silenceDurationMs = 0;
+  }
+
+  hasPendingSpeech(): boolean {
+    return this.candidateSpeechDurationMs > 0 || this.confirmedSpeech;
+  }
+}

--- a/packages/transcription/src/providers/local-whisper.worker.ts
+++ b/packages/transcription/src/providers/local-whisper.worker.ts
@@ -3,13 +3,18 @@ import {
   pipeline,
   type AutomaticSpeechRecognitionPipeline,
 } from '@huggingface/transformers';
+import type { LocalWhisperModelSize } from '../types';
 import type {
   LocalWhisperWorkerRequest,
   LocalWhisperWorkerResponse,
 } from './localWhisperProtocol';
 import { normalizeLocalWhisperDownloadProgress } from './localWhisperProgress';
 
-const LOCAL_WHISPER_MODEL_ID = 'onnx-community/whisper-tiny';
+const LOCAL_WHISPER_MODEL_IDS: Record<LocalWhisperModelSize, string> = {
+  tiny: 'onnx-community/whisper-tiny',
+  base: 'onnx-community/whisper-base',
+  small: 'onnx-community/whisper-small',
+};
 const LOCAL_WHISPER_MODEL_OPTIONS = {
   device: 'webgpu',
   dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' },
@@ -27,8 +32,10 @@ interface WorkerScope {
 const workerScope = globalThis as unknown as WorkerScope;
 env.allowLocalModels = false;
 
-let transcriberPromise: Promise<AutomaticSpeechRecognitionPipeline> | null =
-  null;
+const transcriberPromises = new Map<
+  LocalWhisperModelSize,
+  Promise<AutomaticSpeechRecognitionPipeline>
+>();
 let requestQueue = Promise.resolve();
 
 function errorMessage(cause: unknown): string {
@@ -42,7 +49,7 @@ function postResponse(response: LocalWhisperWorkerResponse): void {
 function debugTiming(
   enabled: boolean | undefined,
   label: string,
-  timings: Record<string, number>
+  timings: Record<string, string | number>
 ): void {
   if (enabled === true) {
     console.debug(`[aituber-onair/transcription] ${label}`, timings);
@@ -50,12 +57,13 @@ function debugTiming(
 }
 
 async function createTranscriber(
+  model: LocalWhisperModelSize,
   debug: boolean | undefined
 ): Promise<AutomaticSpeechRecognitionPipeline> {
   const modelLoadStartedAt = performance.now();
   const transcriber = await pipeline(
     'automatic-speech-recognition',
-    LOCAL_WHISPER_MODEL_ID,
+    LOCAL_WHISPER_MODEL_IDS[model],
     {
       ...LOCAL_WHISPER_MODEL_OPTIONS,
       progress_callback: (data: unknown) => {
@@ -73,6 +81,7 @@ async function createTranscriber(
   const warmUpCompletedAt = performance.now();
   postResponse({ type: 'progress', progress: { phase: 'ready' } });
   debugTiming(debug, 'Local Whisper initialization', {
+    model,
     modelLoadMs: modelLoadedAt - modelLoadStartedAt,
     warmUpMs: warmUpCompletedAt - modelLoadedAt,
     totalMs: warmUpCompletedAt - modelLoadStartedAt,
@@ -81,10 +90,15 @@ async function createTranscriber(
 }
 
 function getTranscriber(
+  model: LocalWhisperModelSize,
   debug: boolean | undefined
 ): Promise<AutomaticSpeechRecognitionPipeline> {
-  transcriberPromise ??= createTranscriber(debug);
-  return transcriberPromise;
+  const current = transcriberPromises.get(model);
+  if (current) return current;
+
+  const transcriber = createTranscriber(model, debug);
+  transcriberPromises.set(model, transcriber);
+  return transcriber;
 }
 
 async function handleRequest(
@@ -92,16 +106,20 @@ async function handleRequest(
 ): Promise<void> {
   if (request.type === 'load') {
     try {
-      await getTranscriber(request.debug);
-      postResponse({ type: 'ready' });
+      await getTranscriber(request.model, request.debug);
+      postResponse({ type: 'ready', model: request.model });
     } catch (cause) {
-      postResponse({ type: 'error', message: errorMessage(cause) });
+      postResponse({
+        type: 'error',
+        model: request.model,
+        message: errorMessage(cause),
+      });
     }
     return;
   }
 
   try {
-    const transcriber = await getTranscriber(request.debug);
+    const transcriber = await getTranscriber(request.model, request.debug);
     const inferenceStartedAt = performance.now();
     const result = await transcriber(request.audio, {
       ...(request.language ? { language: request.language } : {}),
@@ -110,6 +128,7 @@ async function handleRequest(
     const inferenceCompletedAt = performance.now();
     const text = result.text.trim();
     debugTiming(request.debug, 'Local Whisper inference', {
+      model: request.model,
       inferenceMs: inferenceCompletedAt - inferenceStartedAt,
     });
     postResponse({ type: 'result', requestId: request.requestId, text });

--- a/packages/transcription/src/providers/local-whisper.worker.ts
+++ b/packages/transcription/src/providers/local-whisper.worker.ts
@@ -7,6 +7,7 @@ import type {
   LocalWhisperWorkerRequest,
   LocalWhisperWorkerResponse,
 } from './localWhisperProtocol';
+import { normalizeLocalWhisperDownloadProgress } from './localWhisperProgress';
 
 const LOCAL_WHISPER_MODEL_ID = 'onnx-community/whisper-tiny';
 const LOCAL_WHISPER_MODEL_OPTIONS = {
@@ -58,16 +59,19 @@ async function createTranscriber(
     {
       ...LOCAL_WHISPER_MODEL_OPTIONS,
       progress_callback: (data: unknown) => {
-        postResponse({ type: 'progress', data });
+        const progress = normalizeLocalWhisperDownloadProgress(data);
+        if (progress) postResponse({ type: 'progress', progress });
       },
     }
   );
   const modelLoadedAt = performance.now();
+  postResponse({ type: 'progress', progress: { phase: 'initialize' } });
   await transcriber(new Float32Array(WARM_UP_SAMPLE_COUNT), {
     language: 'en',
     task: 'transcribe',
   });
   const warmUpCompletedAt = performance.now();
+  postResponse({ type: 'progress', progress: { phase: 'ready' } });
   debugTiming(debug, 'Local Whisper initialization', {
     modelLoadMs: modelLoadedAt - modelLoadStartedAt,
     warmUpMs: warmUpCompletedAt - modelLoadedAt,

--- a/packages/transcription/src/providers/local-whisper.worker.ts
+++ b/packages/transcription/src/providers/local-whisper.worker.ts
@@ -1,0 +1,123 @@
+import {
+  env,
+  pipeline,
+  type AutomaticSpeechRecognitionPipeline,
+} from '@huggingface/transformers';
+import type {
+  LocalWhisperWorkerRequest,
+  LocalWhisperWorkerResponse,
+} from './localWhisperProtocol';
+
+const LOCAL_WHISPER_MODEL_ID = 'onnx-community/whisper-tiny';
+const LOCAL_WHISPER_MODEL_OPTIONS = {
+  device: 'webgpu',
+  dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' },
+} as const;
+const WARM_UP_SAMPLE_COUNT = 16_000;
+
+interface WorkerScope {
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<LocalWhisperWorkerRequest>) => void
+  ): void;
+  postMessage(message: LocalWhisperWorkerResponse): void;
+}
+
+const workerScope = globalThis as unknown as WorkerScope;
+env.allowLocalModels = false;
+
+let transcriberPromise: Promise<AutomaticSpeechRecognitionPipeline> | null =
+  null;
+let requestQueue = Promise.resolve();
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function postResponse(response: LocalWhisperWorkerResponse): void {
+  workerScope.postMessage(response);
+}
+
+function debugTiming(
+  enabled: boolean | undefined,
+  label: string,
+  timings: Record<string, number>
+): void {
+  if (enabled === true) {
+    console.debug(`[aituber-onair/transcription] ${label}`, timings);
+  }
+}
+
+async function createTranscriber(
+  debug: boolean | undefined
+): Promise<AutomaticSpeechRecognitionPipeline> {
+  const modelLoadStartedAt = performance.now();
+  const transcriber = await pipeline(
+    'automatic-speech-recognition',
+    LOCAL_WHISPER_MODEL_ID,
+    {
+      ...LOCAL_WHISPER_MODEL_OPTIONS,
+      progress_callback: (data: unknown) => {
+        postResponse({ type: 'progress', data });
+      },
+    }
+  );
+  const modelLoadedAt = performance.now();
+  await transcriber(new Float32Array(WARM_UP_SAMPLE_COUNT), {
+    language: 'en',
+    task: 'transcribe',
+  });
+  const warmUpCompletedAt = performance.now();
+  debugTiming(debug, 'Local Whisper initialization', {
+    modelLoadMs: modelLoadedAt - modelLoadStartedAt,
+    warmUpMs: warmUpCompletedAt - modelLoadedAt,
+    totalMs: warmUpCompletedAt - modelLoadStartedAt,
+  });
+  return transcriber;
+}
+
+function getTranscriber(
+  debug: boolean | undefined
+): Promise<AutomaticSpeechRecognitionPipeline> {
+  transcriberPromise ??= createTranscriber(debug);
+  return transcriberPromise;
+}
+
+async function handleRequest(
+  request: LocalWhisperWorkerRequest
+): Promise<void> {
+  if (request.type === 'load') {
+    try {
+      await getTranscriber(request.debug);
+      postResponse({ type: 'ready' });
+    } catch (cause) {
+      postResponse({ type: 'error', message: errorMessage(cause) });
+    }
+    return;
+  }
+
+  try {
+    const transcriber = await getTranscriber(request.debug);
+    const inferenceStartedAt = performance.now();
+    const result = await transcriber(request.audio, {
+      ...(request.language ? { language: request.language } : {}),
+      task: 'transcribe',
+    });
+    const inferenceCompletedAt = performance.now();
+    const text = result.text.trim();
+    debugTiming(request.debug, 'Local Whisper inference', {
+      inferenceMs: inferenceCompletedAt - inferenceStartedAt,
+    });
+    postResponse({ type: 'result', requestId: request.requestId, text });
+  } catch (cause) {
+    postResponse({
+      type: 'error',
+      requestId: request.requestId,
+      message: errorMessage(cause),
+    });
+  }
+}
+
+workerScope.addEventListener('message', (event) => {
+  requestQueue = requestQueue.then(() => handleRequest(event.data));
+});

--- a/packages/transcription/src/providers/localWhisperProgress.ts
+++ b/packages/transcription/src/providers/localWhisperProgress.ts
@@ -1,0 +1,53 @@
+import type { TranscriptionProgress } from '../types';
+
+const DOWNLOAD_STATUSES = new Set(['initiate', 'download', 'progress', 'done']);
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function normalizedRatio(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function normalizeLocalWhisperDownloadProgress(
+  data: unknown
+): TranscriptionProgress | null {
+  if (typeof data !== 'object' || data === null) return null;
+
+  const record = data as Record<string, unknown>;
+  if (
+    typeof record.status !== 'string' ||
+    !DOWNLOAD_STATUSES.has(record.status)
+  ) {
+    return null;
+  }
+
+  const file =
+    typeof record.file === 'string' && record.file ? record.file : undefined;
+  const rawLoaded = finiteNumber(record.loaded);
+  const loadedBytes =
+    rawLoaded !== undefined && rawLoaded >= 0 ? rawLoaded : undefined;
+  const rawTotal = finiteNumber(record.total);
+  const totalBytes =
+    rawTotal !== undefined && rawTotal > 0 ? rawTotal : undefined;
+  const rawProgress = finiteNumber(record.progress);
+  const progress =
+    totalBytes === undefined
+      ? undefined
+      : rawProgress !== undefined
+        ? normalizedRatio(rawProgress / 100)
+        : loadedBytes !== undefined
+          ? normalizedRatio(loadedBytes / totalBytes)
+          : undefined;
+
+  return {
+    phase: 'download',
+    ...(file ? { file } : {}),
+    ...(loadedBytes !== undefined ? { loadedBytes } : {}),
+    ...(totalBytes !== undefined ? { totalBytes } : {}),
+    ...(progress !== undefined ? { progress } : {}),
+  };
+}

--- a/packages/transcription/src/providers/localWhisperProtocol.ts
+++ b/packages/transcription/src/providers/localWhisperProtocol.ts
@@ -1,0 +1,31 @@
+export type LocalWhisperWorkerRequest =
+  | {
+      type: 'load';
+      debug?: boolean;
+    }
+  | {
+      type: 'transcribe';
+      requestId: string;
+      audio: Float32Array;
+      language?: string;
+      debug?: boolean;
+    };
+
+export type LocalWhisperWorkerResponse =
+  | {
+      type: 'ready';
+    }
+  | {
+      type: 'progress';
+      data: unknown;
+    }
+  | {
+      type: 'result';
+      requestId: string;
+      text: string;
+    }
+  | {
+      type: 'error';
+      requestId?: string;
+      message: string;
+    };

--- a/packages/transcription/src/providers/localWhisperProtocol.ts
+++ b/packages/transcription/src/providers/localWhisperProtocol.ts
@@ -1,14 +1,16 @@
-import type { TranscriptionProgress } from '../types';
+import type { LocalWhisperModelSize, TranscriptionProgress } from '../types';
 
 export type LocalWhisperWorkerRequest =
   | {
       type: 'load';
+      model: LocalWhisperModelSize;
       debug?: boolean;
     }
   | {
       type: 'transcribe';
       requestId: string;
       audio: Float32Array;
+      model: LocalWhisperModelSize;
       language?: string;
       debug?: boolean;
     };
@@ -16,6 +18,7 @@ export type LocalWhisperWorkerRequest =
 export type LocalWhisperWorkerResponse =
   | {
       type: 'ready';
+      model: LocalWhisperModelSize;
     }
   | {
       type: 'progress';
@@ -29,5 +32,6 @@ export type LocalWhisperWorkerResponse =
   | {
       type: 'error';
       requestId?: string;
+      model?: LocalWhisperModelSize;
       message: string;
     };

--- a/packages/transcription/src/providers/localWhisperProtocol.ts
+++ b/packages/transcription/src/providers/localWhisperProtocol.ts
@@ -1,3 +1,5 @@
+import type { TranscriptionProgress } from '../types';
+
 export type LocalWhisperWorkerRequest =
   | {
       type: 'load';
@@ -17,7 +19,7 @@ export type LocalWhisperWorkerResponse =
     }
   | {
       type: 'progress';
-      data: unknown;
+      progress: TranscriptionProgress;
     }
   | {
       type: 'result';

--- a/packages/transcription/src/providers/resampleTo16k.ts
+++ b/packages/transcription/src/providers/resampleTo16k.ts
@@ -1,0 +1,32 @@
+const WHISPER_SAMPLE_RATE = 16_000;
+
+export function resampleTo16k(
+  input: Float32Array,
+  inputSampleRate: number
+): Float32Array {
+  if (!Number.isFinite(inputSampleRate) || inputSampleRate <= 0) {
+    throw new RangeError('The input sample rate must be a positive number.');
+  }
+  if (input.length === 0) return new Float32Array();
+  if (inputSampleRate === WHISPER_SAMPLE_RATE) {
+    return new Float32Array(input);
+  }
+
+  const outputLength = Math.max(
+    1,
+    Math.round((input.length * WHISPER_SAMPLE_RATE) / inputSampleRate)
+  );
+  const output = new Float32Array(outputLength);
+  const sourceStep = inputSampleRate / WHISPER_SAMPLE_RATE;
+
+  for (let index = 0; index < outputLength; index += 1) {
+    const sourcePosition = index * sourceStep;
+    const leftIndex = Math.min(Math.floor(sourcePosition), input.length - 1);
+    const rightIndex = Math.min(leftIndex + 1, input.length - 1);
+    const weight = sourcePosition - leftIndex;
+    output[index] =
+      input[leftIndex] * (1 - weight) + input[rightIndex] * weight;
+  }
+
+  return output;
+}

--- a/packages/transcription/src/support.ts
+++ b/packages/transcription/src/support.ts
@@ -1,13 +1,19 @@
 import type { TranscriptionProviderName } from './types';
 
+interface TranscriptionNavigator extends Navigator {
+  gpu?: unknown;
+}
+
 interface BrowserGlobal {
   isSecureContext?: boolean;
   SpeechRecognition?: unknown;
   webkitSpeechRecognition?: unknown;
-  navigator?: Navigator;
+  navigator?: TranscriptionNavigator;
   RTCPeerConnection?: unknown;
   AudioContext?: unknown;
   webkitAudioContext?: unknown;
+  AudioWorkletNode?: unknown;
+  Worker?: unknown;
 }
 
 function browserGlobal(): BrowserGlobal | undefined {
@@ -24,6 +30,17 @@ export function isTranscriptionProviderSupported(
   if (provider === 'web-speech') {
     return Boolean(
       browser.SpeechRecognition ?? browser.webkitSpeechRecognition
+    );
+  }
+
+  if (provider === 'local-whisper') {
+    return Boolean(
+      browser.isSecureContext !== false &&
+        browser.navigator?.mediaDevices?.getUserMedia &&
+        (browser.AudioContext ?? browser.webkitAudioContext) &&
+        browser.AudioWorkletNode &&
+        browser.Worker &&
+        browser.navigator?.gpu
     );
   }
 

--- a/packages/transcription/src/types.ts
+++ b/packages/transcription/src/types.ts
@@ -9,6 +9,16 @@ export interface TranscriptUpdate {
   isFinal: boolean;
 }
 
+export interface TranscriptionProgress {
+  phase: 'download' | 'initialize' | 'ready';
+  file?: string;
+  loadedBytes?: number;
+  totalBytes?: number;
+  /** Normalized progress from 0 to 1, when the total size is known. */
+  progress?: number;
+  message?: string;
+}
+
 export interface TranscriptionCapabilities {
   interimResults: boolean;
   multipleLanguages: boolean;
@@ -117,6 +127,7 @@ export interface RealtimeTranscriptionSession {
   stop(): Promise<void>;
   dispose(): Promise<void>;
   onTranscript(listener: (update: TranscriptUpdate) => void): () => void;
+  onProgress(listener: (progress: TranscriptionProgress) => void): () => void;
   onStateChange(listener: (state: TranscriptionState) => void): () => void;
   onError(listener: (error: TranscriptionError) => void): () => void;
 }

--- a/packages/transcription/src/types.ts
+++ b/packages/transcription/src/types.ts
@@ -69,6 +69,8 @@ export type TranscriptionDelay =
   | 'high'
   | 'xhigh';
 
+export type LocalWhisperModelSize = 'tiny' | 'base' | 'small';
+
 export interface WebSpeechTranscriptionOptions {
   provider: 'web-speech';
   language: string;
@@ -86,6 +88,14 @@ export interface OpenAIRealtimeTranscriptionOptions {
 
 export interface LocalWhisperTranscriptionOptions {
   provider: 'local-whisper';
+
+  /**
+   * Whisper model size.
+   *
+   * Default: "tiny". Larger models download more data on first use and infer
+   * more slowly, but can improve recognition quality.
+   */
+  model?: LocalWhisperModelSize;
 
   /**
    * Optional language hint.

--- a/packages/transcription/src/types.ts
+++ b/packages/transcription/src/types.ts
@@ -1,4 +1,7 @@
-export type TranscriptionProviderName = 'web-speech' | 'openai-realtime';
+export type TranscriptionProviderName =
+  | 'web-speech'
+  | 'openai-realtime'
+  | 'local-whisper';
 
 export interface TranscriptUpdate {
   utteranceId: string;
@@ -71,9 +74,40 @@ export interface OpenAIRealtimeTranscriptionOptions {
   delay?: TranscriptionDelay;
 }
 
+export interface LocalWhisperTranscriptionOptions {
+  provider: 'local-whisper';
+
+  /**
+   * Optional language hint.
+   *
+   * Accepts BCP 47-style input such as "ja-JP" or "en-US". The
+   * implementation normalizes this before passing it to Whisper. When omitted,
+   * Whisper performs language detection.
+   */
+  language?: string;
+
+  /**
+   * Amount of silence used to detect the end of an utterance.
+   *
+   * Default: 500
+   * Minimum: 150
+   */
+  silenceDurationMs?: number;
+
+  /**
+   * Advanced: override the URL of the local Whisper worker asset.
+   * Use this when your bundler cannot resolve the worker file that ships with
+   * this package (for example when the package is pre-bundled by a dev server).
+   * The URL must point to the `local-whisper.worker.js` asset built by this
+   * package or an equivalent module worker.
+   */
+  workerUrl?: string | URL;
+}
+
 export type RealtimeTranscriptionOptions =
   | WebSpeechTranscriptionOptions
-  | OpenAIRealtimeTranscriptionOptions;
+  | OpenAIRealtimeTranscriptionOptions
+  | LocalWhisperTranscriptionOptions;
 
 export interface RealtimeTranscriptionSession {
   readonly provider: TranscriptionProviderName;

--- a/packages/transcription/tests/BaseRealtimeTranscriptionSession.test.ts
+++ b/packages/transcription/tests/BaseRealtimeTranscriptionSession.test.ts
@@ -1,0 +1,53 @@
+import { BaseRealtimeTranscriptionSession } from '../src/BaseRealtimeTranscriptionSession';
+import type { TranscriptionProgress } from '../src/types';
+
+class TestTranscriptionSession extends BaseRealtimeTranscriptionSession {
+  constructor() {
+    super('web-speech', {
+      interimResults: false,
+      multipleLanguages: false,
+      keywords: false,
+      configurableDelay: false,
+    });
+  }
+
+  async start(): Promise<void> {}
+
+  async stop(): Promise<void> {}
+
+  async dispose(): Promise<void> {
+    this.clearListeners();
+  }
+
+  reportProgress(progress: TranscriptionProgress): void {
+    this.emitProgress(progress);
+  }
+}
+
+describe('BaseRealtimeTranscriptionSession', () => {
+  it('registers, unsubscribes, and clears progress listeners', async () => {
+    const session = new TestTranscriptionSession();
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+    const unsubscribe = session.onProgress(firstListener);
+    session.onProgress(secondListener);
+    const progress: TranscriptionProgress = {
+      phase: 'download',
+      file: 'model.onnx',
+      loadedBytes: 25,
+      totalBytes: 100,
+      progress: 0.25,
+    };
+
+    session.reportProgress(progress);
+    unsubscribe();
+    session.reportProgress({ phase: 'initialize' });
+    await session.dispose();
+    session.reportProgress({ phase: 'ready' });
+
+    expect(firstListener).toHaveBeenCalledOnce();
+    expect(firstListener).toHaveBeenCalledWith(progress);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+    expect(secondListener).toHaveBeenLastCalledWith({ phase: 'initialize' });
+  });
+});

--- a/packages/transcription/tests/BrowserPcmTurnCapture.test.ts
+++ b/packages/transcription/tests/BrowserPcmTurnCapture.test.ts
@@ -1,0 +1,112 @@
+import { BrowserPcmTurnCapture } from '../src/providers/BrowserPcmTurnCapture';
+
+class MockAudioNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockAudioWorkletNode extends MockAudioNode {
+  readonly port = { onmessage: null };
+}
+
+class MockAudioContext {
+  readonly sampleRate = 48_000;
+  readonly state: AudioContextState = 'running';
+  readonly destination = new MockAudioNode();
+  readonly audioWorklet = { addModule: vi.fn(async () => undefined) };
+  readonly sourceNode = new MockAudioNode();
+  readonly gainNode = Object.assign(new MockAudioNode(), {
+    gain: { value: 1 },
+  });
+
+  createMediaStreamSource = vi.fn(() => this.sourceNode);
+  createGain = vi.fn(() => this.gainNode);
+  resume = vi.fn(async () => undefined);
+  close = vi.fn(async () => undefined);
+}
+
+class MockBlob {
+  constructor(readonly parts: BlobPart[]) {}
+}
+
+const createObjectURL = vi.fn((_blob: Blob) => 'blob:worklet');
+const revokeObjectURL = vi.fn((_url: string) => undefined);
+
+describe('BrowserPcmTurnCapture', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', MockAudioContext);
+    vi.stubGlobal('AudioWorkletNode', MockAudioWorkletNode);
+    vi.stubGlobal('Blob', MockBlob);
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
+  it('batches 128-frame worklet blocks into approximately 32ms messages', async () => {
+    const stream = {
+      getTracks: () => [],
+    } as unknown as MediaStream;
+    const capture = new BrowserPcmTurnCapture(stream, {
+      silenceDurationMs: 500,
+      onTurn: vi.fn(),
+    });
+    await capture.start();
+    const blob = createObjectURL.mock.calls[0]?.[0] as unknown as
+      | MockBlob
+      | undefined;
+    const source = blob?.parts.join('');
+    if (!source) throw new Error('Expected the AudioWorklet source.');
+
+    const postMessage = vi.fn();
+    class TestAudioWorkletProcessor {
+      readonly port = { postMessage };
+    }
+    let Processor:
+      | (new () => {
+          process(inputs: Float32Array[][]): boolean;
+        })
+      | undefined;
+    const evaluateWorklet = new Function(
+      'AudioWorkletProcessor',
+      'registerProcessor',
+      'sampleRate',
+      source
+    );
+    evaluateWorklet(
+      TestAudioWorkletProcessor,
+      (_name: string, RegisteredProcessor: typeof Processor) => {
+        Processor = RegisteredProcessor;
+      },
+      48_000
+    );
+    if (!Processor) throw new Error('Expected a registered processor.');
+    const processor = new Processor();
+
+    for (let block = 0; block < 11; block += 1) {
+      processor.process([[new Float32Array(128)]]);
+    }
+    expect(postMessage).not.toHaveBeenCalled();
+
+    processor.process([[new Float32Array(128)]]);
+
+    expect(postMessage).toHaveBeenCalledOnce();
+    const [chunk, transfer] = postMessage.mock.calls[0] ?? [];
+    expect(chunk).toBeInstanceOf(Float32Array);
+    expect(chunk).toHaveLength(1_536);
+    expect(transfer).toEqual([chunk.buffer]);
+    await capture.stop();
+  });
+});

--- a/packages/transcription/tests/BrowserVoiceActivityDetector.test.ts
+++ b/packages/transcription/tests/BrowserVoiceActivityDetector.test.ts
@@ -1,0 +1,77 @@
+import { BrowserVoiceActivityDetector } from '../src/providers/BrowserVoiceActivityDetector';
+
+class MockMediaStreamAudioSourceNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockAnalyserNode {
+  fftSize = 2048;
+  smoothingTimeConstant = 0;
+  disconnect = vi.fn();
+
+  getFloatTimeDomainData(samples: Float32Array): void {
+    samples.fill(MockAudioContext.inputLevel);
+  }
+}
+
+class MockAudioContext {
+  static inputLevel = 0;
+
+  state: AudioContextState = 'running';
+  private readonly sourceNode = new MockMediaStreamAudioSourceNode();
+  private readonly analyserNode = new MockAnalyserNode();
+
+  createMediaStreamSource = vi.fn(() => this.sourceNode);
+  createAnalyser = vi.fn(() => this.analyserNode);
+  resume = vi.fn(async () => undefined);
+  close = vi.fn(async () => {
+    this.state = 'closed';
+  });
+}
+
+interface TestableBrowserVoiceActivityDetector {
+  sampleAudioLevel(): void;
+}
+
+describe('BrowserVoiceActivityDetector', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-16T00:00:00Z'));
+    MockAudioContext.inputLevel = 0;
+    Object.defineProperty(globalThis, 'AudioContext', {
+      configurable: true,
+      value: MockAudioContext,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, 'AudioContext');
+  });
+
+  it('ends speech from one silence sample after a throttled interval', async () => {
+    const onSpeechEnd = vi.fn();
+    const detector = new BrowserVoiceActivityDetector(
+      {} as MediaStream,
+      onSpeechEnd
+    );
+    const testableDetector =
+      detector as unknown as TestableBrowserVoiceActivityDetector;
+    await detector.start();
+
+    MockAudioContext.inputLevel = 0.05;
+    testableDetector.sampleAudioLevel();
+    vi.setSystemTime(Date.now() + 50);
+    testableDetector.sampleAudioLevel();
+    vi.setSystemTime(Date.now() + 50);
+    testableDetector.sampleAudioLevel();
+
+    MockAudioContext.inputLevel = 0;
+    vi.setSystemTime(Date.now() + 1_000);
+    testableDetector.sampleAudioLevel();
+
+    expect(onSpeechEnd).toHaveBeenCalledOnce();
+    detector.stop();
+  });
+});

--- a/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
+++ b/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
@@ -1,0 +1,437 @@
+import { TranscriptionSessionError } from '../src/errors';
+import {
+  createRealtimeTranscriptionSession,
+  isTranscriptionProviderSupported,
+} from '../src';
+import {
+  isLikelyWhisperHallucination,
+  LocalWhisperTranscriptionSession,
+  normalizeWhisperLanguage,
+} from '../src/providers/LocalWhisperTranscriptionSession';
+import type { LocalWhisperTranscriptionInput } from '../src/providers/LocalWhisperWorkerClient';
+import type { BrowserPcmTurnCaptureOptions } from '../src/providers/BrowserPcmTurnCapture';
+import type { CapturedAudioTurn } from '../src/providers/PcmTurnAssembler';
+import type {
+  RealtimeTranscriptionSession,
+  LocalWhisperTranscriptionOptions,
+  TranscriptUpdate,
+  TranscriptionError,
+} from '../src/types';
+import type { Mock } from 'vitest';
+
+class MockMediaStreamTrack {
+  stop = vi.fn();
+}
+
+class MockMediaStream {
+  readonly track = new MockMediaStreamTrack();
+
+  getTracks(): MediaStreamTrack[] {
+    return [this.track as unknown as MediaStreamTrack];
+  }
+}
+
+class MockWorkerClient {
+  hasFailed = false;
+  load = vi.fn<[], Promise<void>>(async () => undefined);
+  transcribe = vi.fn<[LocalWhisperTranscriptionInput], Promise<string>>(
+    async () => 'transcribed'
+  );
+  dispose = vi.fn();
+}
+
+class MockCapture {
+  start = vi.fn(async () => undefined);
+  stop = vi.fn(async () => {
+    for (const track of this.stream.getTracks()) track.stop();
+  });
+
+  constructor(
+    private readonly stream: MediaStream,
+    private readonly onTurn: (turn: CapturedAudioTurn) => void
+  ) {}
+
+  emitTurn(turn: CapturedAudioTurn): void {
+    this.onTurn(turn);
+  }
+}
+
+function capturedTurn(
+  confirmedSpeechDurationMs = 300,
+  sampleRate = 16_000
+): CapturedAudioTurn {
+  return {
+    audio: new Float32Array(sampleRate / 2).fill(0.1),
+    sampleRate,
+    confirmedSpeechDurationMs,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (cause: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+let activeSessions: RealtimeTranscriptionSession[] = [];
+let stream: MockMediaStream;
+let workerClient: MockWorkerClient;
+let capture: MockCapture | null;
+let getUserMedia: Mock<[MediaStreamConstraints], Promise<MockMediaStream>>;
+let createWorkerClient: Mock<[workerUrl?: string | URL], MockWorkerClient>;
+let createCapture: Mock<
+  [MediaStream, BrowserPcmTurnCaptureOptions],
+  MockCapture
+>;
+
+function createSession(
+  options: LocalWhisperTranscriptionOptions = { provider: 'local-whisper' }
+): LocalWhisperTranscriptionSession {
+  const session = new LocalWhisperTranscriptionSession(options, {
+    createWorkerClient,
+    createCapture,
+  });
+  activeSessions.push(session);
+  return session;
+}
+
+describe('LocalWhisperTranscriptionSession', () => {
+  beforeEach(() => {
+    activeSessions = [];
+    stream = new MockMediaStream();
+    workerClient = new MockWorkerClient();
+    capture = null;
+    getUserMedia = vi.fn(
+      async (_constraints: MediaStreamConstraints) => stream
+    );
+    createWorkerClient = vi.fn((_workerUrl?: string | URL) => workerClient);
+    createCapture = vi.fn(
+      (mediaStream: MediaStream, options: BrowserPcmTurnCaptureOptions) => {
+        capture = new MockCapture(mediaStream, options.onTurn);
+        return capture;
+      }
+    );
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    });
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    vi.stubGlobal('AudioContext', class {});
+    vi.stubGlobal('AudioWorkletNode', class {});
+    vi.stubGlobal('Worker', class {});
+  });
+
+  afterEach(async () => {
+    await Promise.all(activeSessions.map((session) => session.dispose()));
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'mediaDevices');
+    Reflect.deleteProperty(navigator, 'gpu');
+    Reflect.deleteProperty(window, 'isSecureContext');
+  });
+
+  it('starts capture after loading the worker and exposes fixed capabilities', async () => {
+    const session = createSession({
+      provider: 'local-whisper',
+      silenceDurationMs: 250,
+      workerUrl: '/custom-worker.js',
+    });
+
+    await session.start();
+
+    expect(session.provider).toBe('local-whisper');
+    expect(session.capabilities).toEqual({
+      interimResults: false,
+      multipleLanguages: false,
+      keywords: false,
+      configurableDelay: true,
+    });
+    expect(session.state).toBe('listening');
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+    expect(createWorkerClient).toHaveBeenCalledWith('/custom-worker.js');
+    expect(createCapture).toHaveBeenCalledWith(
+      stream,
+      expect.objectContaining({ silenceDurationMs: 250 })
+    );
+    expect(workerClient.load).toHaveBeenCalledOnce();
+    expect(capture?.start).toHaveBeenCalledOnce();
+  });
+
+  it('is created by the public factory when browser support is available', async () => {
+    expect(isTranscriptionProviderSupported('local-whisper')).toBe(true);
+
+    const session = createRealtimeTranscriptionSession({
+      provider: 'local-whisper',
+      language: 'ja-JP',
+    });
+    activeSessions.push(session);
+
+    expect(session).toBeInstanceOf(LocalWhisperTranscriptionSession);
+    expect(session.provider).toBe('local-whisper');
+  });
+
+  it('normalizes the language and emits ordered final transcripts', async () => {
+    const firstResult = deferred<string>();
+    const secondResult = deferred<string>();
+    workerClient.transcribe
+      .mockImplementationOnce(() => firstResult.promise)
+      .mockImplementationOnce(() => secondResult.promise);
+    const session = createSession({
+      provider: 'local-whisper',
+      language: 'JA_jP',
+    });
+    const updates: TranscriptUpdate[] = [];
+    session.onTranscript((update) => updates.push(update));
+    await session.start();
+
+    capture?.emitTurn(capturedTurn());
+    capture?.emitTurn(capturedTurn());
+    await vi.waitFor(() => {
+      expect(workerClient.transcribe).toHaveBeenCalledTimes(1);
+    });
+    firstResult.resolve(' 最初 ');
+    await vi.waitFor(() => {
+      expect(workerClient.transcribe).toHaveBeenCalledTimes(2);
+    });
+    secondResult.resolve('次');
+    await vi.waitFor(() => {
+      expect(updates).toHaveLength(2);
+    });
+
+    expect(workerClient.transcribe.mock.calls[0]?.[0].language).toBe('ja');
+    expect(updates).toEqual([
+      {
+        utteranceId: 'local-whisper:1',
+        text: '最初',
+        isFinal: true,
+      },
+      {
+        utteranceId: 'local-whisper:2',
+        text: '次',
+        isFinal: true,
+      },
+    ]);
+  });
+
+  it('drops short turns, empty output, and known hallucinations', async () => {
+    workerClient.transcribe
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(' ご視聴ありがとうございました！！ ')
+      .mockResolvedValueOnce('有効な発話');
+    const session = createSession();
+    const updates: TranscriptUpdate[] = [];
+    session.onTranscript((update) => updates.push(update));
+    await session.start();
+
+    capture?.emitTurn(capturedTurn(299));
+    capture?.emitTurn(capturedTurn(300));
+    capture?.emitTurn(capturedTurn(300));
+    capture?.emitTurn(capturedTurn(300));
+    await session.stop();
+
+    expect(workerClient.transcribe).toHaveBeenCalledTimes(3);
+    expect(updates).toEqual([
+      {
+        utteranceId: 'local-whisper:3',
+        text: '有効な発話',
+        isFinal: true,
+      },
+    ]);
+  });
+
+  it('flushes the final capture turn and waits for inference on stop', async () => {
+    const result = deferred<string>();
+    workerClient.transcribe.mockImplementationOnce(() => result.promise);
+    const session = createSession();
+    const updates: TranscriptUpdate[] = [];
+    session.onTranscript((update) => updates.push(update));
+    await session.start();
+    capture?.stop.mockImplementationOnce(async () => {
+      capture?.emitTurn(capturedTurn());
+      stream.track.stop();
+    });
+
+    const stopPromise = session.stop();
+    await vi.waitFor(() => {
+      expect(workerClient.transcribe).toHaveBeenCalledOnce();
+    });
+    expect(session.state).toBe('stopping');
+    result.resolve('停止時の発話');
+    await stopPromise;
+
+    expect(updates[0]?.text).toBe('停止時の発話');
+    expect(session.state).toBe('idle');
+    expect(stream.track.stop).toHaveBeenCalledOnce();
+    expect(workerClient.dispose).not.toHaveBeenCalled();
+  });
+
+  it('cancels a connecting session without emitting an error', async () => {
+    const modelLoad = deferred<void>();
+    workerClient.load.mockImplementationOnce(() => modelLoad.promise);
+    const session = createSession();
+    const errors = vi.fn();
+    session.onError(errors);
+
+    const startPromise = session.start();
+    await vi.waitFor(() => {
+      expect(capture).not.toBeNull();
+    });
+    const stopPromise = session.stop();
+    expect(session.state).toBe('stopping');
+    expect(stream.track.stop).toHaveBeenCalled();
+
+    modelLoad.resolve();
+    await Promise.all([startPromise, stopPromise]);
+
+    expect(session.state).toBe('idle');
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  it('reuses the warm worker client after stop and restart', async () => {
+    const session = createSession();
+    await session.start();
+    await session.stop();
+
+    await session.start();
+
+    expect(createWorkerClient).toHaveBeenCalledOnce();
+    expect(workerClient.load).toHaveBeenCalledTimes(2);
+    expect(createCapture).toHaveBeenCalledTimes(2);
+    expect(session.state).toBe('listening');
+  });
+
+  it('maps microphone permission rejection to a typed error', async () => {
+    getUserMedia.mockRejectedValueOnce(
+      new DOMException('Permission denied', 'NotAllowedError')
+    );
+    const session = createSession();
+    const errors: TranscriptionError[] = [];
+    session.onError((error) => errors.push(error));
+
+    await expect(session.start()).rejects.toMatchObject({
+      code: 'permission-denied',
+      provider: 'local-whisper',
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(session.state).toBe('error');
+    expect(createWorkerClient).not.toHaveBeenCalled();
+  });
+
+  it('maps model initialization failure and releases resources', async () => {
+    workerClient.load.mockRejectedValueOnce(new Error('model unavailable'));
+    const session = createSession();
+
+    await expect(session.start()).rejects.toMatchObject({
+      code: 'provider-error',
+      message: 'Failed to initialize the local Whisper model.',
+    });
+
+    expect(capture?.stop).toHaveBeenCalledOnce();
+    expect(workerClient.dispose).toHaveBeenCalledOnce();
+    expect(session.state).toBe('error');
+  });
+
+  it('keeps a request-level inference failure recoverable', async () => {
+    workerClient.transcribe
+      .mockRejectedValueOnce(new Error('request failed'))
+      .mockResolvedValueOnce('recovered');
+    const session = createSession();
+    const errors: TranscriptionError[] = [];
+    const updates: TranscriptUpdate[] = [];
+    session.onError((error) => errors.push(error));
+    session.onTranscript((update) => updates.push(update));
+    await session.start();
+
+    capture?.emitTurn(capturedTurn());
+    capture?.emitTurn(capturedTurn());
+    await session.stop();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: 'provider-error' });
+    expect(updates[0]?.text).toBe('recovered');
+    expect(session.state).toBe('idle');
+  });
+
+  it('enters error and stops capture after a fatal worker failure', async () => {
+    workerClient.hasFailed = true;
+    workerClient.transcribe.mockRejectedValueOnce(
+      new Error('WebGPU device lost')
+    );
+    const session = createSession();
+    await session.start();
+
+    capture?.emitTurn(capturedTurn());
+    await vi.waitFor(() => {
+      expect(session.state).toBe('error');
+    });
+
+    expect(workerClient.dispose).toHaveBeenCalledOnce();
+    expect(capture?.stop).toHaveBeenCalledOnce();
+  });
+
+  it('disposes capture and worker and rejects a later start', async () => {
+    const session = createSession();
+    await session.start();
+
+    await session.dispose();
+
+    expect(capture?.stop).toHaveBeenCalledOnce();
+    expect(workerClient.dispose).toHaveBeenCalledOnce();
+    expect(session.state).toBe('disposed');
+    expect(() => session.start()).toThrow(TranscriptionSessionError);
+  });
+
+  it('rejects unsupported WebGPU and invalid options', async () => {
+    Reflect.deleteProperty(navigator, 'gpu');
+    const unsupportedSession = createSession();
+
+    await expect(unsupportedSession.start()).rejects.toMatchObject({
+      code: 'unsupported-provider',
+      message: 'Local Whisper transcription requires WebGPU support.',
+    });
+    expect(() =>
+      createSession({
+        provider: 'local-whisper',
+        silenceDurationMs: 149,
+      })
+    ).toThrowError(expect.objectContaining({ code: 'invalid-configuration' }));
+  });
+});
+
+describe('local Whisper text helpers', () => {
+  it('normalizes BCP 47-style language hints', () => {
+    expect(normalizeWhisperLanguage(undefined)).toBeUndefined();
+    expect(normalizeWhisperLanguage('ja')).toBe('ja');
+    expect(normalizeWhisperLanguage('JA_jP')).toBe('ja');
+    expect(normalizeWhisperLanguage('en-GB')).toBe('en');
+    expect(normalizeWhisperLanguage('fr-FR')).toBe('fr');
+  });
+
+  it('matches hallucinations after NFKC and trailing punctuation cleanup', () => {
+    expect(
+      isLikelyWhisperHallucination(' ご視聴ありがとうございました！！ ')
+    ).toBe(true);
+    expect(isLikelyWhisperHallucination('Ｔｈａｎｋ ｙｏｕ．')).toBe(true);
+    expect(isLikelyWhisperHallucination('THANKS FOR WATCHING!')).toBe(true);
+    expect(isLikelyWhisperHallucination('通常の発話です')).toBe(false);
+  });
+});

--- a/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
+++ b/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
@@ -12,6 +12,7 @@ import type { LocalWhisperTranscriptionInput } from '../src/providers/LocalWhisp
 import type { BrowserPcmTurnCaptureOptions } from '../src/providers/BrowserPcmTurnCapture';
 import type { CapturedAudioTurn } from '../src/providers/PcmTurnAssembler';
 import type {
+  LocalWhisperModelSize,
   RealtimeTranscriptionSession,
   LocalWhisperTranscriptionOptions,
   TranscriptUpdate,
@@ -37,7 +38,7 @@ class MockWorkerClient {
   private readonly progressListeners = new Set<
     (progress: TranscriptionProgress) => void
   >();
-  load = vi.fn<[], Promise<void>>(async () => undefined);
+  load = vi.fn<[LocalWhisperModelSize], Promise<void>>(async () => undefined);
   transcribe = vi.fn<[LocalWhisperTranscriptionInput], Promise<string>>(
     async () => 'transcribed'
   );
@@ -185,6 +186,7 @@ describe('LocalWhisperTranscriptionSession', () => {
       expect.objectContaining({ silenceDurationMs: 250 })
     );
     expect(workerClient.load).toHaveBeenCalledOnce();
+    expect(workerClient.load).toHaveBeenCalledWith('tiny');
     expect(capture?.start).toHaveBeenCalledOnce();
   });
 
@@ -237,10 +239,13 @@ describe('LocalWhisperTranscriptionSession', () => {
     workerClient.transcribe
       .mockImplementationOnce(() => firstResult.promise)
       .mockImplementationOnce(() => secondResult.promise);
-    const session = createSession({
+    const options: LocalWhisperTranscriptionOptions = {
       provider: 'local-whisper',
       language: 'JA_jP',
-    });
+      model: 'small',
+    };
+    const session = createSession(options);
+    options.model = 'tiny';
     const updates: TranscriptUpdate[] = [];
     session.onTranscript((update) => updates.push(update));
     await session.start();
@@ -260,6 +265,7 @@ describe('LocalWhisperTranscriptionSession', () => {
     });
 
     expect(workerClient.transcribe.mock.calls[0]?.[0].language).toBe('ja');
+    expect(workerClient.transcribe.mock.calls[0]?.[0].model).toBe('small');
     expect(updates).toEqual([
       {
         utteranceId: 'local-whisper:1',
@@ -455,6 +461,12 @@ describe('LocalWhisperTranscriptionSession', () => {
       createSession({
         provider: 'local-whisper',
         silenceDurationMs: 149,
+      })
+    ).toThrowError(expect.objectContaining({ code: 'invalid-configuration' }));
+    expect(() =>
+      createSession({
+        provider: 'local-whisper',
+        model: 'medium' as LocalWhisperModelSize,
       })
     ).toThrowError(expect.objectContaining({ code: 'invalid-configuration' }));
   });

--- a/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
+++ b/packages/transcription/tests/LocalWhisperTranscriptionSession.test.ts
@@ -16,6 +16,7 @@ import type {
   LocalWhisperTranscriptionOptions,
   TranscriptUpdate,
   TranscriptionError,
+  TranscriptionProgress,
 } from '../src/types';
 import type { Mock } from 'vitest';
 
@@ -33,11 +34,23 @@ class MockMediaStream {
 
 class MockWorkerClient {
   hasFailed = false;
+  private readonly progressListeners = new Set<
+    (progress: TranscriptionProgress) => void
+  >();
   load = vi.fn<[], Promise<void>>(async () => undefined);
   transcribe = vi.fn<[LocalWhisperTranscriptionInput], Promise<string>>(
     async () => 'transcribed'
   );
   dispose = vi.fn();
+
+  onProgress(listener: (progress: TranscriptionProgress) => void): () => void {
+    this.progressListeners.add(listener);
+    return () => this.progressListeners.delete(listener);
+  }
+
+  emitProgress(progress: TranscriptionProgress): void {
+    for (const listener of this.progressListeners) listener(progress);
+  }
 }
 
 class MockCapture {
@@ -173,6 +186,36 @@ describe('LocalWhisperTranscriptionSession', () => {
     );
     expect(workerClient.load).toHaveBeenCalledOnce();
     expect(capture?.start).toHaveBeenCalledOnce();
+  });
+
+  it('emits worker progress only while connecting', async () => {
+    const modelLoad = deferred<void>();
+    workerClient.load.mockImplementationOnce(() => modelLoad.promise);
+    const session = createSession();
+    const progressEvents: TranscriptionProgress[] = [];
+    session.onProgress((progress) => progressEvents.push(progress));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => {
+      expect(workerClient.load).toHaveBeenCalledOnce();
+    });
+    const downloadProgress: TranscriptionProgress = {
+      phase: 'download',
+      file: 'model.onnx',
+      loadedBytes: 50,
+      totalBytes: 100,
+      progress: 0.5,
+    };
+    workerClient.emitProgress(downloadProgress);
+    modelLoad.resolve();
+    await startPromise;
+
+    workerClient.emitProgress({ phase: 'initialize' });
+    const stopPromise = session.stop();
+    workerClient.emitProgress({ phase: 'ready' });
+    await stopPromise;
+
+    expect(progressEvents).toEqual([downloadProgress]);
   });
 
   it('is created by the public factory when browser support is available', async () => {

--- a/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
+++ b/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
@@ -1,0 +1,170 @@
+import { LocalWhisperWorkerClient } from '../src/providers/LocalWhisperWorkerClient';
+import type {
+  LocalWhisperWorkerRequest,
+  LocalWhisperWorkerResponse,
+} from '../src/providers/localWhisperProtocol';
+
+interface PostedMessage {
+  message: LocalWhisperWorkerRequest;
+  transfer: Transferable[];
+}
+
+class MockWorker {
+  static instances: MockWorker[] = [];
+
+  readonly postedMessages: PostedMessage[] = [];
+  readonly terminate = vi.fn();
+  onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+
+  constructor(
+    readonly url: string | URL,
+    readonly options: WorkerOptions
+  ) {
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(message: LocalWhisperWorkerRequest, transfer: Transferable[]) {
+    const cloned = structuredClone(message, { transfer });
+    this.postedMessages.push({ message: cloned, transfer });
+  }
+
+  emit(response: LocalWhisperWorkerResponse): void {
+    this.onmessage?.(new MessageEvent('message', { data: response }));
+  }
+
+  fail(message: string): void {
+    this.onerror?.(new ErrorEvent('error', { message }));
+  }
+}
+
+function currentWorker(): MockWorker {
+  const worker = MockWorker.instances.at(-1);
+  if (!worker) throw new Error('Expected a worker instance.');
+  return worker;
+}
+
+async function createLoadedClient(): Promise<LocalWhisperWorkerClient> {
+  const client = new LocalWhisperWorkerClient('/local-whisper.worker.js');
+  const loadPromise = client.load();
+  currentWorker().emit({ type: 'ready' });
+  await loadPromise;
+  return client;
+}
+
+describe('LocalWhisperWorkerClient', () => {
+  beforeEach(() => {
+    MockWorker.instances = [];
+    vi.stubGlobal('Worker', MockWorker);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads the model once and resolves on ready', async () => {
+    const client = new LocalWhisperWorkerClient('/worker.js');
+
+    const firstLoad = client.load();
+    const secondLoad = client.load();
+    const worker = currentWorker();
+    worker.emit({ type: 'ready' });
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(worker.url).toBe('/worker.js');
+    expect(worker.options).toEqual({ type: 'module' });
+    expect(worker.postedMessages.map(({ message }) => message)).toEqual([
+      { type: 'load' },
+    ]);
+  });
+
+  it('resolves transcription by request ID and transfers audio ownership', async () => {
+    const client = await createLoadedClient();
+    const worker = currentWorker();
+    const audio = new Float32Array([0.1, -0.1]);
+
+    const resultPromise = client.transcribe({ audio, language: 'ja' });
+    await vi.waitFor(() => {
+      expect(worker.postedMessages).toHaveLength(2);
+    });
+    const posted = worker.postedMessages[1];
+    const request = posted?.message;
+    if (!request || request.type !== 'transcribe') {
+      throw new Error('Expected a transcription request.');
+    }
+    worker.emit({
+      type: 'result',
+      requestId: request.requestId,
+      text: 'こんにちは',
+    });
+
+    await expect(resultPromise).resolves.toBe('こんにちは');
+    expect(posted.transfer).toHaveLength(1);
+    expect(audio.byteLength).toBe(0);
+  });
+
+  it('posts multiple inference requests sequentially', async () => {
+    const client = await createLoadedClient();
+    const worker = currentWorker();
+
+    const first = client.transcribe({ audio: new Float32Array([0.1]) });
+    const second = client.transcribe({ audio: new Float32Array([0.2]) });
+    await vi.waitFor(() => {
+      expect(worker.postedMessages).toHaveLength(2);
+    });
+
+    const firstRequest = worker.postedMessages[1]?.message;
+    if (!firstRequest || firstRequest.type !== 'transcribe') {
+      throw new Error('Expected the first transcription request.');
+    }
+    worker.emit({
+      type: 'result',
+      requestId: firstRequest.requestId,
+      text: 'first',
+    });
+    await first;
+    await vi.waitFor(() => {
+      expect(worker.postedMessages).toHaveLength(3);
+    });
+    const secondRequest = worker.postedMessages[2]?.message;
+    if (!secondRequest || secondRequest.type !== 'transcribe') {
+      throw new Error('Expected the second transcription request.');
+    }
+    worker.emit({
+      type: 'result',
+      requestId: secondRequest.requestId,
+      text: 'second',
+    });
+
+    await expect(second).resolves.toBe('second');
+  });
+
+  it('rejects pending work when the worker fails', async () => {
+    const client = await createLoadedClient();
+    const resultPromise = client.transcribe({
+      audio: new Float32Array([0.1]),
+    });
+    await Promise.resolve();
+
+    currentWorker().fail('WebGPU device lost');
+
+    await expect(resultPromise).rejects.toThrow('WebGPU device lost');
+    await expect(
+      client.transcribe({ audio: new Float32Array([0.2]) })
+    ).rejects.toThrow('WebGPU device lost');
+  });
+
+  it('rejects loading and queued inference when disposed', async () => {
+    const client = new LocalWhisperWorkerClient('/worker.js');
+    const loadPromise = client.load();
+    const resultPromise = client.transcribe({
+      audio: new Float32Array([0.1]),
+    });
+
+    client.dispose();
+
+    await expect(loadPromise).rejects.toThrow('disposed');
+    await expect(resultPromise).rejects.toThrow('disposed');
+    expect(currentWorker().terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
+++ b/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
@@ -46,8 +46,8 @@ function currentWorker(): MockWorker {
 
 async function createLoadedClient(): Promise<LocalWhisperWorkerClient> {
   const client = new LocalWhisperWorkerClient('/local-whisper.worker.js');
-  const loadPromise = client.load();
-  currentWorker().emit({ type: 'ready' });
+  const loadPromise = client.load('tiny');
+  currentWorker().emit({ type: 'ready', model: 'tiny' });
   await loadPromise;
   return client;
 }
@@ -65,16 +65,33 @@ describe('LocalWhisperWorkerClient', () => {
   it('loads the model once and resolves on ready', async () => {
     const client = new LocalWhisperWorkerClient('/worker.js');
 
-    const firstLoad = client.load();
-    const secondLoad = client.load();
+    const firstLoad = client.load('tiny');
+    const secondLoad = client.load('tiny');
     const worker = currentWorker();
-    worker.emit({ type: 'ready' });
+    worker.emit({ type: 'ready', model: 'tiny' });
     await Promise.all([firstLoad, secondLoad]);
 
     expect(worker.url).toBe('/worker.js');
     expect(worker.options).toEqual({ type: 'module' });
     expect(worker.postedMessages.map(({ message }) => message)).toEqual([
-      { type: 'load' },
+      { type: 'load', model: 'tiny' },
+    ]);
+  });
+
+  it('loads and retains a separate transcriber for each model size', async () => {
+    const client = new LocalWhisperWorkerClient('/worker.js');
+    const worker = currentWorker();
+
+    const tinyLoad = client.load('tiny');
+    const baseLoad = client.load('base');
+    const repeatedTinyLoad = client.load('tiny');
+    worker.emit({ type: 'ready', model: 'tiny' });
+    worker.emit({ type: 'ready', model: 'base' });
+    await Promise.all([tinyLoad, baseLoad, repeatedTinyLoad]);
+
+    expect(worker.postedMessages.map(({ message }) => message)).toEqual([
+      { type: 'load', model: 'tiny' },
+      { type: 'load', model: 'base' },
     ]);
   });
 
@@ -106,7 +123,11 @@ describe('LocalWhisperWorkerClient', () => {
     const worker = currentWorker();
     const audio = new Float32Array([0.1, -0.1]);
 
-    const resultPromise = client.transcribe({ audio, language: 'ja' });
+    const resultPromise = client.transcribe({
+      audio,
+      model: 'tiny',
+      language: 'ja',
+    });
     await vi.waitFor(() => {
       expect(worker.postedMessages).toHaveLength(2);
     });
@@ -124,14 +145,21 @@ describe('LocalWhisperWorkerClient', () => {
     await expect(resultPromise).resolves.toBe('こんにちは');
     expect(posted.transfer).toHaveLength(1);
     expect(audio.byteLength).toBe(0);
+    expect(request.model).toBe('tiny');
   });
 
   it('posts multiple inference requests sequentially', async () => {
     const client = await createLoadedClient();
     const worker = currentWorker();
 
-    const first = client.transcribe({ audio: new Float32Array([0.1]) });
-    const second = client.transcribe({ audio: new Float32Array([0.2]) });
+    const first = client.transcribe({
+      audio: new Float32Array([0.1]),
+      model: 'tiny',
+    });
+    const second = client.transcribe({
+      audio: new Float32Array([0.2]),
+      model: 'tiny',
+    });
     await vi.waitFor(() => {
       expect(worker.postedMessages).toHaveLength(2);
     });
@@ -166,6 +194,7 @@ describe('LocalWhisperWorkerClient', () => {
     const client = await createLoadedClient();
     const resultPromise = client.transcribe({
       audio: new Float32Array([0.1]),
+      model: 'tiny',
     });
     await Promise.resolve();
 
@@ -173,15 +202,16 @@ describe('LocalWhisperWorkerClient', () => {
 
     await expect(resultPromise).rejects.toThrow('WebGPU device lost');
     await expect(
-      client.transcribe({ audio: new Float32Array([0.2]) })
+      client.transcribe({ audio: new Float32Array([0.2]), model: 'tiny' })
     ).rejects.toThrow('WebGPU device lost');
   });
 
   it('rejects loading and queued inference when disposed', async () => {
     const client = new LocalWhisperWorkerClient('/worker.js');
-    const loadPromise = client.load();
+    const loadPromise = client.load('small');
     const resultPromise = client.transcribe({
       audio: new Float32Array([0.1]),
+      model: 'small',
     });
 
     client.dispose();

--- a/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
+++ b/packages/transcription/tests/LocalWhisperWorkerClient.test.ts
@@ -78,6 +78,29 @@ describe('LocalWhisperWorkerClient', () => {
     ]);
   });
 
+  it('forwards normalized progress messages and lets listeners unsubscribe', () => {
+    const client = new LocalWhisperWorkerClient('/worker.js');
+    const listener = vi.fn();
+    const unsubscribe = client.onProgress(listener);
+    const progress = {
+      phase: 'download' as const,
+      file: 'model.onnx',
+      loadedBytes: 25,
+      totalBytes: 100,
+      progress: 0.25,
+    };
+
+    currentWorker().emit({ type: 'progress', progress });
+    unsubscribe();
+    currentWorker().emit({
+      type: 'progress',
+      progress: { phase: 'initialize' },
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(progress);
+  });
+
   it('resolves transcription by request ID and transfers audio ownership', async () => {
     const client = await createLoadedClient();
     const worker = currentWorker();

--- a/packages/transcription/tests/PcmTurnAssembler.test.ts
+++ b/packages/transcription/tests/PcmTurnAssembler.test.ts
@@ -1,0 +1,71 @@
+import { PcmTurnAssembler } from '../src/providers/PcmTurnAssembler';
+
+function createAssembler(
+  overrides: Partial<ConstructorParameters<typeof PcmTurnAssembler>[0]> = {}
+) {
+  return new PcmTurnAssembler({
+    sampleRate: 1000,
+    rmsThreshold: 0.015,
+    minSpeechDurationMs: 100,
+    silenceDurationMs: 50,
+    preRollMs: 200,
+    maxUtteranceMs: 30_000,
+    ...overrides,
+  });
+}
+
+describe('PcmTurnAssembler', () => {
+  it('prepends only the configured rolling pre-roll', () => {
+    const assembler = createAssembler();
+    assembler.pushChunk(new Float32Array(300).fill(0.001));
+    assembler.pushChunk(new Float32Array(100).fill(0.1));
+
+    const turns = assembler.pushChunk(new Float32Array(50));
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.audio).toHaveLength(250);
+    expect(turns[0]?.audio.slice(0, 100)).toEqual(
+      new Float32Array(100).fill(0.001)
+    );
+    expect(turns[0]?.audio.slice(100, 200)).toEqual(
+      new Float32Array(100).fill(0.1)
+    );
+    expect(turns[0]?.confirmedSpeechDurationMs).toBe(100);
+  });
+
+  it('force-finalizes at the maximum duration and continues speech', () => {
+    const assembler = createAssembler({
+      preRollMs: 0,
+      maxUtteranceMs: 300,
+    });
+    assembler.pushChunk(new Float32Array(100).fill(0.1));
+
+    const forcedTurns = assembler.pushChunk(new Float32Array(250).fill(0.1));
+    const finalTurns = assembler.pushChunk(new Float32Array(50));
+
+    expect(forcedTurns).toHaveLength(1);
+    expect(forcedTurns[0]?.audio).toHaveLength(300);
+    expect(forcedTurns[0]?.confirmedSpeechDurationMs).toBe(300);
+    expect(finalTurns).toHaveLength(1);
+    expect(finalTurns[0]?.audio).toHaveLength(100);
+    expect(finalTurns[0]?.confirmedSpeechDurationMs).toBe(50);
+  });
+
+  it('flushes confirmed speech and drops an unconfirmed candidate', () => {
+    const confirmed = createAssembler({ preRollMs: 0 });
+    confirmed.pushChunk(new Float32Array(100).fill(0.1));
+
+    const confirmedTurns = confirmed.flush();
+
+    expect(confirmedTurns).toHaveLength(1);
+    expect(confirmedTurns[0]?.audio).toHaveLength(100);
+
+    const unconfirmed = createAssembler({
+      preRollMs: 0,
+      minSpeechDurationMs: 150,
+    });
+    unconfirmed.pushChunk(new Float32Array(100).fill(0.1));
+
+    expect(unconfirmed.flush()).toEqual([]);
+  });
+});

--- a/packages/transcription/tests/VoiceActivityTracker.test.ts
+++ b/packages/transcription/tests/VoiceActivityTracker.test.ts
@@ -1,0 +1,93 @@
+import { VoiceActivityTracker } from '../src/providers/VoiceActivityTracker';
+
+const defaultOptions = {
+  rmsThreshold: 0.015,
+  minSpeechDurationMs: 150,
+  silenceDurationMs: 700,
+};
+
+function createTracker(options = defaultOptions) {
+  const onSpeechStart = vi.fn();
+  const onSpeechEnd = vi.fn();
+  const tracker = new VoiceActivityTracker(options, {
+    onSpeechStart,
+    onSpeechEnd,
+  });
+
+  return { tracker, onSpeechStart, onSpeechEnd };
+}
+
+describe('VoiceActivityTracker', () => {
+  it('ignores short noise that does not reach the speech duration', () => {
+    const { tracker, onSpeechStart, onSpeechEnd } = createTracker();
+
+    tracker.pushFrame(0.05, 100);
+    tracker.pushFrame(0, 50);
+
+    expect(onSpeechStart).not.toHaveBeenCalled();
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+    expect(tracker.hasPendingSpeech()).toBe(false);
+  });
+
+  it('confirms sustained speech once', () => {
+    const { tracker, onSpeechStart } = createTracker();
+
+    tracker.pushFrame(0.05, 50);
+    tracker.pushFrame(0.05, 50);
+    tracker.pushFrame(0.05, 50);
+    tracker.pushFrame(0.05, 50);
+
+    expect(onSpeechStart).toHaveBeenCalledOnce();
+    expect(tracker.hasPendingSpeech()).toBe(true);
+  });
+
+  it('keeps confirmed speech active through a brief pause', () => {
+    const { tracker, onSpeechEnd } = createTracker();
+    tracker.pushFrame(0.05, 150);
+
+    tracker.pushFrame(0, 650);
+    tracker.pushFrame(0.05, 50);
+    tracker.pushFrame(0, 650);
+
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+    expect(tracker.hasPendingSpeech()).toBe(true);
+  });
+
+  it('ends confirmed speech after sustained silence', () => {
+    const { tracker, onSpeechEnd } = createTracker();
+    tracker.pushFrame(0.05, 150);
+
+    tracker.pushFrame(0, 699);
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+
+    tracker.pushFrame(0, 1);
+    expect(onSpeechEnd).toHaveBeenCalledOnce();
+    expect(tracker.hasPendingSpeech()).toBe(false);
+  });
+
+  it('clears pending state on reset', () => {
+    const { tracker, onSpeechStart, onSpeechEnd } = createTracker();
+    tracker.pushFrame(0.05, 150);
+
+    tracker.reset();
+    tracker.pushFrame(0, 700);
+
+    expect(onSpeechStart).toHaveBeenCalledOnce();
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+    expect(tracker.hasPendingSpeech()).toBe(false);
+  });
+
+  it('uses a custom silence duration', () => {
+    const { tracker, onSpeechEnd } = createTracker({
+      ...defaultOptions,
+      silenceDurationMs: 300,
+    });
+    tracker.pushFrame(0.05, 150);
+
+    tracker.pushFrame(0, 299);
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+
+    tracker.pushFrame(0, 1);
+    expect(onSpeechEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/transcription/tests/localWhisperProgress.test.ts
+++ b/packages/transcription/tests/localWhisperProgress.test.ts
@@ -1,0 +1,56 @@
+import { normalizeLocalWhisperDownloadProgress } from '../src/providers/localWhisperProgress';
+
+describe('normalizeLocalWhisperDownloadProgress', () => {
+  it('normalizes known download totals and percentage values', () => {
+    expect(
+      normalizeLocalWhisperDownloadProgress({
+        status: 'progress',
+        file: 'model.onnx',
+        loaded: 25,
+        total: 100,
+        progress: 25,
+        rawOnly: 'not exposed',
+      })
+    ).toEqual({
+      phase: 'download',
+      file: 'model.onnx',
+      loadedBytes: 25,
+      totalBytes: 100,
+      progress: 0.25,
+    });
+  });
+
+  it('derives progress from byte totals and clamps it to the public range', () => {
+    expect(
+      normalizeLocalWhisperDownloadProgress({
+        status: 'done',
+        loaded: 120,
+        total: 100,
+      })
+    ).toEqual({
+      phase: 'download',
+      loadedBytes: 120,
+      totalBytes: 100,
+      progress: 1,
+    });
+  });
+
+  it('omits progress without a known total and ignores raw ready events', () => {
+    expect(
+      normalizeLocalWhisperDownloadProgress({
+        status: 'download',
+        file: 'model.onnx',
+        loaded: 20,
+        progress: 40,
+      })
+    ).toEqual({
+      phase: 'download',
+      file: 'model.onnx',
+      loadedBytes: 20,
+    });
+    expect(
+      normalizeLocalWhisperDownloadProgress({ status: 'ready' })
+    ).toBeNull();
+    expect(normalizeLocalWhisperDownloadProgress('progress')).toBeNull();
+  });
+});

--- a/packages/transcription/tests/resampleTo16k.test.ts
+++ b/packages/transcription/tests/resampleTo16k.test.ts
@@ -1,0 +1,43 @@
+import { resampleTo16k } from '../src/providers/resampleTo16k';
+
+function sineWave(sampleRate: number, durationSeconds: number): Float32Array {
+  const samples = new Float32Array(sampleRate * durationSeconds);
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = Math.sin((2 * Math.PI * 440 * index) / sampleRate);
+  }
+  return samples;
+}
+
+describe('resampleTo16k', () => {
+  it('resamples 48 kHz input to 16 kHz', () => {
+    const output = resampleTo16k(sineWave(48_000, 1), 48_000);
+
+    expect(output).toHaveLength(16_000);
+    expect([...output].every(Number.isFinite)).toBe(true);
+  });
+
+  it('resamples 44.1 kHz input while preserving duration', () => {
+    const input = sineWave(44_100, 2);
+
+    const output = resampleTo16k(input, 44_100);
+
+    expect(output).toHaveLength(32_000);
+    expect(output.length / 16_000).toBeCloseTo(input.length / 44_100, 5);
+    expect([...output].every(Number.isFinite)).toBe(true);
+  });
+
+  it('copies input that is already 16 kHz', () => {
+    const input = new Float32Array([0, 0.5, -0.5]);
+
+    const output = resampleTo16k(input, 16_000);
+
+    expect(output).toEqual(input);
+    expect(output).not.toBe(input);
+  });
+
+  it('handles empty input safely', () => {
+    expect(resampleTo16k(new Float32Array(), 48_000)).toEqual(
+      new Float32Array()
+    );
+  });
+});

--- a/packages/transcription/tsup.config.ts
+++ b/packages/transcription/tsup.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsup';
+
+const bundledWorkerPackages = [
+  '@huggingface/transformers',
+  '@huggingface/jinja',
+  '@huggingface/tokenizers',
+  'onnxruntime-common',
+  'onnxruntime-web',
+];
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    shims: true,
+    outDir: 'dist',
+  },
+  {
+    entry: {
+      'local-whisper.worker': 'src/providers/local-whisper.worker.ts',
+    },
+    format: ['esm'],
+    platform: 'browser',
+    noExternal: bundledWorkerPackages,
+    splitting: false,
+    minify: true,
+    dts: false,
+    outDir: 'dist',
+  },
+]);


### PR DESCRIPTION
## Summary

Adds a browser-local Whisper transcription provider (`provider: 'local-whisper'`) to `@aituber-onair/transcription`, plus progress events and a model-size option, and prepares the `0.0.2` release.

- **Local Whisper provider**: runs `onnx-community/whisper-{tiny,base,small}` in a dedicated module worker with Transformers.js on WebGPU. No API key; microphone audio never leaves the browser (model assets are fetched from the Hugging Face Hub and ONNX Runtime WASM from jsDelivr on first use, then cached).
- **Audio pipeline**: AudioWorklet PCM capture (32 ms batches), a pure `VoiceActivityTracker` state machine (also now used by the OpenAI provider), 200 ms pre-roll, 30 s max utterance splitting, linear 16 kHz resampling, sequential inference, warm-up before `listening`.
- **Guards**: utterances with less than 300 ms of confirmed speech are dropped; well-known Whisper hallucination phrases (e.g. `ご視聴ありがとうございました`, `Thank you.`) are suppressed after NFKC/lowercase/punctuation normalization.
- **Progress events**: `session.onProgress()` with `TranscriptionProgress { phase: 'download' | 'initialize' | 'ready', file?, loadedBytes?, totalBytes?, progress? }`. Only providers with long initialization emit it — currently `local-whisper`.
- **Model size**: `model?: 'tiny' | 'base' | 'small'` (default `tiny`); dtype stays fixed to an fp32 encoder + q4 decoder.
- **Packaging**: `@huggingface/transformers` is a devDependency bundled into `dist/local-whisper.worker.js` (~517 KB, browser platform); the package keeps zero runtime dependencies and the main entry does not reference Transformers.js. An advanced `workerUrl` option covers bundlers that cannot resolve the packaged worker asset.
- **Example**: the framework-free browser sample gains a Local Whisper card with model / language / silence controls and aggregated download progress (EN/JA).
- **Docs**: README (EN/JA), example README, CHANGELOG. Local Whisper is positioned as less accurate than Web Speech / OpenAI Realtime, for use cases that prioritize no API key and no audio upload.
- **Release**: `@aituber-onair/transcription` `0.0.1` → `0.0.2` (still experimental).

Public API changes: `TranscriptionProviderName` gains `'local-whisper'`; new `LocalWhisperTranscriptionOptions`, `LocalWhisperModelSize`, `TranscriptionProgress`; `RealtimeTranscriptionSession.onProgress()`.

## Measurements (Chrome / WebGPU, same short Japanese and English clips)

| Model | First download | Japanese result | Inference ja / en | Cached init |
| --- | ---: | --- | ---: | ---: |
| `tiny` (default) | ~122 MB | こんにちは今日はいい天気ですね | 237 / 203 ms | ~0.9 s |
| `base` | ~209 MB | こんにちは、今日は、いい天気ですね。 | 256 / 311 ms | ~1.2 s |
| `small` | ~589 MB | こんにちは、今日は、いい天気ですね。 | 575 / 552 ms | ~2.5 s |

Speech-end → transcript with the default 500 ms silence window: ~680–720 ms for `tiny`.

## Test plan

- [x] `npm -w @aituber-onair/transcription run test` — 12 files / 70 tests
- [x] Repo DoD: `npm run fmt` → `npm run lint` → `npm run test` → `npm run build`
- [x] `npm install --package-lock-only` + `npm ci`
- [x] Package build: `dist/local-whisper.worker.js` present, no `huggingface` reference in `dist/index.js`, no `sharp` / `onnxruntime-node` in the worker bundle; `npm pack --dry-run` includes the worker
- [x] Real Chrome/WebGPU end-to-end via fake microphone (`--use-file-for-fake-audio-capture`) for tiny / base / small: correct Japanese and English transcripts, progress 0% → 99% → initialize → ready, no console errors, microphone tracks ended after `stop()`, worker terminated after `dispose()`
- [x] Manual check with a physical microphone for `tiny`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
