### PR TITLE
Add Kizuna viewer bonds to every React example and persist them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,10 @@
   `packages/core/examples/react-pngtuber-app`,
   `packages/core/examples/react-pet-app`,
   `packages/core/examples/react-vrm-app`,
-  `packages/core/examples/react-live2d-app`, and
-  `packages/core/examples/react-purupuru-app`. For each provider, verify the
+  `packages/core/examples/react-live2d-app`,
+  `packages/core/examples/react-purupuru-app`,
+  `packages/core/examples/react-inochi2d-app`, and
+  `packages/core/examples/react-psd-app`. For each provider, verify the
   engine selector, persisted settings type/defaults, settings UI,
   `VoiceServiceOptions` wiring, README mention, lockfile metadata, and example
   build. Cloud voice providers that expose voice-list APIs should provide a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,10 @@ Usage:
   `packages/core/examples/react-pngtuber-app`,
   `packages/core/examples/react-pet-app`,
   `packages/core/examples/react-vrm-app`,
-  `packages/core/examples/react-live2d-app`, and
-  `packages/core/examples/react-purupuru-app`. For every new TTS provider, check
+  `packages/core/examples/react-live2d-app`,
+  `packages/core/examples/react-purupuru-app`,
+  `packages/core/examples/react-inochi2d-app`, and
+  `packages/core/examples/react-psd-app`. For every new TTS provider, check
   the engine selector, persisted settings type/defaults, settings UI,
   `VoiceServiceOptions` wiring, README mention, lockfile metadata, and example
   build. If the provider has a voice-list API, surface it as a selectable list

--- a/docs/agent-model-provider-guidelines.md
+++ b/docs/agent-model-provider-guidelines.md
@@ -441,6 +441,9 @@ When TTS settings are involved, check these core React examples as needed:
 - `packages/core/examples/react-pet-app`
 - `packages/core/examples/react-vrm-app`
 - `packages/core/examples/react-live2d-app`
+- `packages/core/examples/react-purupuru-app`
+- `packages/core/examples/react-inochi2d-app`
+- `packages/core/examples/react-psd-app`
 
 Do not bump versions unless the user asks for release work.
 

--- a/packages/core/examples/react-inochi2d-app/package-lock.json
+++ b/packages/core/examples/react-inochi2d-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
         "@aituber-onair/core": "../..",
+        "@aituber-onair/kizuna": "../../../kizuna",
         "@aituber-onair/manneri": "../../../manneri",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -63,6 +64,20 @@
         "vitest": "^1.3.1"
       }
     },
+    "../../../kizuna": {
+      "name": "@aituber-onair/kizuna",
+      "version": "0.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "jsdom": "^22.1.0",
+        "typescript": "^5.0.0",
+        "vite": "^5.4.21",
+        "vitest": "^1.3.1"
+      }
+    },
     "../../../manneri": {
       "name": "@aituber-onair/manneri",
       "version": "0.4.0",
@@ -83,6 +98,10 @@
     },
     "node_modules/@aituber-onair/core": {
       "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@aituber-onair/kizuna": {
+      "resolved": "../../../kizuna",
       "link": true
     },
     "node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-inochi2d-app/package.json
+++ b/packages/core/examples/react-inochi2d-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
     "@aituber-onair/core": "../..",
+    "@aituber-onair/kizuna": "../../../kizuna",
     "@aituber-onair/manneri": "../../../manneri",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/packages/core/examples/react-inochi2d-app/src/App.tsx
+++ b/packages/core/examples/react-inochi2d-app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -16,6 +17,7 @@ import { useTwitchComments } from './hooks/useTwitchComments';
 import { useYoutubeComments } from './hooks/useYoutubeComments';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
 import { getEmotionEffectAnchor } from './lib/emotionEffectAnchor';
+import { createBondIdentity } from './lib/kizunaBond';
 import {
   INOCHI2D_CUSTOM_MODEL_ID,
   buildCustomInochiModel,
@@ -182,6 +184,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -200,7 +206,10 @@ export default function App() {
     (text: string) => {
       stop();
       setAvatarReaction(null);
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [processChat, stop],
   );
@@ -233,16 +242,30 @@ export default function App() {
 
   const handleYoutubeComment = useCallback(
     (comment: YouTubeChatMessage) => {
+      const timestamp = new Date(comment.publishedAt).getTime();
+      void recordBondMessage(
+        createBondIdentity('youtube', comment.userName),
+        comment.userComment,
+        Number.isFinite(timestamp) ? timestamp : Date.now(),
+      ).catch((error) => {
+        console.error('Failed to record YouTube Kizuna interaction:', error);
+      });
       enqueueYouTubeComments([comment]);
     },
-    [enqueueYouTubeComments],
+    [enqueueYouTubeComments, recordBondMessage],
   );
 
   const handleTwitchComment = useCallback(
     (comment: TwitchChatMessage) => {
+      void recordBondMessage(
+        createBondIdentity('twitch', comment.userName),
+        comment.userComment,
+      ).catch((error) => {
+        console.error('Failed to record Twitch Kizuna interaction:', error);
+      });
       enqueueTwitchComments([comment]);
     },
-    [enqueueTwitchComments],
+    [enqueueTwitchComments, recordBondMessage],
   );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
@@ -468,6 +491,8 @@ export default function App() {
         }}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -574,6 +599,7 @@ export default function App() {
                 streamErrorMessage={streamErrorMessage}
                 screenVisionController={screenVisionController}
                 onBackgroundImageChange={handleBackgroundImageChange}
+                onResetKizunaData={resetKizunaData}
               />
             </div>
           </div>

--- a/packages/core/examples/react-inochi2d-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-inochi2d-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows a decrease variant for an angry reply', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-inochi2d-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-inochi2d-app/src/components/BondToastStack.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({ toasts, onDismiss }: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points)
+    ? String(points)
+    : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-inochi2d-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-inochi2d-app/src/components/SettingsPanel.tsx
@@ -31,6 +31,7 @@ interface SettingsPanelProps extends SettingsHook {
   streamErrorMessage?: string;
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -341,12 +342,14 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
   backgroundImageUrl,
   streamErrorMessage,
   screenVisionController,
   onBackgroundImageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -355,6 +358,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -789,6 +795,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -898,6 +914,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 感情表現エフェクトの連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-inochi2d-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-inochi2d-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,14 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+  type InteractionKind,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -19,14 +27,29 @@ import type {
   XaiSampleRate,
 } from '@aituber-onair/core';
 import type { Message as ManneriMessage } from '@aituber-onair/manneri';
-import type { ChatMessage } from '../types/chat';
-import type { AppSettings, ChatProviderOption } from '../types/settings';
-import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
-
 interface ScreenplayLike {
   emotion?: string;
   text?: string;
 }
+import type { ChatMessage } from '../types/chat';
+import type { AppSettings, ChatProviderOption } from '../types/settings';
+import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -35,15 +58,49 @@ interface UseAituberCoreOptions {
   settings: AppSettings;
   getApiKeyForProvider: (provider: ChatProviderOption) => string;
 }
-
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface KizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createKizunaManager(enablePersistence = true): KizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+    reaction: 5,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(config, storageProvider, KIZUNA_STORAGE_KEY),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -308,15 +365,27 @@ function buildVoiceOptions(
 }
 
 function extractScreenplay(data: unknown): ScreenplayLike | null {
-  if (!data || typeof data !== 'object') return null;
-  const source = (data as { screenplay?: unknown }).screenplay ?? data;
-  if (!source || typeof source !== 'object') return null;
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const maybeWrapped = data as { screenplay?: unknown };
+  const source = maybeWrapped.screenplay ?? data;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+
   const screenplay = source as { emotion?: unknown; text?: unknown };
   const emotion =
     typeof screenplay.emotion === 'string' ? screenplay.emotion : undefined;
   const text =
     typeof screenplay.text === 'string' ? screenplay.text : undefined;
-  return emotion || text ? { emotion, text } : null;
+
+  if (!emotion && !text) {
+    return null;
+  }
+
+  return { emotion, text };
 }
 
 export function useAituberCore({
@@ -327,6 +396,19 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const activeBondIdentityRef = useRef<BondIdentity | null>(null);
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
   const chatHistoryRef = useRef<ReturnType<AITuberOnAirCore['getChatHistory']>>(
     [],
   );
@@ -336,11 +418,184 @@ export function useAituberCore({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondInteraction = useCallback(
+    async (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+      const manager = kizunaRef.current;
+      await manager.initialize();
+      const previousSnapshot = manager.getBondSnapshot(identity.userId);
+      const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+      const result = await manager.processInteraction({
+        userId: identity.userId,
+        kind,
+        message,
+        emotion,
+        isOwner: identity.isOwner,
+        timestamp,
+        metadata: {
+          displayName: getBondContextDisplayName(identity.source),
+          source: identity.source,
+        },
+      });
+      const nextSnapshot = manager.getBondSnapshot(identity.userId);
+      if (!nextSnapshot) return null;
+
+      const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+      if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+        bondToastSequenceRef.current += 1;
+        const id = bondToastSequenceRef.current;
+        const toast: BondToast = {
+          id,
+          userId: identity.userId,
+          displayName: identity.displayName,
+          pointsAdded: result.pointsAdded,
+          previousIntimacy,
+          nextIntimacy,
+          previousStage: previousSnapshot
+            ? formatBondStage(previousSnapshot.stage)
+            : '未接触',
+          nextStage: formatBondStage(nextSnapshot.stage),
+          leveledUp: result.leveledUp,
+          ...(result.newLevel !== undefined && {
+            newLevel: result.newLevel,
+          }),
+        };
+        const previousToastId = bondToastByUserRef.current.get(identity.userId);
+        if (previousToastId !== undefined) {
+          const previousTimer = bondToastTimersRef.current.get(previousToastId);
+          if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+          bondToastTimersRef.current.delete(previousToastId);
+        }
+        bondToastByUserRef.current.set(identity.userId, id);
+        setBondToasts((current) =>
+          [
+            ...current.filter(({ id: toastId }) =>
+              previousToastId === undefined
+                ? true
+                : toastId !== previousToastId,
+            ),
+            toast,
+          ].slice(-MAX_BOND_TOASTS),
+        );
+        const timer = window.setTimeout(
+          () => dismissBondToast(id),
+          BOND_TOAST_DURATION_MS,
+        );
+        bondToastTimersRef.current.set(id, timer);
+      }
+      return nextSnapshot;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
+
+  const queueBondInteraction = useCallback(
+    (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp?: number,
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(() =>
+        recordBondInteraction(identity, kind, message, emotion, timestamp),
+      );
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [recordBondInteraction],
+  );
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> =>
+      queueBondInteraction(identity, 'message', message, undefined, timestamp),
+    [queueBondInteraction],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
   const onSpeechStartRef = useRef(onSpeechStart);
   const onSpeechEndRef = useRef(onSpeechEnd);
+
   useEffect(() => {
     onAudioPlayRef.current = onAudioPlay;
     onSpeechStartRef.current = onSpeechStart;
@@ -350,6 +605,25 @@ export function useAituberCore({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    activeBondIdentityRef.current = null;
+    const timer = window.setTimeout(clearBondToasts, 0);
+    return () => window.clearTimeout(timer);
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      bondToastTimersRef.current.clear();
+      bondToastByUserRef.current.clear();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -468,13 +742,14 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ASSISTANT_RESPONSE, (data: unknown) => {
       let content: string;
+      let responseEmotion: string | undefined;
       if (typeof data === 'string') {
         content = data;
       } else {
         const d = data as {
           message?: { content?: string } | string;
           rawText?: string;
-          screenplay?: { text?: string };
+          screenplay?: { emotion?: string; text?: string };
         };
         const msg = d?.message;
         const cleanText = d?.screenplay?.text?.trim();
@@ -483,6 +758,7 @@ export function useAituberCore({
           ((typeof msg === 'string' ? msg : msg?.content) ??
             d?.rawText ??
             String(data));
+        responseEmotion = d?.screenplay?.emotion;
       }
       setMessages((prev) => [
         ...prev,
@@ -494,11 +770,26 @@ export function useAituberCore({
         },
       ]);
       setPartialResponse('');
+
+      const bondIdentity = activeBondIdentityRef.current;
+      activeBondIdentityRef.current = null;
+      if (bondIdentity && responseEmotion) {
+        void queueBondInteraction(
+          bondIdentity,
+          'reaction',
+          content,
+          responseEmotion,
+        ).catch((error) => {
+          console.error('Failed to record Kizuna response emotion:', error);
+        });
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_START, (data: unknown) => {
       const screenplay = extractScreenplay(data);
-      if (screenplay) onSpeechStartRef.current?.(screenplay);
+      if (screenplay) {
+        onSpeechStartRef.current?.(screenplay);
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_END, () => {
@@ -507,6 +798,7 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ERROR, (error: unknown) => {
       console.error('AITuberOnAirCore error:', error);
+      activeBondIdentityRef.current = null;
       setIsProcessing(false);
       onSpeechEndRef.current?.();
     });
@@ -527,9 +819,11 @@ export function useAituberCore({
     settings.llm.systemPrompt,
     settings.llm.endpoint,
     settings.llm.xaiReasoningEffort,
+    settings.kizuna.enabled,
     llmApiKey,
     isApiKeyOptionalProvider,
     createMessageId,
+    queueBondInteraction,
   ]);
 
   // Effect 2: Update voice service when TTS settings change (no core recreation)
@@ -570,73 +864,130 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond =
+          settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(manneriMessages);
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        activeBondIdentityRef.current =
+          shouldTrackBond && bondIdentity ? bondIdentity : null;
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        activeBondIdentityRef.current = null;
+        core.updateChatOptions({
+          systemPrompt:
+            settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -645,5 +996,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-inochi2d-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-inochi2d-app/src/hooks/useLiveCommentIntelligence.ts
@@ -25,6 +25,7 @@ import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { useInterval } from './useInterval';
+import { createBondIdentity, type BondIdentity } from '../lib/kizunaBond';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
@@ -33,6 +34,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +202,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-inochi2d-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-inochi2d-app/src/hooks/useSettings.ts
@@ -269,6 +269,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -310,6 +313,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1304,6 +1308,13 @@ export function useSettings() {
     [],
   );
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const getApiKeyForProvider = useCallback(
     (provider: ChatProviderOption): string => {
       if (provider === 'gemini-nano') {
@@ -1393,6 +1404,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-inochi2d-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-inochi2d-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-inochi2d-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the Inochi2D Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-inochi2d-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-inochi2d-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<T extends KizunaStorageRemover>(
+  storageProvider: T | null,
+): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-inochi2d-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-inochi2d-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-inochi2d-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-inochi2d-app/src/styles/base.css
+++ b/packages/core/examples/react-inochi2d-app/src/styles/base.css
@@ -640,3 +640,196 @@ body {
     padding-bottom: 86px;
   }
 }
+
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16) both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}

--- a/packages/core/examples/react-inochi2d-app/src/types/settings.ts
+++ b/packages/core/examples/react-inochi2d-app/src/types/settings.ts
@@ -173,6 +173,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface VisualSettings {
   backgroundMode: 'default' | 'green';
   layoutMode: 'chat' | 'broadcast';
@@ -197,4 +201,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }

--- a/packages/core/examples/react-live2d-app/package-lock.json
+++ b/packages/core/examples/react-live2d-app/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@aituber-onair/comment-intelligence": "../../../comment-intelligence",
 				"@aituber-onair/core": "../..",
+				"@aituber-onair/kizuna": "../../../kizuna",
 				"@aituber-onair/manneri": "../../../manneri",
 				"pixi-live2d-display-lipsyncpatch": "github:shinshin86/pixi-live2d-display-lipsyncpatch#release/v0.5.0-ls-7-noMaskFix",
 				"pixi.js": "^7.4.3",
@@ -65,6 +66,20 @@
 				"vitest": "^1.3.1"
 			}
 		},
+		"../../../kizuna": {
+			"name": "@aituber-onair/kizuna",
+			"version": "0.0.3",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "1.9.4",
+				"@types/node": "^18.15.0",
+				"@vitest/coverage-v8": "^1.3.1",
+				"jsdom": "^22.1.0",
+				"typescript": "^5.0.0",
+				"vite": "^5.4.21",
+				"vitest": "^1.3.1"
+			}
+		},
 		"../../../manneri": {
 			"name": "@aituber-onair/manneri",
 			"version": "0.4.0",
@@ -85,6 +100,10 @@
 		},
 		"node_modules/@aituber-onair/core": {
 			"resolved": "../..",
+			"link": true
+		},
+		"node_modules/@aituber-onair/kizuna": {
+			"resolved": "../../../kizuna",
 			"link": true
 		},
 		"node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-live2d-app/package.json
+++ b/packages/core/examples/react-live2d-app/package.json
@@ -13,6 +13,7 @@
 	"dependencies": {
 		"@aituber-onair/comment-intelligence": "../../../comment-intelligence",
 		"@aituber-onair/core": "../..",
+		"@aituber-onair/kizuna": "../../../kizuna",
 		"@aituber-onair/manneri": "../../../manneri",
 		"pixi-live2d-display-lipsyncpatch": "github:shinshin86/pixi-live2d-display-lipsyncpatch#release/v0.5.0-ls-7-noMaskFix",
 		"pixi.js": "^7.4.3",

--- a/packages/core/examples/react-live2d-app/src/App.tsx
+++ b/packages/core/examples/react-live2d-app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -16,6 +17,7 @@ import { useTwitchComments } from './hooks/useTwitchComments';
 import { useYoutubeComments } from './hooks/useYoutubeComments';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
 import { getEmotionEffectAnchor } from './lib/emotionEffectAnchor';
+import { createBondIdentity } from './lib/kizunaBond';
 import {
   createBundledLive2DModelSource,
   getBundledLive2DModels,
@@ -194,6 +196,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -212,7 +218,10 @@ export default function App() {
     (text: string) => {
       stop();
       setAvatarReaction(null);
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [processChat, stop],
   );
@@ -245,16 +254,30 @@ export default function App() {
 
   const handleYoutubeComment = useCallback(
     (comment: YouTubeChatMessage) => {
+      const timestamp = new Date(comment.publishedAt).getTime();
+      void recordBondMessage(
+        createBondIdentity('youtube', comment.userName),
+        comment.userComment,
+        Number.isFinite(timestamp) ? timestamp : Date.now(),
+      ).catch((error) => {
+        console.error('Failed to record YouTube Kizuna interaction:', error);
+      });
       enqueueYouTubeComments([comment]);
     },
-    [enqueueYouTubeComments],
+    [enqueueYouTubeComments, recordBondMessage],
   );
 
   const handleTwitchComment = useCallback(
     (comment: TwitchChatMessage) => {
+      void recordBondMessage(
+        createBondIdentity('twitch', comment.userName),
+        comment.userComment,
+      ).catch((error) => {
+        console.error('Failed to record Twitch Kizuna interaction:', error);
+      });
       enqueueTwitchComments([comment]);
     },
-    [enqueueTwitchComments],
+    [enqueueTwitchComments, recordBondMessage],
   );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
@@ -425,6 +448,8 @@ export default function App() {
         }}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -522,6 +547,7 @@ export default function App() {
                 streamErrorMessage={streamErrorMessage}
                 screenVisionController={screenVisionController}
                 onBackgroundImageChange={handleBackgroundImageChange}
+                onResetKizunaData={resetKizunaData}
               />
             </div>
           </div>

--- a/packages/core/examples/react-live2d-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-live2d-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows a decrease variant for an angry reply', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-live2d-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-live2d-app/src/components/BondToastStack.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({ toasts, onDismiss }: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points)
+    ? String(points)
+    : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-live2d-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-live2d-app/src/components/SettingsPanel.tsx
@@ -31,6 +31,7 @@ interface SettingsPanelProps extends SettingsHook {
   streamErrorMessage?: string;
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -341,12 +342,14 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
   backgroundImageUrl,
   streamErrorMessage,
   screenVisionController,
   onBackgroundImageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -355,6 +358,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -789,6 +795,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -898,6 +914,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 感情表現エフェクトの連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-live2d-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-live2d-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,14 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+  type InteractionKind,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -19,14 +27,29 @@ import type {
   XaiSampleRate,
 } from '@aituber-onair/core';
 import type { Message as ManneriMessage } from '@aituber-onair/manneri';
-import type { ChatMessage } from '../types/chat';
-import type { AppSettings, ChatProviderOption } from '../types/settings';
-import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
-
 interface ScreenplayLike {
   emotion?: string;
   text?: string;
 }
+import type { ChatMessage } from '../types/chat';
+import type { AppSettings, ChatProviderOption } from '../types/settings';
+import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -35,15 +58,49 @@ interface UseAituberCoreOptions {
   settings: AppSettings;
   getApiKeyForProvider: (provider: ChatProviderOption) => string;
 }
-
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface KizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createKizunaManager(enablePersistence = true): KizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+    reaction: 5,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(config, storageProvider, KIZUNA_STORAGE_KEY),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -308,15 +365,27 @@ function buildVoiceOptions(
 }
 
 function extractScreenplay(data: unknown): ScreenplayLike | null {
-  if (!data || typeof data !== 'object') return null;
-  const source = (data as { screenplay?: unknown }).screenplay ?? data;
-  if (!source || typeof source !== 'object') return null;
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const maybeWrapped = data as { screenplay?: unknown };
+  const source = maybeWrapped.screenplay ?? data;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+
   const screenplay = source as { emotion?: unknown; text?: unknown };
   const emotion =
     typeof screenplay.emotion === 'string' ? screenplay.emotion : undefined;
   const text =
     typeof screenplay.text === 'string' ? screenplay.text : undefined;
-  return emotion || text ? { emotion, text } : null;
+
+  if (!emotion && !text) {
+    return null;
+  }
+
+  return { emotion, text };
 }
 
 export function useAituberCore({
@@ -327,6 +396,19 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const activeBondIdentityRef = useRef<BondIdentity | null>(null);
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
   const chatHistoryRef = useRef<ReturnType<AITuberOnAirCore['getChatHistory']>>(
     [],
   );
@@ -336,11 +418,184 @@ export function useAituberCore({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondInteraction = useCallback(
+    async (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+      const manager = kizunaRef.current;
+      await manager.initialize();
+      const previousSnapshot = manager.getBondSnapshot(identity.userId);
+      const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+      const result = await manager.processInteraction({
+        userId: identity.userId,
+        kind,
+        message,
+        emotion,
+        isOwner: identity.isOwner,
+        timestamp,
+        metadata: {
+          displayName: getBondContextDisplayName(identity.source),
+          source: identity.source,
+        },
+      });
+      const nextSnapshot = manager.getBondSnapshot(identity.userId);
+      if (!nextSnapshot) return null;
+
+      const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+      if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+        bondToastSequenceRef.current += 1;
+        const id = bondToastSequenceRef.current;
+        const toast: BondToast = {
+          id,
+          userId: identity.userId,
+          displayName: identity.displayName,
+          pointsAdded: result.pointsAdded,
+          previousIntimacy,
+          nextIntimacy,
+          previousStage: previousSnapshot
+            ? formatBondStage(previousSnapshot.stage)
+            : '未接触',
+          nextStage: formatBondStage(nextSnapshot.stage),
+          leveledUp: result.leveledUp,
+          ...(result.newLevel !== undefined && {
+            newLevel: result.newLevel,
+          }),
+        };
+        const previousToastId = bondToastByUserRef.current.get(identity.userId);
+        if (previousToastId !== undefined) {
+          const previousTimer = bondToastTimersRef.current.get(previousToastId);
+          if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+          bondToastTimersRef.current.delete(previousToastId);
+        }
+        bondToastByUserRef.current.set(identity.userId, id);
+        setBondToasts((current) =>
+          [
+            ...current.filter(({ id: toastId }) =>
+              previousToastId === undefined
+                ? true
+                : toastId !== previousToastId,
+            ),
+            toast,
+          ].slice(-MAX_BOND_TOASTS),
+        );
+        const timer = window.setTimeout(
+          () => dismissBondToast(id),
+          BOND_TOAST_DURATION_MS,
+        );
+        bondToastTimersRef.current.set(id, timer);
+      }
+      return nextSnapshot;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
+
+  const queueBondInteraction = useCallback(
+    (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp?: number,
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(() =>
+        recordBondInteraction(identity, kind, message, emotion, timestamp),
+      );
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [recordBondInteraction],
+  );
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> =>
+      queueBondInteraction(identity, 'message', message, undefined, timestamp),
+    [queueBondInteraction],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
   const onSpeechStartRef = useRef(onSpeechStart);
   const onSpeechEndRef = useRef(onSpeechEnd);
+
   useEffect(() => {
     onAudioPlayRef.current = onAudioPlay;
     onSpeechStartRef.current = onSpeechStart;
@@ -350,6 +605,25 @@ export function useAituberCore({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    activeBondIdentityRef.current = null;
+    const timer = window.setTimeout(clearBondToasts, 0);
+    return () => window.clearTimeout(timer);
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      bondToastTimersRef.current.clear();
+      bondToastByUserRef.current.clear();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -468,13 +742,14 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ASSISTANT_RESPONSE, (data: unknown) => {
       let content: string;
+      let responseEmotion: string | undefined;
       if (typeof data === 'string') {
         content = data;
       } else {
         const d = data as {
           message?: { content?: string } | string;
           rawText?: string;
-          screenplay?: { text?: string };
+          screenplay?: { emotion?: string; text?: string };
         };
         const msg = d?.message;
         const cleanText = d?.screenplay?.text?.trim();
@@ -483,6 +758,7 @@ export function useAituberCore({
           ((typeof msg === 'string' ? msg : msg?.content) ??
             d?.rawText ??
             String(data));
+        responseEmotion = d?.screenplay?.emotion;
       }
       setMessages((prev) => [
         ...prev,
@@ -494,11 +770,26 @@ export function useAituberCore({
         },
       ]);
       setPartialResponse('');
+
+      const bondIdentity = activeBondIdentityRef.current;
+      activeBondIdentityRef.current = null;
+      if (bondIdentity && responseEmotion) {
+        void queueBondInteraction(
+          bondIdentity,
+          'reaction',
+          content,
+          responseEmotion,
+        ).catch((error) => {
+          console.error('Failed to record Kizuna response emotion:', error);
+        });
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_START, (data: unknown) => {
       const screenplay = extractScreenplay(data);
-      if (screenplay) onSpeechStartRef.current?.(screenplay);
+      if (screenplay) {
+        onSpeechStartRef.current?.(screenplay);
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_END, () => {
@@ -507,6 +798,7 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ERROR, (error: unknown) => {
       console.error('AITuberOnAirCore error:', error);
+      activeBondIdentityRef.current = null;
       setIsProcessing(false);
       onSpeechEndRef.current?.();
     });
@@ -527,9 +819,11 @@ export function useAituberCore({
     settings.llm.systemPrompt,
     settings.llm.endpoint,
     settings.llm.xaiReasoningEffort,
+    settings.kizuna.enabled,
     llmApiKey,
     isApiKeyOptionalProvider,
     createMessageId,
+    queueBondInteraction,
   ]);
 
   // Effect 2: Update voice service when TTS settings change (no core recreation)
@@ -570,73 +864,130 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond =
+          settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(manneriMessages);
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        activeBondIdentityRef.current =
+          shouldTrackBond && bondIdentity ? bondIdentity : null;
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        activeBondIdentityRef.current = null;
+        core.updateChatOptions({
+          systemPrompt:
+            settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -645,5 +996,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-live2d-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-live2d-app/src/hooks/useLiveCommentIntelligence.ts
@@ -25,6 +25,7 @@ import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { useInterval } from './useInterval';
+import { createBondIdentity, type BondIdentity } from '../lib/kizunaBond';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
@@ -33,6 +34,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +202,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-live2d-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-live2d-app/src/hooks/useSettings.ts
@@ -269,6 +269,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -310,6 +313,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1241,6 +1245,13 @@ export function useSettings() {
     }));
   }, []);
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const updateManneriSimilarityThreshold = useCallback(
     (similarityThreshold: number) => {
       setSettings((prev) => ({
@@ -1388,6 +1399,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-live2d-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-live2d-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-live2d-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the Live2D Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-live2d-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-live2d-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<T extends KizunaStorageRemover>(
+  storageProvider: T | null,
+): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-live2d-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-live2d-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-live2d-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-live2d-app/src/styles/base.css
+++ b/packages/core/examples/react-live2d-app/src/styles/base.css
@@ -665,3 +665,196 @@ body {
     height: 100%;
   }
 }
+
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16) both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}

--- a/packages/core/examples/react-live2d-app/src/types/settings.ts
+++ b/packages/core/examples/react-live2d-app/src/types/settings.ts
@@ -173,6 +173,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface VisualSettings {
   backgroundMode: 'default' | 'green';
   layoutMode: 'chat' | 'broadcast';
@@ -197,4 +201,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }

--- a/packages/core/examples/react-pet-app/package-lock.json
+++ b/packages/core/examples/react-pet-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
         "@aituber-onair/core": "../..",
+        "@aituber-onair/kizuna": "../../../kizuna",
         "@aituber-onair/manneri": "../../../manneri",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -26,7 +27,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^1.6.1"
       }
     },
     "../..": {
@@ -62,6 +64,20 @@
         "vitest": "^1.3.1"
       }
     },
+    "../../../kizuna": {
+      "name": "@aituber-onair/kizuna",
+      "version": "0.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "jsdom": "^22.1.0",
+        "typescript": "^5.0.0",
+        "vite": "^5.4.21",
+        "vitest": "^1.3.1"
+      }
+    },
     "../../../manneri": {
       "name": "@aituber-onair/manneri",
       "version": "0.4.0",
@@ -82,6 +98,10 @@
     },
     "node_modules/@aituber-onair/core": {
       "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@aituber-onair/kizuna": {
+      "resolved": "../../../kizuna",
       "link": true
     },
     "node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-pet-app/package.json
+++ b/packages/core/examples/react-pet-app/package.json
@@ -7,11 +7,13 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
     "@aituber-onair/core": "../..",
+    "@aituber-onair/kizuna": "../../../kizuna",
     "@aituber-onair/manneri": "../../../manneri",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
@@ -28,6 +30,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/core/examples/react-pet-app/src/App.tsx
+++ b/packages/core/examples/react-pet-app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -16,6 +17,9 @@ import { useSettings } from './hooks/useSettings';
 import { useTwitchComments } from './hooks/useTwitchComments';
 import { useYoutubeComments } from './hooks/useYoutubeComments';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
+import { createBondIdentity } from './lib/kizunaBond';
+import type { TwitchChatMessage } from './services/twitch/twitchService';
+import type { YouTubeChatMessage } from './services/youtube/youtubeService';
 import './styles/app.css';
 
 const DEFAULT_SETTINGS_DIALOG_OFFSET: DialogDragPoint = { x: 0, y: 0 };
@@ -125,6 +129,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     settings: settingsHook.settings,
@@ -142,7 +150,10 @@ export default function App() {
     (text: string) => {
       // Stop previous audio if speech is currently playing
       stop();
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [stop, processChat],
   );
@@ -172,6 +183,40 @@ export default function App() {
       streamTitle: settingsHook.settings.commentIntelligence.streamTitle,
       topicFilter: settingsHook.settings.commentIntelligence.topicFilter,
     });
+
+  const handleYouTubeComments = useCallback(
+    (comments: YouTubeChatMessage[]) => {
+      for (const comment of comments) {
+        const timestamp = new Date(comment.publishedAt).getTime();
+        void recordBondMessage(
+          createBondIdentity('youtube', comment.userName),
+          comment.userComment,
+          Number.isFinite(timestamp) ? timestamp : Date.now(),
+        ).catch((error) => {
+          console.error('Failed to record YouTube Kizuna interaction:', error);
+        });
+      }
+      enqueueYouTubeComments(comments);
+    },
+    [enqueueYouTubeComments, recordBondMessage],
+  );
+
+  const handleTwitchComments = useCallback(
+    (comments: TwitchChatMessage[]) => {
+      for (const comment of comments) {
+        const timestamp = new Date(comment.publishedAt).getTime();
+        void recordBondMessage(
+          createBondIdentity('twitch', comment.userName),
+          comment.userComment,
+          Number.isFinite(timestamp) ? timestamp : Date.now(),
+        ).catch((error) => {
+          console.error('Failed to record Twitch Kizuna interaction:', error);
+        });
+      }
+      enqueueTwitchComments(comments);
+    },
+    [enqueueTwitchComments, recordBondMessage],
+  );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
     if (backgroundObjectUrlRef.current) {
@@ -218,7 +263,7 @@ export default function App() {
       settingsHook.settings.stream.platform === 'youtube' &&
       settingsHook.settings.stream.youtubeEnabled,
     intervalMs: settingsHook.settings.stream.youtubeCommentIntervalMs,
-    onComments: enqueueYouTubeComments,
+    onComments: handleYouTubeComments,
   });
 
   useTwitchComments({
@@ -229,7 +274,7 @@ export default function App() {
       settingsHook.settings.stream.platform === 'twitch' &&
       settingsHook.settings.stream.twitchEnabled,
     intervalMs: settingsHook.settings.stream.twitchCommentIntervalMs,
-    onComments: enqueueTwitchComments,
+    onComments: handleTwitchComments,
     onTokenExpired: () => {
       settingsHook.updateTwitchAccessToken('');
       settingsHook.updateTwitchEnabled(false);
@@ -287,6 +332,8 @@ export default function App() {
         onToggleSettings={toggleSettingsDialog}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -316,6 +363,7 @@ export default function App() {
             <SettingsPanel
               {...settingsHook}
               isProcessing={isProcessing}
+              onResetKizunaData={resetKizunaData}
               backgroundImageUrl={backgroundImageUrl}
               streamErrorMessage={streamErrorMessage}
               screenVisionController={screenVisionController}

--- a/packages/core/examples/react-pet-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-pet-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows the decrease variant when intimacy falls', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-pet-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-pet-app/src/components/BondToastStack.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({ toasts, onDismiss }: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points)
+    ? String(points)
+    : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-pet-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-pet-app/src/components/SettingsPanel.tsx
@@ -23,6 +23,7 @@ type ScreenVisionController = ReturnType<typeof useScreenVisionController>;
 
 interface SettingsPanelProps extends SettingsHook {
   isProcessing: boolean;
+  onResetKizunaData: () => Promise<void>;
   backgroundImageUrl: string | null;
   activePet: ActivePetAsset | null;
   petAssetError: string;
@@ -316,8 +317,10 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
+  onResetKizunaData,
   backgroundImageUrl,
   activePet,
   petAssetError,
@@ -335,6 +338,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -824,6 +830,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -930,6 +946,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 表情連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-pet-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-pet-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,13 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -22,6 +29,22 @@ import type { Message as ManneriMessage } from '@aituber-onair/manneri';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -31,12 +54,46 @@ interface UseAituberCoreOptions {
 
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface KizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createKizunaManager(enablePersistence = true): KizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(config, storageProvider, KIZUNA_STORAGE_KEY),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -306,6 +363,18 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
   const chatHistoryRef = useRef<
     ReturnType<AITuberOnAirCore['getChatHistory']>
   >([]);
@@ -315,6 +384,156 @@ export function useAituberCore({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(async () => {
+        if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+        const manager = kizunaRef.current;
+        await manager.initialize();
+        const previousSnapshot = manager.getBondSnapshot(identity.userId);
+        const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+        const interactionResult = await manager.processInteraction({
+          userId: identity.userId,
+          kind: 'message',
+          message,
+          isOwner: identity.isOwner,
+          timestamp,
+          metadata: {
+            displayName: getBondContextDisplayName(identity.source),
+            source: identity.source,
+          },
+        });
+        const nextSnapshot = manager.getBondSnapshot(identity.userId);
+        if (!nextSnapshot) return null;
+
+        const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+        if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+          bondToastSequenceRef.current += 1;
+          const id = bondToastSequenceRef.current;
+          const toast: BondToast = {
+            id,
+            userId: identity.userId,
+            displayName: identity.displayName,
+            pointsAdded: interactionResult.pointsAdded,
+            previousIntimacy,
+            nextIntimacy,
+            previousStage: previousSnapshot
+              ? formatBondStage(previousSnapshot.stage)
+              : '未接触',
+            nextStage: formatBondStage(nextSnapshot.stage),
+            leveledUp: interactionResult.leveledUp,
+            ...(interactionResult.newLevel !== undefined && {
+              newLevel: interactionResult.newLevel,
+            }),
+          };
+          const previousToastId = bondToastByUserRef.current.get(
+            identity.userId,
+          );
+          if (previousToastId !== undefined) {
+            const previousTimer =
+              bondToastTimersRef.current.get(previousToastId);
+            if (previousTimer !== undefined) {
+              window.clearTimeout(previousTimer);
+            }
+            bondToastTimersRef.current.delete(previousToastId);
+          }
+          bondToastByUserRef.current.set(identity.userId, id);
+          setBondToasts((current) =>
+            [
+              ...current.filter(({ id: toastId }) =>
+                previousToastId === undefined
+                  ? true
+                  : toastId !== previousToastId,
+              ),
+              toast,
+            ].slice(-MAX_BOND_TOASTS),
+          );
+          const timer = window.setTimeout(
+            () => dismissBondToast(id),
+            BOND_TOAST_DURATION_MS,
+          );
+          bondToastTimersRef.current.set(id, timer);
+        }
+        return nextSnapshot;
+      });
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
@@ -323,6 +542,22 @@ export function useAituberCore({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    const timer = window.setTimeout(clearBondToasts, 0);
+    return () => window.clearTimeout(timer);
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -532,73 +767,125 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond =
+          settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(
+                  manneriMessages,
+                );
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        core.updateChatOptions({
+          systemPrompt:
+            settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -607,5 +894,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-pet-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-pet-app/src/hooks/useLiveCommentIntelligence.ts
@@ -24,6 +24,7 @@ import type { TwitchChatMessage } from '../services/twitch/twitchService';
 import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
+import { createBondIdentity, type BondIdentity } from '../lib/kizunaBond';
 import { useInterval } from './useInterval';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
@@ -33,6 +34,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +202,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-pet-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-pet-app/src/hooks/useSettings.ts
@@ -242,6 +242,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -269,6 +272,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1132,6 +1136,13 @@ export function useSettings() {
     }));
   }, []);
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const updateManneriSimilarityThreshold = useCallback(
     (similarityThreshold: number) => {
       setSettings((prev) => ({
@@ -1277,6 +1288,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-pet-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-pet-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-pet-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-pet-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-pet-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-pet-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the Pet Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Pet Kizuna message interactions', () => {
+  it('grows the bond using messages without recording reactions', async () => {
+    let now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    config.basePoints = { ...config.basePoints, message: 20 };
+    const manager = new KizunaManager(
+      config,
+      undefined,
+      'react-pet-message-growth-test',
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const firstPoints = manager.getBondSnapshot('form:owner')?.points ?? 0;
+    const firstIntimacy = manager.toRelationshipCapital('form:owner');
+
+    now += 60_000;
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello again',
+      isOwner: true,
+      timestamp: now,
+    });
+
+    expect(manager.getBondSnapshot('form:owner')?.points).toBeGreaterThan(
+      firstPoints,
+    );
+    expect(manager.toRelationshipCapital('form:owner')).toBeGreaterThan(
+      firstIntimacy,
+    );
+    const interactionKinds =
+      manager
+        .getUser('form:owner')
+        ?.stats.interactionHistory?.map(({ kind }) => kind) ?? [];
+    expect(interactionKinds).toEqual(['message', 'message']);
+    expect(interactionKinds).not.toContain('reaction');
+    manager.destroy();
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-pet-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-pet-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-pet-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<T extends KizunaStorageRemover>(
+  storageProvider: T | null,
+): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-pet-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-pet-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-pet-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-pet-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-pet-app/src/styles/app.css
+++ b/packages/core/examples/react-pet-app/src/styles/app.css
@@ -155,6 +155,200 @@ body {
   margin-bottom: 4px;
 }
 
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16)
+    both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}
+
 .settings-field select,
 .settings-field textarea,
 .settings-field input[type="password"],

--- a/packages/core/examples/react-pet-app/src/types/settings.ts
+++ b/packages/core/examples/react-pet-app/src/types/settings.ts
@@ -168,6 +168,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface PetManifest {
   id?: string;
   displayName?: string;
@@ -196,4 +200,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }

--- a/packages/core/examples/react-pngtuber-app/src/App.tsx
+++ b/packages/core/examples/react-pngtuber-app/src/App.tsx
@@ -178,6 +178,7 @@ export default function App() {
     bondToasts,
     dismissBondToast,
     recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -460,6 +461,7 @@ export default function App() {
               screenVisionController={screenVisionController}
               onBackgroundImageChange={handleBackgroundImageChange}
               onAvatarImageChange={handleAvatarImageChange}
+              onResetKizunaData={resetKizunaData}
             />
           </div>
         </div>

--- a/packages/core/examples/react-pngtuber-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-pngtuber-app/src/components/SettingsPanel.tsx
@@ -34,6 +34,7 @@ interface SettingsPanelProps extends SettingsHook {
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
   onAvatarImageChange: (key: AvatarImageKey, file: File | null) => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -360,6 +361,7 @@ export function SettingsPanel({
   screenVisionController,
   onBackgroundImageChange,
   onAvatarImageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -368,6 +370,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -810,6 +815,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -935,6 +950,67 @@ export function SettingsPanel({
                 フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
                 その視聴者との関係性をSystem Promptへ追加します。
               </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
@@ -38,8 +38,8 @@ import {
   type BondToast,
 } from '../lib/kizunaBond';
 import {
-  attemptPngTuberKizunaStorageClear,
-  PNGTUBER_KIZUNA_STORAGE_KEY,
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
   tryCreateKizunaStorageProvider,
 } from '../lib/kizunaStorage';
 import {
@@ -104,7 +104,7 @@ function createPngTuberKizunaManager(
     manager: new KizunaManager(
       config,
       storageProvider,
-      PNGTUBER_KIZUNA_STORAGE_KEY,
+      KIZUNA_STORAGE_KEY,
     ),
     storageProvider: storageProvider ?? null,
   };
@@ -392,18 +392,16 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
-  const kizunaRef = useRef<KizunaManager | null>(null);
-  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(null);
-  if (!kizunaRef.current) {
-    const setup = createPngTuberKizunaManager();
-    kizunaRef.current = setup.manager;
-    kizunaStorageProviderRef.current = setup.storageProvider;
-  }
-  const coreRequestQueueRef = useRef<SerialTaskQueue | null>(null);
-  if (!coreRequestQueueRef.current) {
-    coreRequestQueueRef.current = createSerialTaskQueue();
-  }
-  const enqueueCoreRequest = coreRequestQueueRef.current;
+  const [initialKizunaSetup] = useState(() =>
+    createPngTuberKizunaManager(),
+  );
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
   const activeBondIdentityRef = useRef<BondIdentity | null>(null);
   const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
   const bondToastSequenceRef = useRef(0);
@@ -453,7 +451,7 @@ export function useAituberCore({
       kizunaRef.current?.destroy();
 
       const storageClearResult =
-        await attemptPngTuberKizunaStorageClear(
+        await attemptKizunaStorageClear(
           kizunaStorageProviderRef.current,
         );
       if (!storageClearResult.storageCleared) {

--- a/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
@@ -75,14 +75,14 @@ const MAX_BOND_TOASTS = 4;
 const BOND_TOAST_DURATION_MS = 4_500;
 const VISIBLE_BOND_CHANGE = 0.0005;
 
-interface PngTuberKizunaManagerSetup {
+interface KizunaManagerSetup {
   manager: KizunaManager;
   storageProvider: IStorageProvider | null;
 }
 
-function createPngTuberKizunaManager(
+function createKizunaManager(
   enablePersistence = true,
-): PngTuberKizunaManagerSetup {
+): KizunaManagerSetup {
   const config = createDefaultKizunaConfig();
   config.basePoints = {
     ...config.basePoints,
@@ -392,9 +392,7 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
-  const [initialKizunaSetup] = useState(() =>
-    createPngTuberKizunaManager(),
-  );
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
   const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
   const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
     initialKizunaSetup.storageProvider,
@@ -461,9 +459,7 @@ export function useAituberCore({
         );
       }
 
-      const setup = createPngTuberKizunaManager(
-        storageClearResult.storageCleared,
-      );
+      const setup = createKizunaManager(storageClearResult.storageCleared);
       kizunaRef.current = setup.manager;
       kizunaStorageProviderRef.current = storageClearResult.storageCleared
         ? setup.storageProvider

--- a/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-pngtuber-app/src/hooks/useAituberCore.ts
@@ -9,8 +9,10 @@ import {
 import { ManneriDetector } from '@aituber-onair/manneri';
 import {
   KizunaManager,
+  LocalStorageProvider,
   createDefaultKizunaConfig,
   type BondSnapshot,
+  type IStorageProvider,
   type InteractionKind,
 } from '@aituber-onair/kizuna';
 import type {
@@ -35,6 +37,11 @@ import {
   type BondIdentity,
   type BondToast,
 } from '../lib/kizunaBond';
+import {
+  attemptPngTuberKizunaStorageClear,
+  PNGTUBER_KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
 import {
   createSerialTaskQueue,
   type SerialTaskQueue,
@@ -68,14 +75,39 @@ const MAX_BOND_TOASTS = 4;
 const BOND_TOAST_DURATION_MS = 4_500;
 const VISIBLE_BOND_CHANGE = 0.0005;
 
-function createPngTuberKizunaManager(): KizunaManager {
+interface PngTuberKizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createPngTuberKizunaManager(
+  enablePersistence = true,
+): PngTuberKizunaManagerSetup {
   const config = createDefaultKizunaConfig();
   config.basePoints = {
     ...config.basePoints,
     message: 20,
     reaction: 5,
   };
-  return new KizunaManager(config, undefined, 'react-pngtuber-bond');
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(
+      config,
+      storageProvider,
+      PNGTUBER_KIZUNA_STORAGE_KEY,
+    ),
+    storageProvider: storageProvider ?? null,
+  };
 }
 
 function toManneriMessages(
@@ -361,8 +393,11 @@ export function useAituberCore({
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
   const kizunaRef = useRef<KizunaManager | null>(null);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(null);
   if (!kizunaRef.current) {
-    kizunaRef.current = createPngTuberKizunaManager();
+    const setup = createPngTuberKizunaManager();
+    kizunaRef.current = setup.manager;
+    kizunaStorageProviderRef.current = setup.storageProvider;
   }
   const coreRequestQueueRef = useRef<SerialTaskQueue | null>(null);
   if (!coreRequestQueueRef.current) {
@@ -385,6 +420,14 @@ export function useAituberCore({
   const [partialResponse, setPartialResponse] = useState('');
   const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
 
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
   const dismissBondToast = useCallback((id: number) => {
     const timer = bondToastTimersRef.current.get(id);
     if (timer !== undefined) window.clearTimeout(timer);
@@ -394,6 +437,56 @@ export function useAituberCore({
     }
     setBondToasts((current) => current.filter((toast) => toast.id !== id));
   }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult =
+        await attemptPngTuberKizunaStorageClear(
+          kizunaStorageProviderRef.current,
+        );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createPngTuberKizunaManager(
+        storageClearResult.storageCleared,
+      );
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
 
   const recordBondInteraction = useCallback(
     async (
@@ -405,6 +498,7 @@ export function useAituberCore({
     ): Promise<BondSnapshot | null> => {
       if (!settings.kizuna.enabled || !kizunaRef.current) return null;
       const manager = kizunaRef.current;
+      await manager.initialize();
       const previousSnapshot = manager.getBondSnapshot(identity.userId);
       const previousIntimacy = manager.toRelationshipCapital(identity.userId);
       const result = await manager.processInteraction({
@@ -517,13 +611,8 @@ export function useAituberCore({
   useEffect(() => {
     if (settings.kizuna.enabled) return;
     activeBondIdentityRef.current = null;
-    setBondToasts([]);
-    for (const timer of bondToastTimersRef.current.values()) {
-      window.clearTimeout(timer);
-    }
-    bondToastTimersRef.current.clear();
-    bondToastByUserRef.current.clear();
-  }, [settings.kizuna.enabled]);
+    clearBondToasts();
+  }, [clearBondToasts, settings.kizuna.enabled]);
 
   useEffect(
     () => () => {
@@ -907,5 +996,6 @@ export function useAituberCore({
     bondToasts,
     dismissBondToast,
     recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.test.ts
@@ -7,9 +7,9 @@ import {
 } from '@aituber-onair/kizuna';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  attemptPngTuberKizunaStorageClear,
-  clearPngTuberKizunaStorage,
-  PNGTUBER_KIZUNA_STORAGE_KEY,
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
   tryCreateKizunaStorageProvider,
 } from './kizunaStorage';
 
@@ -35,22 +35,22 @@ describe('tryCreateKizunaStorageProvider', () => {
   });
 });
 
-describe('clearPngTuberKizunaStorage', () => {
+describe('clearKizunaStorage', () => {
   it('removes only the PNGTuber Kizuna storage key', async () => {
     const remove = vi.fn().mockResolvedValue(undefined);
 
-    await clearPngTuberKizunaStorage({ remove });
+    await clearKizunaStorage({ remove });
 
     expect(remove).toHaveBeenCalledOnce();
-    expect(remove).toHaveBeenCalledWith(PNGTUBER_KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
   });
 
   it('does nothing when persistence is unavailable', async () => {
-    await expect(clearPngTuberKizunaStorage(null)).resolves.toBeUndefined();
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
   });
 });
 
-describe('attemptPngTuberKizunaStorageClear', () => {
+describe('attemptKizunaStorageClear', () => {
   it('retains a failed provider so the next reset retries removal', async () => {
     const error = new Error('remove failed');
     const remove = vi
@@ -59,10 +59,8 @@ describe('attemptPngTuberKizunaStorageClear', () => {
       .mockResolvedValueOnce(undefined);
     const storageProvider = { remove };
 
-    const firstAttempt = await attemptPngTuberKizunaStorageClear(
-      storageProvider,
-    );
-    const secondAttempt = await attemptPngTuberKizunaStorageClear(
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
       firstAttempt.storageProvider,
     );
 
@@ -78,11 +76,11 @@ describe('attemptPngTuberKizunaStorageClear', () => {
     expect(remove).toHaveBeenCalledTimes(2);
     expect(remove).toHaveBeenNthCalledWith(
       1,
-      PNGTUBER_KIZUNA_STORAGE_KEY,
+      KIZUNA_STORAGE_KEY,
     );
     expect(remove).toHaveBeenNthCalledWith(
       2,
-      PNGTUBER_KIZUNA_STORAGE_KEY,
+      KIZUNA_STORAGE_KEY,
     );
   });
 });
@@ -97,7 +95,7 @@ describe('Kizuna localStorage persistence', () => {
     const manager = new KizunaManager(
       config,
       storageProvider,
-      PNGTUBER_KIZUNA_STORAGE_KEY,
+      KIZUNA_STORAGE_KEY,
     );
 
     await manager.processInteraction({
@@ -113,7 +111,7 @@ describe('Kizuna localStorage persistence', () => {
     const restoredManager = new KizunaManager(
       config,
       new LocalStorageProvider(),
-      PNGTUBER_KIZUNA_STORAGE_KEY,
+      KIZUNA_STORAGE_KEY,
     );
     await restoredManager.initialize();
 

--- a/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptPngTuberKizunaStorageClear,
+  clearPngTuberKizunaStorage,
+  PNGTUBER_KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearPngTuberKizunaStorage', () => {
+  it('removes only the PNGTuber Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearPngTuberKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(PNGTUBER_KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearPngTuberKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptPngTuberKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptPngTuberKizunaStorageClear(
+      storageProvider,
+    );
+    const secondAttempt = await attemptPngTuberKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(
+      1,
+      PNGTUBER_KIZUNA_STORAGE_KEY,
+    );
+    expect(remove).toHaveBeenNthCalledWith(
+      2,
+      PNGTUBER_KIZUNA_STORAGE_KEY,
+    );
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      PNGTUBER_KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      PNGTUBER_KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const PNGTUBER_KIZUNA_STORAGE_KEY = 'react-pngtuber-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearPngTuberKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(PNGTUBER_KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptPngTuberKizunaStorageClear<
+  T extends KizunaStorageRemover,
+>(storageProvider: T | null): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearPngTuberKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-pngtuber-app/src/lib/kizunaStorage.ts
@@ -1,4 +1,4 @@
-export const PNGTUBER_KIZUNA_STORAGE_KEY = 'react-pngtuber-bond';
+export const KIZUNA_STORAGE_KEY = 'react-pngtuber-bond';
 
 interface KizunaStorageRemover {
   remove: (key: string) => Promise<void>;
@@ -27,18 +27,18 @@ export function tryCreateKizunaStorageProvider<T>(
   }
 }
 
-export async function clearPngTuberKizunaStorage(
+export async function clearKizunaStorage(
   storageProvider: KizunaStorageRemover | null,
 ): Promise<void> {
   if (!storageProvider) return;
-  await storageProvider.remove(PNGTUBER_KIZUNA_STORAGE_KEY);
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
 }
 
-export async function attemptPngTuberKizunaStorageClear<
+export async function attemptKizunaStorageClear<
   T extends KizunaStorageRemover,
 >(storageProvider: T | null): Promise<KizunaStorageClearResult<T>> {
   try {
-    await clearPngTuberKizunaStorage(storageProvider);
+    await clearKizunaStorage(storageProvider);
     return { storageCleared: true, storageProvider };
   } catch (error) {
     return { storageCleared: false, storageProvider, error };

--- a/packages/core/examples/react-pngtuber-app/src/styles/app.css
+++ b/packages/core/examples/react-pngtuber-app/src/styles/app.css
@@ -204,6 +204,47 @@ body {
   accent-color: #e94560;
 }
 
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
 /* ── Kizuna bond notifications ── */
 
 .bond-toast-stack {

--- a/packages/core/examples/react-psd-app/package-lock.json
+++ b/packages/core/examples/react-psd-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
         "@aituber-onair/core": "../..",
+        "@aituber-onair/kizuna": "../../../kizuna",
         "@aituber-onair/manneri": "../../../manneri",
         "@webtoon/psd": "^0.4.0",
         "ag-psd": "^31.0.2",
@@ -65,6 +66,20 @@
         "vitest": "^1.3.1"
       }
     },
+    "../../../kizuna": {
+      "name": "@aituber-onair/kizuna",
+      "version": "0.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "jsdom": "^22.1.0",
+        "typescript": "^5.0.0",
+        "vite": "^5.4.21",
+        "vitest": "^1.3.1"
+      }
+    },
     "../../../manneri": {
       "name": "@aituber-onair/manneri",
       "version": "0.4.0",
@@ -85,6 +100,10 @@
     },
     "node_modules/@aituber-onair/core": {
       "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@aituber-onair/kizuna": {
+      "resolved": "../../../kizuna",
       "link": true
     },
     "node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-psd-app/package.json
+++ b/packages/core/examples/react-psd-app/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
     "@aituber-onair/core": "../..",
+    "@aituber-onair/kizuna": "../../../kizuna",
     "@aituber-onair/manneri": "../../../manneri",
     "@webtoon/psd": "^0.4.0",
     "ag-psd": "^31.0.2",

--- a/packages/core/examples/react-psd-app/src/App.tsx
+++ b/packages/core/examples/react-psd-app/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -25,6 +26,9 @@ import {
   type PsdEmotionReactionDraft,
 } from './lib/psdEmotionEffects';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
+import { createBondIdentity } from './lib/kizunaBond';
+import type { TwitchChatMessage } from './services/twitch/twitchService';
+import type { YouTubeChatMessage } from './services/youtube/youtubeService';
 import type { AvatarViewTransform } from './types/settings';
 import './styles/app.css';
 
@@ -208,6 +212,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -231,7 +239,10 @@ export default function App() {
       // Stop previous audio if speech is currently playing
       stop();
       resetAvatarReaction();
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [stop, resetAvatarReaction, processChat],
   );
@@ -261,6 +272,40 @@ export default function App() {
       streamTitle: settingsHook.settings.commentIntelligence.streamTitle,
       topicFilter: settingsHook.settings.commentIntelligence.topicFilter,
     });
+
+  const handleYouTubeComments = useCallback(
+    (comments: YouTubeChatMessage[]) => {
+      for (const comment of comments) {
+        const timestamp = new Date(comment.publishedAt).getTime();
+        void recordBondMessage(
+          createBondIdentity('youtube', comment.userName),
+          comment.userComment,
+          Number.isFinite(timestamp) ? timestamp : Date.now(),
+        ).catch((error) => {
+          console.error('Failed to record YouTube Kizuna interaction:', error);
+        });
+      }
+      enqueueYouTubeComments(comments);
+    },
+    [enqueueYouTubeComments, recordBondMessage],
+  );
+
+  const handleTwitchComments = useCallback(
+    (comments: TwitchChatMessage[]) => {
+      for (const comment of comments) {
+        const timestamp = new Date(comment.publishedAt).getTime();
+        void recordBondMessage(
+          createBondIdentity('twitch', comment.userName),
+          comment.userComment,
+          Number.isFinite(timestamp) ? timestamp : Date.now(),
+        ).catch((error) => {
+          console.error('Failed to record Twitch Kizuna interaction:', error);
+        });
+      }
+      enqueueTwitchComments(comments);
+    },
+    [enqueueTwitchComments, recordBondMessage],
+  );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
     if (backgroundObjectUrlRef.current) {
@@ -307,7 +352,7 @@ export default function App() {
       settingsHook.settings.stream.platform === 'youtube' &&
       settingsHook.settings.stream.youtubeEnabled,
     intervalMs: settingsHook.settings.stream.youtubeCommentIntervalMs,
-    onComments: enqueueYouTubeComments,
+    onComments: handleYouTubeComments,
   });
 
   useTwitchComments({
@@ -318,7 +363,7 @@ export default function App() {
       settingsHook.settings.stream.platform === 'twitch' &&
       settingsHook.settings.stream.twitchEnabled,
     intervalMs: settingsHook.settings.stream.twitchCommentIntervalMs,
-    onComments: enqueueTwitchComments,
+    onComments: handleTwitchComments,
     onTokenExpired: () => {
       settingsHook.updateTwitchAccessToken('');
       settingsHook.updateTwitchEnabled(false);
@@ -382,6 +427,8 @@ export default function App() {
         onToggleSettings={toggleSettingsDialog}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -417,6 +464,7 @@ export default function App() {
               screenVisionController={screenVisionController}
               onBackgroundImageChange={handleBackgroundImageChange}
               resetVisualAvatarView={resetVisualAvatarView}
+              onResetKizunaData={resetKizunaData}
             />
           </div>
         </div>

--- a/packages/core/examples/react-psd-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-psd-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows a decrease variant for an angry reply', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-psd-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-psd-app/src/components/BondToastStack.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({ toasts, onDismiss }: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points)
+    ? String(points)
+    : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-psd-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-psd-app/src/components/SettingsPanel.tsx
@@ -42,6 +42,7 @@ interface SettingsPanelProps extends SettingsHook {
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
   resetVisualAvatarView: () => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -785,6 +786,7 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
   backgroundImageUrl,
@@ -792,6 +794,7 @@ export function SettingsPanel({
   streamErrorMessage,
   screenVisionController,
   onBackgroundImageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -800,6 +803,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -1251,6 +1257,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -1357,6 +1373,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 表情連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-psd-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-psd-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,14 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+  type InteractionKind,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -19,14 +27,29 @@ import type {
   XaiSampleRate,
 } from '@aituber-onair/core';
 import type { Message as ManneriMessage } from '@aituber-onair/manneri';
-import type { ChatMessage } from '../types/chat';
-import type { AppSettings, ChatProviderOption } from '../types/settings';
-import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
-
 interface ScreenplayLike {
   emotion?: string;
   text?: string;
 }
+import type { ChatMessage } from '../types/chat';
+import type { AppSettings, ChatProviderOption } from '../types/settings';
+import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -35,15 +58,49 @@ interface UseAituberCoreOptions {
   settings: AppSettings;
   getApiKeyForProvider: (provider: ChatProviderOption) => string;
 }
-
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface KizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createKizunaManager(enablePersistence = true): KizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+    reaction: 5,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(config, storageProvider, KIZUNA_STORAGE_KEY),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -308,16 +365,27 @@ function buildVoiceOptions(
 }
 
 function extractScreenplay(data: unknown): ScreenplayLike | null {
-  if (!data || typeof data !== 'object') return null;
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
   const maybeWrapped = data as { screenplay?: unknown };
   const source = maybeWrapped.screenplay ?? data;
-  if (!source || typeof source !== 'object') return null;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+
   const screenplay = source as { emotion?: unknown; text?: unknown };
   const emotion =
     typeof screenplay.emotion === 'string' ? screenplay.emotion : undefined;
   const text =
     typeof screenplay.text === 'string' ? screenplay.text : undefined;
-  return emotion || text ? { emotion, text } : null;
+
+  if (!emotion && !text) {
+    return null;
+  }
+
+  return { emotion, text };
 }
 
 export function useAituberCore({
@@ -328,6 +396,19 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const activeBondIdentityRef = useRef<BondIdentity | null>(null);
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
   const chatHistoryRef = useRef<ReturnType<AITuberOnAirCore['getChatHistory']>>(
     [],
   );
@@ -337,6 +418,178 @@ export function useAituberCore({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondInteraction = useCallback(
+    async (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+      const manager = kizunaRef.current;
+      await manager.initialize();
+      const previousSnapshot = manager.getBondSnapshot(identity.userId);
+      const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+      const result = await manager.processInteraction({
+        userId: identity.userId,
+        kind,
+        message,
+        emotion,
+        isOwner: identity.isOwner,
+        timestamp,
+        metadata: {
+          displayName: getBondContextDisplayName(identity.source),
+          source: identity.source,
+        },
+      });
+      const nextSnapshot = manager.getBondSnapshot(identity.userId);
+      if (!nextSnapshot) return null;
+
+      const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+      if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+        bondToastSequenceRef.current += 1;
+        const id = bondToastSequenceRef.current;
+        const toast: BondToast = {
+          id,
+          userId: identity.userId,
+          displayName: identity.displayName,
+          pointsAdded: result.pointsAdded,
+          previousIntimacy,
+          nextIntimacy,
+          previousStage: previousSnapshot
+            ? formatBondStage(previousSnapshot.stage)
+            : '未接触',
+          nextStage: formatBondStage(nextSnapshot.stage),
+          leveledUp: result.leveledUp,
+          ...(result.newLevel !== undefined && {
+            newLevel: result.newLevel,
+          }),
+        };
+        const previousToastId = bondToastByUserRef.current.get(identity.userId);
+        if (previousToastId !== undefined) {
+          const previousTimer = bondToastTimersRef.current.get(previousToastId);
+          if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+          bondToastTimersRef.current.delete(previousToastId);
+        }
+        bondToastByUserRef.current.set(identity.userId, id);
+        setBondToasts((current) =>
+          [
+            ...current.filter(({ id: toastId }) =>
+              previousToastId === undefined
+                ? true
+                : toastId !== previousToastId,
+            ),
+            toast,
+          ].slice(-MAX_BOND_TOASTS),
+        );
+        const timer = window.setTimeout(
+          () => dismissBondToast(id),
+          BOND_TOAST_DURATION_MS,
+        );
+        bondToastTimersRef.current.set(id, timer);
+      }
+      return nextSnapshot;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
+
+  const queueBondInteraction = useCallback(
+    (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp?: number,
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(() =>
+        recordBondInteraction(identity, kind, message, emotion, timestamp),
+      );
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [recordBondInteraction],
+  );
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> =>
+      queueBondInteraction(identity, 'message', message, undefined, timestamp),
+    [queueBondInteraction],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
@@ -352,6 +605,25 @@ export function useAituberCore({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    activeBondIdentityRef.current = null;
+    const timer = window.setTimeout(clearBondToasts, 0);
+    return () => window.clearTimeout(timer);
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      bondToastTimersRef.current.clear();
+      bondToastByUserRef.current.clear();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -470,13 +742,14 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ASSISTANT_RESPONSE, (data: unknown) => {
       let content: string;
+      let responseEmotion: string | undefined;
       if (typeof data === 'string') {
         content = data;
       } else {
         const d = data as {
           message?: { content?: string } | string;
-          screenplay?: { text?: string };
           rawText?: string;
+          screenplay?: { emotion?: string; text?: string };
         };
         const msg = d?.message;
         const cleanText = d?.screenplay?.text?.trim();
@@ -485,6 +758,7 @@ export function useAituberCore({
           ((typeof msg === 'string' ? msg : msg?.content) ??
             d?.rawText ??
             String(data));
+        responseEmotion = d?.screenplay?.emotion;
       }
       setMessages((prev) => [
         ...prev,
@@ -496,11 +770,26 @@ export function useAituberCore({
         },
       ]);
       setPartialResponse('');
+
+      const bondIdentity = activeBondIdentityRef.current;
+      activeBondIdentityRef.current = null;
+      if (bondIdentity && responseEmotion) {
+        void queueBondInteraction(
+          bondIdentity,
+          'reaction',
+          content,
+          responseEmotion,
+        ).catch((error) => {
+          console.error('Failed to record Kizuna response emotion:', error);
+        });
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_START, (data: unknown) => {
       const screenplay = extractScreenplay(data);
-      if (screenplay) onSpeechStartRef.current?.(screenplay);
+      if (screenplay) {
+        onSpeechStartRef.current?.(screenplay);
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_END, () => {
@@ -509,6 +798,7 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ERROR, (error: unknown) => {
       console.error('AITuberOnAirCore error:', error);
+      activeBondIdentityRef.current = null;
       setIsProcessing(false);
       onSpeechEndRef.current?.();
     });
@@ -529,9 +819,11 @@ export function useAituberCore({
     settings.llm.systemPrompt,
     settings.llm.endpoint,
     settings.llm.xaiReasoningEffort,
+    settings.kizuna.enabled,
     llmApiKey,
     isApiKeyOptionalProvider,
     createMessageId,
+    queueBondInteraction,
   ]);
 
   // Effect 2: Update voice service when TTS settings change (no core recreation)
@@ -572,73 +864,130 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond =
+          settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(manneriMessages);
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        activeBondIdentityRef.current =
+          shouldTrackBond && bondIdentity ? bondIdentity : null;
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        activeBondIdentityRef.current = null;
+        core.updateChatOptions({
+          systemPrompt:
+            settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -647,5 +996,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-psd-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-psd-app/src/hooks/useLiveCommentIntelligence.ts
@@ -25,6 +25,7 @@ import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { useInterval } from './useInterval';
+import { createBondIdentity, type BondIdentity } from '../lib/kizunaBond';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
@@ -33,6 +34,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +202,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-psd-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-psd-app/src/hooks/useSettings.ts
@@ -277,6 +277,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -328,6 +331,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1341,6 +1345,13 @@ export function useSettings() {
     [],
   );
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const getApiKeyForProvider = useCallback(
     (provider: ChatProviderOption): string => {
       if (provider === 'gemini-nano') {
@@ -1432,6 +1443,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-psd-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-psd-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-psd-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-psd-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-psd-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-psd-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the PSD Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-psd-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-psd-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-psd-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<T extends KizunaStorageRemover>(
+  storageProvider: T | null,
+): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-psd-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-psd-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-psd-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-psd-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-psd-app/src/styles/app.css
+++ b/packages/core/examples/react-psd-app/src/styles/app.css
@@ -1110,3 +1110,196 @@ body {
     height: 100%;
   }
 }
+
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16) both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}

--- a/packages/core/examples/react-psd-app/src/types/settings.ts
+++ b/packages/core/examples/react-psd-app/src/types/settings.ts
@@ -173,6 +173,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface AvatarViewTransform {
   x: number;
   y: number;
@@ -205,4 +209,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }

--- a/packages/core/examples/react-purupuru-app/package-lock.json
+++ b/packages/core/examples/react-purupuru-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
         "@aituber-onair/core": "../..",
+        "@aituber-onair/kizuna": "../../../kizuna",
         "@aituber-onair/manneri": "../../../manneri",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -63,6 +64,20 @@
         "vitest": "^1.3.1"
       }
     },
+    "../../../kizuna": {
+      "name": "@aituber-onair/kizuna",
+      "version": "0.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "jsdom": "^22.1.0",
+        "typescript": "^5.0.0",
+        "vite": "^5.4.21",
+        "vitest": "^1.3.1"
+      }
+    },
     "../../../manneri": {
       "name": "@aituber-onair/manneri",
       "version": "0.4.0",
@@ -83,6 +98,10 @@
     },
     "node_modules/@aituber-onair/core": {
       "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@aituber-onair/kizuna": {
+      "resolved": "../../../kizuna",
       "link": true
     },
     "node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-purupuru-app/package.json
+++ b/packages/core/examples/react-purupuru-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
     "@aituber-onair/core": "../..",
+    "@aituber-onair/kizuna": "../../../kizuna",
     "@aituber-onair/manneri": "../../../manneri",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/packages/core/examples/react-purupuru-app/src/App.tsx
+++ b/packages/core/examples/react-purupuru-app/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -16,6 +17,7 @@ import { useSettings } from './hooks/useSettings';
 import { useTwitchComments } from './hooks/useTwitchComments';
 import { useYoutubeComments } from './hooks/useYoutubeComments';
 import { getPuruPuruEffectAnchor } from './lib/purupuruEffectAnchor';
+import { createBondIdentity } from './lib/kizunaBond';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
 import type { PuruPuruAvatarPackage } from './lib/purupuruPackage';
 import { loadPuruPuruPackage } from './lib/purupuruPackage';
@@ -194,6 +196,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -213,7 +219,10 @@ export default function App() {
       // Stop previous audio if speech is currently playing
       stop();
       resetAvatarReaction();
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [stop, resetAvatarReaction, processChat],
   );
@@ -246,16 +255,30 @@ export default function App() {
 
   const handleYoutubeComment = useCallback(
     (comment: YouTubeChatMessage) => {
+      const timestamp = new Date(comment.publishedAt).getTime();
+      void recordBondMessage(
+        createBondIdentity('youtube', comment.userName),
+        comment.userComment,
+        Number.isFinite(timestamp) ? timestamp : Date.now(),
+      ).catch((error) => {
+        console.error('Failed to record YouTube Kizuna interaction:', error);
+      });
       enqueueYouTubeComments([comment]);
     },
-    [enqueueYouTubeComments],
+    [enqueueYouTubeComments, recordBondMessage],
   );
 
   const handleTwitchComment = useCallback(
     (comment: TwitchChatMessage) => {
+      void recordBondMessage(
+        createBondIdentity('twitch', comment.userName),
+        comment.userComment,
+      ).catch((error) => {
+        console.error('Failed to record Twitch Kizuna interaction:', error);
+      });
       enqueueTwitchComments([comment]);
     },
-    [enqueueTwitchComments],
+    [enqueueTwitchComments, recordBondMessage],
   );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
@@ -520,6 +543,8 @@ export default function App() {
         onToggleSettings={toggleSettingsDialog}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -557,6 +582,7 @@ export default function App() {
               screenVisionController={screenVisionController}
               onBackgroundImageChange={handleBackgroundImageChange}
               onAvatarPackageChange={handleAvatarPackageChange}
+              onResetKizunaData={resetKizunaData}
             />
           </div>
         </div>

--- a/packages/core/examples/react-purupuru-app/src/App.tsx
+++ b/packages/core/examples/react-purupuru-app/src/App.tsx
@@ -48,6 +48,39 @@ interface SettingsDialogDragState {
   rect: DOMRect;
 }
 
+interface DefaultAvatarPackageLoadOptions {
+  isCurrent: () => boolean;
+  onLoaded: (loaded: PuruPuruAvatarPackage) => void;
+  onFailed: (error: unknown) => void;
+}
+
+async function loadDefaultAvatarPackage({
+  isCurrent,
+  onLoaded,
+  onFailed,
+}: DefaultAvatarPackageLoadOptions): Promise<void> {
+  try {
+    const response = await fetch(DEFAULT_AVATAR_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${DEFAULT_AVATAR_URL}.`);
+    }
+
+    const blob = await response.blob();
+    const file = new File([blob], DEFAULT_AVATAR_FILE_NAME, {
+      type: blob.type || 'application/zip',
+    });
+    const loaded = await loadPuruPuruPackage(file);
+
+    if (!isCurrent()) {
+      loaded.dispose();
+      return;
+    }
+    onLoaded(loaded);
+  } catch (error) {
+    if (isCurrent()) onFailed(error);
+  }
+}
+
 export default function App() {
   const { play, stop, mouthLevel, isSpeaking, smoothedValue } =
     useAudioLipsync();
@@ -318,41 +351,28 @@ export default function App() {
     setAvatarPackageSource(null);
   }, []);
 
-  const loadDefaultAvatarPackage = useCallback(async () => {
+  const startDefaultAvatarPackageLoad = useCallback(() => {
     const requestId = avatarLoadRequestRef.current + 1;
     avatarLoadRequestRef.current = requestId;
 
-    try {
-      const response = await fetch(DEFAULT_AVATAR_URL);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${DEFAULT_AVATAR_URL}.`);
-      }
-
-      const blob = await response.blob();
-      const file = new File([blob], DEFAULT_AVATAR_FILE_NAME, {
-        type: blob.type || 'application/zip',
-      });
-      const loaded = await loadPuruPuruPackage(file);
-
-      if (requestId !== avatarLoadRequestRef.current) {
-        loaded.dispose();
-        return;
-      }
-
-      setAvatarLoadError(null);
-      installAvatarPackage(loaded, 'default');
-    } catch (error) {
-      if (requestId !== avatarLoadRequestRef.current) return;
-      console.warn('Failed to load the bundled default avatar.', error);
-      setAvatarLoadError(null);
-      clearAvatarPackage();
-    }
+    void loadDefaultAvatarPackage({
+      isCurrent: () => requestId === avatarLoadRequestRef.current,
+      onLoaded: (loaded) => {
+        setAvatarLoadError(null);
+        installAvatarPackage(loaded, 'default');
+      },
+      onFailed: (error) => {
+        console.warn('Failed to load the bundled default avatar.', error);
+        setAvatarLoadError(null);
+        clearAvatarPackage();
+      },
+    });
   }, [clearAvatarPackage, installAvatarPackage]);
 
   const handleAvatarPackageChange = useCallback(
     async (file: File | null) => {
       if (!file) {
-        void loadDefaultAvatarPackage();
+        startDefaultAvatarPackageLoad();
         return;
       }
 
@@ -378,12 +398,12 @@ export default function App() {
         );
       }
     },
-    [installAvatarPackage, loadDefaultAvatarPackage],
+    [installAvatarPackage, startDefaultAvatarPackageLoad],
   );
 
   useEffect(() => {
-    void loadDefaultAvatarPackage();
-  }, [loadDefaultAvatarPackage]);
+    startDefaultAvatarPackageLoad();
+  }, [startDefaultAvatarPackageLoad]);
 
   useEffect(() => {
     const hash = window.location.hash;

--- a/packages/core/examples/react-purupuru-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-purupuru-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows a decrease variant for an angry reply', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-purupuru-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-purupuru-app/src/components/BondToastStack.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({ toasts, onDismiss }: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points)
+    ? String(points)
+    : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
@@ -461,6 +461,20 @@ export function SettingsPanel({
     speakerRef.current = settings.tts.speaker;
   }, [settings.tts.speaker]);
 
+  const handleTTSEngineChange = (engine: TTSEngineOption) => {
+    if (engine !== 'minimax') {
+      setMinimaxVoices([]);
+    }
+    updateTTSEngine(engine);
+  };
+
+  const handleMinimaxApiKeyChange = (apiKey: string) => {
+    if (!apiKey.trim()) {
+      setMinimaxVoices([]);
+    }
+    updateMinimaxApiKey(apiKey);
+  };
+
   const selectedAivisCloudPresetId = useMemo(() => {
     const matched = AIVIS_CLOUD_PRESETS.find(
       (preset) =>
@@ -544,7 +558,6 @@ export function SettingsPanel({
 
     const apiKey = settings.tts.minimaxApiKey?.trim();
     if (!apiKey) {
-      setMinimaxVoices([]);
       return;
     }
 
@@ -1206,7 +1219,7 @@ export function SettingsPanel({
                 id="tts-engine"
                 value={settings.tts.engine}
                 onChange={(e) =>
-                  updateTTSEngine(e.target.value as TTSEngineOption)
+                  handleTTSEngineChange(e.target.value as TTSEngineOption)
                 }
                 disabled={disabled}
               >
@@ -2467,7 +2480,7 @@ export function SettingsPanel({
                     id="tts-minimax-apikey"
                     type="password"
                     value={settings.tts.minimaxApiKey || ''}
-                    onChange={(e) => updateMinimaxApiKey(e.target.value)}
+                    onChange={(e) => handleMinimaxApiKeyChange(e.target.value)}
                     placeholder="MiniMax API Key"
                     disabled={disabled}
                   />

--- a/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-purupuru-app/src/components/SettingsPanel.tsx
@@ -36,6 +36,7 @@ interface SettingsPanelProps extends SettingsHook {
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
   onAvatarPackageChange: (file: File | null) => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -348,6 +349,7 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
   backgroundImageUrl,
@@ -358,6 +360,7 @@ export function SettingsPanel({
   screenVisionController,
   onBackgroundImageChange,
   onAvatarPackageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -366,6 +369,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -801,6 +807,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -910,6 +926,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 表情連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-purupuru-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-purupuru-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,14 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+  type InteractionKind,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -19,14 +27,29 @@ import type {
   XaiSampleRate,
 } from '@aituber-onair/core';
 import type { Message as ManneriMessage } from '@aituber-onair/manneri';
-import type { ChatMessage } from '../types/chat';
-import type { AppSettings, ChatProviderOption } from '../types/settings';
-import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
-
 interface ScreenplayLike {
   emotion?: string;
   text?: string;
 }
+import type { ChatMessage } from '../types/chat';
+import type { AppSettings, ChatProviderOption } from '../types/settings';
+import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -35,15 +58,49 @@ interface UseAituberCoreOptions {
   settings: AppSettings;
   getApiKeyForProvider: (provider: ChatProviderOption) => string;
 }
-
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface KizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createKizunaManager(enablePersistence = true): KizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+    reaction: 5,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(config, storageProvider, KIZUNA_STORAGE_KEY),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -339,27 +396,234 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
-  const chatHistoryRef = useRef<
-    ReturnType<AITuberOnAirCore['getChatHistory']>
-  >([]);
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const activeBondIdentityRef = useRef<BondIdentity | null>(null);
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
+  const chatHistoryRef = useRef<ReturnType<AITuberOnAirCore['getChatHistory']>>(
+    [],
+  );
   const manneriDetectorRef = useRef<ManneriDetector | null>(null);
   const messagesRef = useRef<ChatMessage[]>([]);
   const messageIdSequenceRef = useRef(0);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondInteraction = useCallback(
+    async (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+      const manager = kizunaRef.current;
+      await manager.initialize();
+      const previousSnapshot = manager.getBondSnapshot(identity.userId);
+      const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+      const result = await manager.processInteraction({
+        userId: identity.userId,
+        kind,
+        message,
+        emotion,
+        isOwner: identity.isOwner,
+        timestamp,
+        metadata: {
+          displayName: getBondContextDisplayName(identity.source),
+          source: identity.source,
+        },
+      });
+      const nextSnapshot = manager.getBondSnapshot(identity.userId);
+      if (!nextSnapshot) return null;
+
+      const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+      if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+        bondToastSequenceRef.current += 1;
+        const id = bondToastSequenceRef.current;
+        const toast: BondToast = {
+          id,
+          userId: identity.userId,
+          displayName: identity.displayName,
+          pointsAdded: result.pointsAdded,
+          previousIntimacy,
+          nextIntimacy,
+          previousStage: previousSnapshot
+            ? formatBondStage(previousSnapshot.stage)
+            : '未接触',
+          nextStage: formatBondStage(nextSnapshot.stage),
+          leveledUp: result.leveledUp,
+          ...(result.newLevel !== undefined && {
+            newLevel: result.newLevel,
+          }),
+        };
+        const previousToastId = bondToastByUserRef.current.get(identity.userId);
+        if (previousToastId !== undefined) {
+          const previousTimer = bondToastTimersRef.current.get(previousToastId);
+          if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+          bondToastTimersRef.current.delete(previousToastId);
+        }
+        bondToastByUserRef.current.set(identity.userId, id);
+        setBondToasts((current) =>
+          [
+            ...current.filter(({ id: toastId }) =>
+              previousToastId === undefined
+                ? true
+                : toastId !== previousToastId,
+            ),
+            toast,
+          ].slice(-MAX_BOND_TOASTS),
+        );
+        const timer = window.setTimeout(
+          () => dismissBondToast(id),
+          BOND_TOAST_DURATION_MS,
+        );
+        bondToastTimersRef.current.set(id, timer);
+      }
+      return nextSnapshot;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
+
+  const queueBondInteraction = useCallback(
+    (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp?: number,
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(() =>
+        recordBondInteraction(identity, kind, message, emotion, timestamp),
+      );
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [recordBondInteraction],
+  );
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> =>
+      queueBondInteraction(identity, 'message', message, undefined, timestamp),
+    [queueBondInteraction],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
-  onAudioPlayRef.current = onAudioPlay;
   const onSpeechStartRef = useRef(onSpeechStart);
-  onSpeechStartRef.current = onSpeechStart;
   const onSpeechEndRef = useRef(onSpeechEnd);
-  onSpeechEndRef.current = onSpeechEnd;
+
+  useEffect(() => {
+    onAudioPlayRef.current = onAudioPlay;
+    onSpeechStartRef.current = onSpeechStart;
+    onSpeechEndRef.current = onSpeechEnd;
+  }, [onAudioPlay, onSpeechEnd, onSpeechStart]);
 
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    activeBondIdentityRef.current = null;
+    const timer = window.setTimeout(clearBondToasts, 0);
+    return () => window.clearTimeout(timer);
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      bondToastTimersRef.current.clear();
+      bondToastByUserRef.current.clear();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -396,8 +660,7 @@ export function useAituberCore({
   const isOpenAIGPT5Model =
     settings.llm.provider === 'openai' && isGPT5Model(resolvedModel);
   const xaiProviderOptions =
-    settings.llm.provider === 'xai' &&
-    isXaiReasoningEffortModel(resolvedModel)
+    settings.llm.provider === 'xai' && isXaiReasoningEffortModel(resolvedModel)
       ? {
           reasoning_effort:
             settings.llm.xaiReasoningEffort ||
@@ -439,8 +702,7 @@ export function useAituberCore({
       model: resolvedModel,
       providerOptions,
       chatOptions: {
-        systemPrompt:
-          settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        systemPrompt: settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
         ...(isOpenAIGPT5Model ? GPT5_SAMPLE_CHAT_OPTIONS : {}),
       },
       voiceOptions: buildVoiceOptions(
@@ -480,13 +742,14 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ASSISTANT_RESPONSE, (data: unknown) => {
       let content: string;
+      let responseEmotion: string | undefined;
       if (typeof data === 'string') {
         content = data;
       } else {
         const d = data as {
           message?: { content?: string } | string;
-          screenplay?: { text?: string };
           rawText?: string;
+          screenplay?: { emotion?: string; text?: string };
         };
         const msg = d?.message;
         const cleanText = d?.screenplay?.text?.trim();
@@ -495,6 +758,7 @@ export function useAituberCore({
           ((typeof msg === 'string' ? msg : msg?.content) ??
             d?.rawText ??
             String(data));
+        responseEmotion = d?.screenplay?.emotion;
       }
       setMessages((prev) => [
         ...prev,
@@ -506,6 +770,19 @@ export function useAituberCore({
         },
       ]);
       setPartialResponse('');
+
+      const bondIdentity = activeBondIdentityRef.current;
+      activeBondIdentityRef.current = null;
+      if (bondIdentity && responseEmotion) {
+        void queueBondInteraction(
+          bondIdentity,
+          'reaction',
+          content,
+          responseEmotion,
+        ).catch((error) => {
+          console.error('Failed to record Kizuna response emotion:', error);
+        });
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_START, (data: unknown) => {
@@ -521,6 +798,7 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ERROR, (error: unknown) => {
       console.error('AITuberOnAirCore error:', error);
+      activeBondIdentityRef.current = null;
       setIsProcessing(false);
       onSpeechEndRef.current?.();
     });
@@ -541,9 +819,11 @@ export function useAituberCore({
     settings.llm.systemPrompt,
     settings.llm.endpoint,
     settings.llm.xaiReasoningEffort,
+    settings.kizuna.enabled,
     llmApiKey,
     isApiKeyOptionalProvider,
     createMessageId,
+    queueBondInteraction,
   ]);
 
   // Effect 2: Update voice service when TTS settings change (no core recreation)
@@ -584,73 +864,130 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond =
+          settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(manneriMessages);
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        activeBondIdentityRef.current =
+          shouldTrackBond && bondIdentity ? bondIdentity : null;
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        activeBondIdentityRef.current = null;
+        core.updateChatOptions({
+          systemPrompt:
+            settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -659,5 +996,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-purupuru-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-purupuru-app/src/hooks/useLiveCommentIntelligence.ts
@@ -25,6 +25,7 @@ import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { useInterval } from './useInterval';
+import { createBondIdentity, type BondIdentity } from '../lib/kizunaBond';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
@@ -33,6 +34,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +202,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-purupuru-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-purupuru-app/src/hooks/useSettings.ts
@@ -360,6 +360,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -387,6 +390,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1354,6 +1358,13 @@ export function useSettings() {
     }));
   }, []);
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const updateManneriSimilarityThreshold = useCallback(
     (similarityThreshold: number) => {
       setSettings((prev) => ({
@@ -1504,6 +1515,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-purupuru-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-purupuru-app/src/hooks/useSettings.ts
@@ -522,8 +522,12 @@ export function useSettings() {
     }));
   }, []);
 
+  const openRouterApiKey = settings.llm.apiKeys.openrouter;
+  const openRouterMaxCandidates =
+    settings.llm.openRouterDynamicFreeModels?.maxCandidates;
+
   const refreshOpenRouterDynamicFreeModels = useCallback(async () => {
-    const apiKey = settings.llm.apiKeys.openrouter?.trim() || '';
+    const apiKey = openRouterApiKey?.trim() || '';
     if (!apiKey) {
       const message = 'OpenRouter API key is required.';
       setOpenRouterRefreshError(message);
@@ -535,7 +539,7 @@ export function useSettings() {
 
     try {
       const maxCandidates = normalizePositiveInteger(
-        settings.llm.openRouterDynamicFreeModels?.maxCandidates,
+        openRouterMaxCandidates,
         DEFAULT_OPENROUTER_MAX_CANDIDATES,
       );
       const result: RefreshOpenRouterFreeModelsResult =
@@ -567,10 +571,7 @@ export function useSettings() {
     } finally {
       setIsRefreshingOpenRouterFreeModels(false);
     }
-  }, [
-    settings.llm.apiKeys.openrouter,
-    settings.llm.openRouterDynamicFreeModels?.maxCandidates,
-  ]);
+  }, [openRouterApiKey, openRouterMaxCandidates]);
 
   const updateOpenRouterMaxCandidates = useCallback((maxCandidates: number) => {
     const normalized = normalizePositiveInteger(

--- a/packages/core/examples/react-purupuru-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-purupuru-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-purupuru-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the PuruPuru Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-purupuru-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-purupuru-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<T extends KizunaStorageRemover>(
+  storageProvider: T | null,
+): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-purupuru-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-purupuru-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-purupuru-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-purupuru-app/src/styles/app.css
+++ b/packages/core/examples/react-purupuru-app/src/styles/app.css
@@ -858,3 +858,196 @@ body {
     flex-basis: 100%;
   }
 }
+
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16) both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}

--- a/packages/core/examples/react-purupuru-app/src/types/settings.ts
+++ b/packages/core/examples/react-purupuru-app/src/types/settings.ts
@@ -172,6 +172,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface PuruPuruEffectAnchor {
   faceX: number;
   faceY: number;
@@ -216,4 +220,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }

--- a/packages/core/examples/react-vrm-app/package-lock.json
+++ b/packages/core/examples/react-vrm-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
         "@aituber-onair/core": "../..",
+        "@aituber-onair/kizuna": "../../../kizuna",
         "@aituber-onair/manneri": "../../../manneri",
         "@pixiv/three-vrm-animation": "^3.4.5",
         "react": "^19.2.0",
@@ -64,6 +65,20 @@
         "vitest": "^1.3.1"
       }
     },
+    "../../../kizuna": {
+      "name": "@aituber-onair/kizuna",
+      "version": "0.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "jsdom": "^22.1.0",
+        "typescript": "^5.0.0",
+        "vite": "^5.4.21",
+        "vitest": "^1.3.1"
+      }
+    },
     "../../../manneri": {
       "name": "@aituber-onair/manneri",
       "version": "0.4.0",
@@ -84,6 +99,10 @@
     },
     "node_modules/@aituber-onair/core": {
       "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@aituber-onair/kizuna": {
+      "resolved": "../../../kizuna",
       "link": true
     },
     "node_modules/@aituber-onair/manneri": {

--- a/packages/core/examples/react-vrm-app/package.json
+++ b/packages/core/examples/react-vrm-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aituber-onair/comment-intelligence": "../../../comment-intelligence",
     "@aituber-onair/core": "../..",
+    "@aituber-onair/kizuna": "../../../kizuna",
     "@aituber-onair/manneri": "../../../manneri",
     "@pixiv/three-vrm-animation": "^3.4.5",
     "react": "^19.2.0",

--- a/packages/core/examples/react-vrm-app/src/App.tsx
+++ b/packages/core/examples/react-vrm-app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { BondToastStack } from './components/BondToastStack';
 import { ChatPanel } from './components/ChatPanel';
 import { SettingsPanel } from './components/SettingsPanel';
 import { useAudioLipsync } from './hooks/useAudioLipsync';
@@ -16,6 +17,7 @@ import { useTwitchComments } from './hooks/useTwitchComments';
 import { useYoutubeComments } from './hooks/useYoutubeComments';
 import { clampDialogDragDelta, type DialogDragPoint } from './lib/dialogDrag';
 import { getEmotionEffectAnchor } from './lib/emotionEffectAnchor';
+import { createBondIdentity } from './lib/kizunaBond';
 import {
   createLinkedVrmEmotionEffectReaction,
   createVrmReactionFromScreenplay,
@@ -199,6 +201,10 @@ export default function App() {
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   } = useAituberCore({
     onAudioPlay: handleAudioPlay,
     onSpeechStart: handleSpeechStart,
@@ -219,7 +225,10 @@ export default function App() {
       stop();
       emitAvatarReaction({ type: 'reset', fadeMs: 160 });
       setEmotionEffectReaction(null);
-      processChat(text);
+      processChat(text, {
+        bondIdentity: createBondIdentity('form', 'あなた'),
+        bondMessage: text,
+      });
     },
     [stop, emitAvatarReaction, processChat],
   );
@@ -252,16 +261,30 @@ export default function App() {
 
   const handleYoutubeComment = useCallback(
     (comment: YouTubeChatMessage) => {
+      const timestamp = new Date(comment.publishedAt).getTime();
+      void recordBondMessage(
+        createBondIdentity('youtube', comment.userName),
+        comment.userComment,
+        Number.isFinite(timestamp) ? timestamp : Date.now(),
+      ).catch((error) => {
+        console.error('Failed to record YouTube Kizuna interaction:', error);
+      });
       enqueueYouTubeComments([comment]);
     },
-    [enqueueYouTubeComments],
+    [enqueueYouTubeComments, recordBondMessage],
   );
 
   const handleTwitchComment = useCallback(
     (comment: TwitchChatMessage) => {
+      void recordBondMessage(
+        createBondIdentity('twitch', comment.userName),
+        comment.userComment,
+      ).catch((error) => {
+        console.error('Failed to record Twitch Kizuna interaction:', error);
+      });
       enqueueTwitchComments([comment]);
     },
-    [enqueueTwitchComments],
+    [enqueueTwitchComments, recordBondMessage],
   );
 
   const handleBackgroundImageChange = useCallback((file: File | null) => {
@@ -397,6 +420,8 @@ export default function App() {
         onToggleSettings={toggleSettingsDialog}
       />
 
+      <BondToastStack toasts={bondToasts} onDismiss={dismissBondToast} />
+
       {settingsOpen && (
         <div className="settings-dialog-overlay" onClick={closeSettingsDialog}>
           <div
@@ -430,6 +455,7 @@ export default function App() {
               streamErrorMessage={streamErrorMessage}
               screenVisionController={screenVisionController}
               onBackgroundImageChange={handleBackgroundImageChange}
+              onResetKizunaData={resetKizunaData}
             />
           </div>
         </div>

--- a/packages/core/examples/react-vrm-app/src/components/BondToastStack.test.ts
+++ b/packages/core/examples/react-vrm-app/src/components/BondToastStack.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { BondToast } from '../lib/kizunaBond';
+import { BondToastStack } from './BondToastStack';
+
+const baseToast: BondToast = {
+  id: 1,
+  userId: 'youtube:Aki',
+  displayName: 'Aki',
+  pointsAdded: 20,
+  previousIntimacy: 0.1,
+  nextIntimacy: 0.25,
+  previousStage: '新しい視聴者',
+  nextStage: '顔なじみ',
+  leveledUp: false,
+};
+
+describe('BondToastStack', () => {
+  it('shows the viewer, intimacy change, and changed stage', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [baseToast],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('Aki');
+    expect(html).toContain('親密度 10% → 25%');
+    expect(html).toContain('新しい視聴者 → 顔なじみ');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('highlights a level change without a stage change', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            previousStage: '顔なじみ',
+            nextStage: '顔なじみ',
+            leveledUp: true,
+            newLevel: 3,
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('レベル3に上がりました');
+    expect(html).toContain('bond-toast-highlight');
+  });
+
+  it('shows a decrease variant for an angry reply', () => {
+    const html = renderToStaticMarkup(
+      createElement(BondToastStack, {
+        toasts: [
+          {
+            ...baseToast,
+            pointsAdded: -7.5,
+            previousIntimacy: 0.2,
+            nextIntimacy: 0.12,
+            previousStage: '知り合い',
+            nextStage: '知り合い',
+          },
+        ],
+        onDismiss: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('-7.5ポイント');
+    expect(html).toContain('親密度 20% → 12%');
+    expect(html).toContain('bond-toast-decreased');
+  });
+});

--- a/packages/core/examples/react-vrm-app/src/components/BondToastStack.tsx
+++ b/packages/core/examples/react-vrm-app/src/components/BondToastStack.tsx
@@ -1,0 +1,74 @@
+import type { CSSProperties } from 'react';
+import type { BondToast } from '../lib/kizunaBond';
+
+interface BondToastStackProps {
+  toasts: BondToast[];
+  onDismiss: (id: number) => void;
+}
+
+type ToastStyle = CSSProperties & {
+  '--bond-from': string;
+  '--bond-to': string;
+};
+
+export function BondToastStack({
+  toasts,
+  onDismiss,
+}: BondToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <aside className="bond-toast-stack" aria-label="親密度の変化通知">
+      {toasts.map((toast) => {
+        const decreased = toast.nextIntimacy < toast.previousIntimacy;
+        const highlighted =
+          decreased ||
+          toast.leveledUp ||
+          toast.previousStage !== toast.nextStage;
+        const style: ToastStyle = {
+          '--bond-from': `${toast.previousIntimacy * 100}%`,
+          '--bond-to': `${toast.nextIntimacy * 100}%`,
+        };
+        return (
+          <section
+            key={toast.id}
+            className={`bond-toast${highlighted ? ' bond-toast-highlight' : ''}${decreased ? ' bond-toast-decreased' : ''}`}
+            role="status"
+          >
+            <button
+              type="button"
+              className="bond-toast-dismiss"
+              onClick={() => onDismiss(toast.id)}
+              aria-label={`${toast.displayName}の通知を閉じる`}
+            >
+              ×
+            </button>
+            <div className="bond-toast-heading">
+              <strong>{toast.displayName}</strong>
+              <span>{formatSignedPoints(toast.pointsAdded)}ポイント</span>
+            </div>
+            <p>
+              親密度 {Math.round(toast.previousIntimacy * 100)}% →{' '}
+              {Math.round(toast.nextIntimacy * 100)}%
+            </p>
+            <div className="bond-toast-track" aria-hidden="true">
+              <i style={style} />
+            </div>
+            <small>
+              {toast.previousStage !== toast.nextStage
+                ? `関係ステージ: ${toast.previousStage} → ${toast.nextStage}`
+                : toast.leveledUp
+                  ? `レベル${toast.newLevel ?? ''}に上がりました · ${toast.nextStage}`
+                  : `現在の関係ステージ: ${toast.nextStage}`}
+            </small>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}
+
+function formatSignedPoints(points: number): string {
+  const formatted = Number.isInteger(points) ? String(points) : points.toFixed(1);
+  return points > 0 ? `+${formatted}` : formatted;
+}

--- a/packages/core/examples/react-vrm-app/src/components/SettingsPanel.tsx
+++ b/packages/core/examples/react-vrm-app/src/components/SettingsPanel.tsx
@@ -31,6 +31,7 @@ interface SettingsPanelProps extends SettingsHook {
   streamErrorMessage?: string;
   screenVisionController: ScreenVisionController;
   onBackgroundImageChange: (file: File | null) => void;
+  onResetKizunaData: () => Promise<void>;
 }
 
 const PROVIDERS: {
@@ -341,12 +342,14 @@ export function SettingsPanel({
   updateManneriLookbackWindow,
   updateManneriInterventionCooldownMs,
   updateManneriMinMessageLength,
+  updateKizunaEnabled,
   getApiKeyForProvider,
   isProcessing,
   backgroundImageUrl,
   streamErrorMessage,
   screenVisionController,
   onBackgroundImageChange,
+  onResetKizunaData,
 }: SettingsPanelProps) {
   const disabled = isProcessing;
   const [systemPromptDraft, setSystemPromptDraft] = useState(
@@ -355,6 +358,9 @@ export function SettingsPanel({
   const committedEndpoint = settings.llm.endpoint || '';
   const [endpointDraft, setEndpointDraft] = useState(committedEndpoint);
   const [endpointError, setEndpointError] = useState('');
+  const [kizunaResetState, setKizunaResetState] = useState<
+    'idle' | 'confirming' | 'resetting' | 'success' | 'error'
+  >('idle');
 
   const commitSystemPrompt = () => {
     if (systemPromptDraft !== settings.llm.systemPrompt) {
@@ -790,6 +796,16 @@ export function SettingsPanel({
     }));
   };
 
+  const handleConfirmKizunaReset = async () => {
+    setKizunaResetState('resetting');
+    try {
+      await onResetKizunaData();
+      setKizunaResetState('success');
+    } catch {
+      setKizunaResetState('error');
+    }
+  };
+
   return (
     <div className="settings-panel">
       {/* LLM Section */}
@@ -899,6 +915,86 @@ export function SettingsPanel({
                 既定値を使用します。アバター固有の制御指示を削除すると、
                 感情表現エフェクトの連動に影響する場合があります。
               </p>
+            </div>
+
+            <div className="settings-field settings-kizuna-field">
+              <label htmlFor="kizuna-enabled">
+                <input
+                  id="kizuna-enabled"
+                  type="checkbox"
+                  checked={settings.kizuna.enabled}
+                  onChange={(event) =>
+                    updateKizunaEnabled(event.target.checked)
+                  }
+                  disabled={disabled}
+                />
+                視聴者ごとの親密度を記録する（Kizuna）
+              </label>
+              <p className="settings-field-hint">
+                フォーム入力、YouTube、Twitchを別の人物として記録し、応答前に
+                その視聴者との関係性をSystem Promptへ追加します。
+              </p>
+              <p className="settings-field-hint">
+                Kizunaを無効にしても、保存済みの絆データは残ります。
+              </p>
+              <div className="settings-kizuna-reset">
+                {kizunaResetState === 'confirming' ? (
+                  <div
+                    className="settings-kizuna-reset-confirmation"
+                    role="group"
+                    aria-label="絆データのリセット確認"
+                  >
+                    <p>本当に絆データをリセットしますか？</p>
+                    <div className="settings-kizuna-reset-actions">
+                      <button
+                        type="button"
+                        className="settings-action-button settings-kizuna-reset-button"
+                        onClick={() => void handleConfirmKizunaReset()}
+                        disabled={disabled}
+                      >
+                        リセットを実行
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-clear-button"
+                        onClick={() => setKizunaResetState('idle')}
+                        disabled={disabled}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="settings-action-button settings-kizuna-reset-button"
+                    onClick={() => setKizunaResetState('confirming')}
+                    disabled={disabled || kizunaResetState === 'resetting'}
+                  >
+                    {kizunaResetState === 'resetting'
+                      ? 'リセット中...'
+                      : '絆データをリセット'}
+                  </button>
+                )}
+                {kizunaResetState === 'success' && (
+                  <p
+                    className="settings-kizuna-reset-status is-success"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    絆データをリセットしました。
+                  </p>
+                )}
+                {kizunaResetState === 'error' && (
+                  <p
+                    className="settings-kizuna-reset-status is-error"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    保存データを削除できませんでした。ブラウザの保存設定を確認してください。
+                  </p>
+                )}
+              </div>
             </div>
 
             {isOpenAIGPT5Model && (

--- a/packages/core/examples/react-vrm-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-vrm-app/src/hooks/useAituberCore.ts
@@ -7,6 +7,14 @@ import {
   isXaiReasoningEffortModel,
 } from '@aituber-onair/core';
 import { ManneriDetector } from '@aituber-onair/manneri';
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+  type BondSnapshot,
+  type IStorageProvider,
+  type InteractionKind,
+} from '@aituber-onair/kizuna';
 import type {
   VoiceServiceOptions,
   ElevenLabsApplyTextNormalization,
@@ -23,6 +31,22 @@ import type { ScreenplayLike } from '../lib/vrmReactions';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { DEFAULT_SYSTEM_PROMPT } from '../constants/prompts';
+import {
+  buildBondAwareSystemPrompt,
+  formatBondStage,
+  getBondContextDisplayName,
+  type BondIdentity,
+  type BondToast,
+} from '../lib/kizunaBond';
+import {
+  attemptKizunaStorageClear,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from '../lib/kizunaStorage';
+import {
+  createSerialTaskQueue,
+  type SerialTaskQueue,
+} from '../lib/serialTaskQueue';
 
 interface UseAituberCoreOptions {
   onAudioPlay: (arrayBuffer: ArrayBuffer) => Promise<void>;
@@ -34,12 +58,53 @@ interface UseAituberCoreOptions {
 
 type ProcessChatOptions = {
   displayText?: string;
+  bondIdentity?: BondIdentity;
+  bondMessage?: string;
+  bondAlreadyRecorded?: boolean;
 };
 
 const DEFAULT_VISION_PROMPT =
   'OBS仮想カメラの画面を見て、配信者として短く自然にコメントしてください。';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
 const GPT5_SAMPLE_CHAT_OPTIONS = { responseLength: 'veryShort' as const };
+const MAX_BOND_TOASTS = 4;
+const BOND_TOAST_DURATION_MS = 4_500;
+const VISIBLE_BOND_CHANGE = 0.0005;
+
+interface VrmKizunaManagerSetup {
+  manager: KizunaManager;
+  storageProvider: IStorageProvider | null;
+}
+
+function createVrmKizunaManager(
+  enablePersistence = true,
+): VrmKizunaManagerSetup {
+  const config = createDefaultKizunaConfig();
+  config.basePoints = {
+    ...config.basePoints,
+    message: 20,
+    reaction: 5,
+  };
+  const storageProvider = enablePersistence
+    ? tryCreateKizunaStorageProvider(
+        () => new LocalStorageProvider(),
+        (error) => {
+          console.warn(
+            'Kizuna persistence is unavailable; continuing with in-memory storage.',
+            error,
+          );
+        },
+      )
+    : undefined;
+  return {
+    manager: new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    ),
+    storageProvider: storageProvider ?? null,
+  };
+}
 
 function toManneriMessages(
   messages: ChatMessage[],
@@ -335,6 +400,19 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
+  const [initialKizunaSetup] = useState(() => createVrmKizunaManager());
+  const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
+  const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
+    initialKizunaSetup.storageProvider,
+  );
+  const [enqueueCoreRequest] = useState<SerialTaskQueue>(() =>
+    createSerialTaskQueue(),
+  );
+  const activeBondIdentityRef = useRef<BondIdentity | null>(null);
+  const bondQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const bondToastSequenceRef = useRef(0);
+  const bondToastTimersRef = useRef(new Map<number, number>());
+  const bondToastByUserRef = useRef(new Map<string, number>());
   const chatHistoryRef = useRef<
     ReturnType<AITuberOnAirCore['getChatHistory']>
   >([]);
@@ -344,6 +422,178 @@ export function useAituberCore({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [partialResponse, setPartialResponse] = useState('');
+  const [bondToasts, setBondToasts] = useState<BondToast[]>([]);
+
+  useEffect(() => {
+    const manager = kizunaRef.current;
+    if (!manager) return;
+    void manager.initialize().catch((error) => {
+      console.error('Failed to initialize Kizuna data:', error);
+    });
+  }, []);
+
+  const dismissBondToast = useCallback((id: number) => {
+    const timer = bondToastTimersRef.current.get(id);
+    if (timer !== undefined) window.clearTimeout(timer);
+    bondToastTimersRef.current.delete(id);
+    for (const [userId, toastId] of bondToastByUserRef.current) {
+      if (toastId === id) bondToastByUserRef.current.delete(userId);
+    }
+    setBondToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearBondToasts = useCallback(() => {
+    for (const timer of bondToastTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    bondToastTimersRef.current.clear();
+    bondToastByUserRef.current.clear();
+    setBondToasts([]);
+  }, []);
+
+  const resetKizunaData = useCallback((): Promise<void> => {
+    const reset = bondQueueRef.current.then(async () => {
+      activeBondIdentityRef.current = null;
+      kizunaRef.current?.destroy();
+
+      const storageClearResult = await attemptKizunaStorageClear(
+        kizunaStorageProviderRef.current,
+      );
+      if (!storageClearResult.storageCleared) {
+        console.error(
+          'Failed to clear persisted Kizuna data:',
+          storageClearResult.error,
+        );
+      }
+
+      const setup = createVrmKizunaManager(storageClearResult.storageCleared);
+      kizunaRef.current = setup.manager;
+      kizunaStorageProviderRef.current = storageClearResult.storageCleared
+        ? setup.storageProvider
+        : storageClearResult.storageProvider;
+      try {
+        await setup.manager.initialize();
+      } catch (error) {
+        console.error('Failed to initialize reset Kizuna data:', error);
+      }
+      clearBondToasts();
+
+      if (!storageClearResult.storageCleared) {
+        throw storageClearResult.error;
+      }
+    });
+    bondQueueRef.current = reset.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reset;
+  }, [clearBondToasts]);
+
+  const recordBondInteraction = useCallback(
+    async (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> => {
+      if (!settings.kizuna.enabled || !kizunaRef.current) return null;
+      const manager = kizunaRef.current;
+      await manager.initialize();
+      const previousSnapshot = manager.getBondSnapshot(identity.userId);
+      const previousIntimacy = manager.toRelationshipCapital(identity.userId);
+      const result = await manager.processInteraction({
+        userId: identity.userId,
+        kind,
+        message,
+        emotion,
+        isOwner: identity.isOwner,
+        timestamp,
+        metadata: {
+          displayName: getBondContextDisplayName(identity.source),
+          source: identity.source,
+        },
+      });
+      const nextSnapshot = manager.getBondSnapshot(identity.userId);
+      if (!nextSnapshot) return null;
+
+      const nextIntimacy = manager.toRelationshipCapital(identity.userId);
+      if (Math.abs(nextIntimacy - previousIntimacy) > VISIBLE_BOND_CHANGE) {
+        bondToastSequenceRef.current += 1;
+        const id = bondToastSequenceRef.current;
+        const toast: BondToast = {
+          id,
+          userId: identity.userId,
+          displayName: identity.displayName,
+          pointsAdded: result.pointsAdded,
+          previousIntimacy,
+          nextIntimacy,
+          previousStage: previousSnapshot
+            ? formatBondStage(previousSnapshot.stage)
+            : '未接触',
+          nextStage: formatBondStage(nextSnapshot.stage),
+          leveledUp: result.leveledUp,
+          ...(result.newLevel !== undefined && {
+            newLevel: result.newLevel,
+          }),
+        };
+        const previousToastId = bondToastByUserRef.current.get(identity.userId);
+        if (previousToastId !== undefined) {
+          const previousTimer = bondToastTimersRef.current.get(previousToastId);
+          if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+          bondToastTimersRef.current.delete(previousToastId);
+        }
+        bondToastByUserRef.current.set(identity.userId, id);
+        setBondToasts((current) =>
+          [
+            ...current.filter(({ id: toastId }) =>
+              previousToastId === undefined
+                ? true
+                : toastId !== previousToastId,
+            ),
+            toast,
+          ].slice(-MAX_BOND_TOASTS),
+        );
+        const timer = window.setTimeout(
+          () => dismissBondToast(id),
+          BOND_TOAST_DURATION_MS,
+        );
+        bondToastTimersRef.current.set(id, timer);
+      }
+      return nextSnapshot;
+    },
+    [dismissBondToast, settings.kizuna.enabled],
+  );
+
+  const queueBondInteraction = useCallback(
+    (
+      identity: BondIdentity,
+      kind: InteractionKind,
+      message: string,
+      emotion?: string,
+      timestamp?: number,
+    ): Promise<BondSnapshot | null> => {
+      const result = bondQueueRef.current.then(() =>
+        recordBondInteraction(identity, kind, message, emotion, timestamp),
+      );
+      bondQueueRef.current = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    [recordBondInteraction],
+  );
+
+  const recordBondMessage = useCallback(
+    (
+      identity: BondIdentity,
+      message: string,
+      timestamp = Date.now(),
+    ): Promise<BondSnapshot | null> =>
+      queueBondInteraction(identity, 'message', message, undefined, timestamp),
+    [queueBondInteraction],
+  );
 
   // Keep the latest onAudioPlay callback in a ref
   const onAudioPlayRef = useRef(onAudioPlay);
@@ -356,6 +606,24 @@ export function useAituberCore({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    if (settings.kizuna.enabled) return;
+    activeBondIdentityRef.current = null;
+    clearBondToasts();
+  }, [clearBondToasts, settings.kizuna.enabled]);
+
+  useEffect(
+    () => () => {
+      kizunaRef.current?.destroy();
+      for (const timer of bondToastTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      bondToastTimersRef.current.clear();
+      bondToastByUserRef.current.clear();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!settings.manneri.enabled) {
@@ -476,13 +744,14 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ASSISTANT_RESPONSE, (data: unknown) => {
       let content: string;
+      let responseEmotion: string | undefined;
       if (typeof data === 'string') {
         content = data;
       } else {
         const d = data as {
           message?: { content?: string } | string;
-          screenplay?: { text?: string };
           rawText?: string;
+          screenplay?: { emotion?: string; text?: string };
         };
         const msg = d?.message;
         const cleanText = d?.screenplay?.text?.trim();
@@ -491,6 +760,7 @@ export function useAituberCore({
           ((typeof msg === 'string' ? msg : msg?.content) ??
             d?.rawText ??
             String(data));
+        responseEmotion = d?.screenplay?.emotion;
       }
       setMessages((prev) => [
         ...prev,
@@ -502,6 +772,19 @@ export function useAituberCore({
         },
       ]);
       setPartialResponse('');
+
+      const bondIdentity = activeBondIdentityRef.current;
+      activeBondIdentityRef.current = null;
+      if (bondIdentity && responseEmotion) {
+        void queueBondInteraction(
+          bondIdentity,
+          'reaction',
+          content,
+          responseEmotion,
+        ).catch((error) => {
+          console.error('Failed to record Kizuna response emotion:', error);
+        });
+      }
     });
 
     core.on(AITuberOnAirCoreEvent.SPEECH_START, (data: unknown) => {
@@ -517,6 +800,7 @@ export function useAituberCore({
 
     core.on(AITuberOnAirCoreEvent.ERROR, (error: unknown) => {
       console.error('AITuberOnAirCore error:', error);
+      activeBondIdentityRef.current = null;
       setIsProcessing(false);
       onSpeechEndRef.current?.();
     });
@@ -537,9 +821,11 @@ export function useAituberCore({
     settings.llm.systemPrompt,
     settings.llm.endpoint,
     settings.llm.xaiReasoningEffort,
+    settings.kizuna.enabled,
     llmApiKey,
     isApiKeyOptionalProvider,
     createMessageId,
+    queueBondInteraction,
   ]);
 
   // Effect 2: Update voice service when TTS settings change (no core recreation)
@@ -580,73 +866,128 @@ export function useAituberCore({
   ]);
 
   const processChat = useCallback(
-    async (text: string, options?: ProcessChatOptions) => {
-      if (!coreRef.current || !text.trim()) return;
+    (text: string, options?: ProcessChatOptions) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !text.trim()) return;
 
-      let coreInput = text.trim();
-      const displayText = (options?.displayText ?? text).trim();
-      const manneriDetector = manneriDetectorRef.current;
+        let coreInput = text.trim();
+        const displayText = (options?.displayText ?? text).trim();
+        const bondIdentity = options?.bondIdentity;
+        const shouldTrackBond = settings.kizuna.enabled && Boolean(bondIdentity);
+        const manneriDetector = manneriDetectorRef.current;
 
-      if (manneriDetector) {
-        try {
-          const manneriMessages = toManneriMessages(
-            messagesRef.current,
-            coreInput,
-          );
-          if (manneriDetector.shouldIntervene(manneriMessages)) {
-            const prompt =
-              manneriDetector.generateDiversificationPrompt(manneriMessages);
-            coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+        if (shouldTrackBond && bondIdentity && kizunaRef.current) {
+          try {
+            if (options?.bondAlreadyRecorded) {
+              await bondQueueRef.current;
+            } else {
+              await recordBondMessage(
+                bondIdentity,
+                options?.bondMessage ?? displayText,
+              );
+            }
+            const bondContext = kizunaRef.current.getBondContext(
+              bondIdentity.userId,
+              { language: 'ja' },
+            );
+            core.updateChatOptions({
+              systemPrompt: buildBondAwareSystemPrompt(
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+                bondContext,
+              ),
+            });
+          } catch (error) {
+            console.error('Failed to update Kizuna bond context:', error);
+            core.updateChatOptions({
+              systemPrompt:
+                settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+            });
           }
-        } catch (err) {
-          console.warn('Manneri detection failed:', err);
+        } else {
+          core.updateChatOptions({
+            systemPrompt:
+              settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+          });
         }
-      }
 
-      // Append the user message to the chat log
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: displayText,
-          timestamp: Date.now(),
-        },
-      ]);
+        if (manneriDetector) {
+          try {
+            const manneriMessages = toManneriMessages(
+              messagesRef.current,
+              coreInput,
+            );
+            if (manneriDetector.shouldIntervene(manneriMessages)) {
+              const prompt =
+                manneriDetector.generateDiversificationPrompt(manneriMessages);
+              coreInput = buildManneriAugmentedInput(coreInput, prompt.content);
+            }
+          } catch (err) {
+            console.warn('Manneri detection failed:', err);
+          }
+        }
 
-      try {
-        await coreRef.current.processChat(coreInput);
-      } catch (err) {
-        console.error('processChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: displayText,
+            timestamp: Date.now(),
+          },
+        ]);
+
+        activeBondIdentityRef.current =
+          shouldTrackBond && bondIdentity ? bondIdentity : null;
+        try {
+          await core.processChat(coreInput);
+        } catch (err) {
+          console.error('processChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [
+      createMessageId,
+      enqueueCoreRequest,
+      recordBondMessage,
+      settings.kizuna.enabled,
+      settings.llm.systemPrompt,
+    ],
   );
 
   const processVisionChat = useCallback(
-    async (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) => {
-      if (!coreRef.current || !imageDataUrl) return;
+    (imageDataUrl: string, prompt = DEFAULT_VISION_PROMPT) =>
+      enqueueCoreRequest(async () => {
+        const core = coreRef.current;
+        if (!core || !imageDataUrl) return;
 
-      const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: createMessageId(),
-          role: 'user',
-          content: '画面を見てコメント',
-          timestamp: Date.now(),
-        },
-      ]);
+        const trimmedPrompt = prompt.trim() || DEFAULT_VISION_PROMPT;
+        activeBondIdentityRef.current = null;
+        core.updateChatOptions({
+          systemPrompt: settings.llm.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+        });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createMessageId(),
+            role: 'user',
+            content: '画面を見てコメント',
+            timestamp: Date.now(),
+          },
+        ]);
 
-      try {
-        await coreRef.current.processVisionChat(imageDataUrl, trimmedPrompt);
-      } catch (err) {
-        console.error('processVisionChat error:', err);
-        setIsProcessing(false);
-      }
-    },
-    [createMessageId],
+        try {
+          await core.processVisionChat(imageDataUrl, trimmedPrompt);
+        } catch (err) {
+          console.error('processVisionChat error:', err);
+          setIsProcessing(false);
+        } finally {
+          activeBondIdentityRef.current = null;
+        }
+      }),
+    [createMessageId, enqueueCoreRequest, settings.llm.systemPrompt],
   );
 
   return {
@@ -655,5 +996,9 @@ export function useAituberCore({
     partialResponse,
     processChat,
     processVisionChat,
+    bondToasts,
+    dismissBondToast,
+    recordBondMessage,
+    resetKizunaData,
   };
 }

--- a/packages/core/examples/react-vrm-app/src/hooks/useAituberCore.ts
+++ b/packages/core/examples/react-vrm-app/src/hooks/useAituberCore.ts
@@ -71,14 +71,14 @@ const MAX_BOND_TOASTS = 4;
 const BOND_TOAST_DURATION_MS = 4_500;
 const VISIBLE_BOND_CHANGE = 0.0005;
 
-interface VrmKizunaManagerSetup {
+interface KizunaManagerSetup {
   manager: KizunaManager;
   storageProvider: IStorageProvider | null;
 }
 
-function createVrmKizunaManager(
+function createKizunaManager(
   enablePersistence = true,
-): VrmKizunaManagerSetup {
+): KizunaManagerSetup {
   const config = createDefaultKizunaConfig();
   config.basePoints = {
     ...config.basePoints,
@@ -400,7 +400,7 @@ export function useAituberCore({
   getApiKeyForProvider,
 }: UseAituberCoreOptions) {
   const coreRef = useRef<AITuberOnAirCore | null>(null);
-  const [initialKizunaSetup] = useState(() => createVrmKizunaManager());
+  const [initialKizunaSetup] = useState(() => createKizunaManager());
   const kizunaRef = useRef<KizunaManager | null>(initialKizunaSetup.manager);
   const kizunaStorageProviderRef = useRef<IStorageProvider | null>(
     initialKizunaSetup.storageProvider,
@@ -466,7 +466,7 @@ export function useAituberCore({
         );
       }
 
-      const setup = createVrmKizunaManager(storageClearResult.storageCleared);
+      const setup = createKizunaManager(storageClearResult.storageCleared);
       kizunaRef.current = setup.manager;
       kizunaStorageProviderRef.current = storageClearResult.storageCleared
         ? setup.storageProvider

--- a/packages/core/examples/react-vrm-app/src/hooks/useLiveCommentIntelligence.ts
+++ b/packages/core/examples/react-vrm-app/src/hooks/useLiveCommentIntelligence.ts
@@ -25,6 +25,10 @@ import type { YouTubeChatMessage } from '../services/youtube/youtubeService';
 import type { ChatMessage } from '../types/chat';
 import type { AppSettings, ChatProviderOption } from '../types/settings';
 import { useInterval } from './useInterval';
+import {
+  createBondIdentity,
+  type BondIdentity,
+} from '../lib/kizunaBond';
 
 type StreamPlatform = 'youtube' | 'twitch' | 'none';
 const GPT5_SAMPLE_PROVIDER_OPTIONS = { gpt5Preset: 'casual' as const };
@@ -33,6 +37,9 @@ type ProcessChat = (
   text: string,
   options?: {
     displayText?: string;
+    bondIdentity?: BondIdentity;
+    bondMessage?: string;
+    bondAlreadyRecorded?: boolean;
   },
 ) => Promise<void>;
 
@@ -198,8 +205,14 @@ export function useLiveCommentIntelligence({
       const promptForCore = formatCommentIntelligencePrompt(result);
       const authorName = selected.author.displayName ?? selected.author.name;
       const displayText = `「${authorName}」さんのコメント: ${selected.text}`;
+      const bondSource = selected.platform === 'twitch' ? 'twitch' : 'youtube';
 
-      await processChat(promptForCore, { displayText });
+      await processChat(promptForCore, {
+        displayText,
+        bondIdentity: createBondIdentity(bondSource, authorName),
+        bondMessage: selected.text,
+        bondAlreadyRecorded: true,
+      });
     } finally {
       isFlushingRef.current = false;
     }

--- a/packages/core/examples/react-vrm-app/src/hooks/useSettings.ts
+++ b/packages/core/examples/react-vrm-app/src/hooks/useSettings.ts
@@ -269,6 +269,9 @@ function getDefaultSettings(): AppSettings {
       interventionCooldownMs: 5 * 60 * 1000,
       minMessageLength: 10,
     },
+    kizuna: {
+      enabled: false,
+    },
   };
 }
 
@@ -310,6 +313,7 @@ function loadSettings(): AppSettings {
           ...saved.commentIntelligence,
         },
         manneri: { ...defaults.manneri, ...saved.manneri },
+        kizuna: { ...defaults.kizuna, ...saved.kizuna },
       };
     }
   } catch {
@@ -1241,6 +1245,13 @@ export function useSettings() {
     }));
   }, []);
 
+  const updateKizunaEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({
+      ...prev,
+      kizuna: { ...prev.kizuna, enabled },
+    }));
+  }, []);
+
   const updateManneriSimilarityThreshold = useCallback(
     (similarityThreshold: number) => {
       setSettings((prev) => ({
@@ -1388,6 +1399,7 @@ export function useSettings() {
     updateManneriLookbackWindow,
     updateManneriInterventionCooldownMs,
     updateManneriMinMessageLength,
+    updateKizunaEnabled,
     getApiKeyForProvider,
   };
 }

--- a/packages/core/examples/react-vrm-app/src/lib/kizunaBond.test.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/kizunaBond.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBondAwareSystemPrompt,
+  createBondIdentity,
+  formatBondStage,
+  getBondContextDisplayName,
+} from './kizunaBond';
+
+describe('createBondIdentity', () => {
+  it('keeps YouTube and Twitch viewers separate by source', () => {
+    expect(createBondIdentity('youtube', 'Aki')).toMatchObject({
+      userId: 'youtube:Aki',
+      displayName: 'Aki',
+      isOwner: false,
+    });
+    expect(createBondIdentity('twitch', 'Aki').userId).toBe('twitch:Aki');
+  });
+
+  it('uses a stable owner identity for the chat form', () => {
+    expect(createBondIdentity('form', 'ignored')).toEqual({
+      userId: 'form:owner',
+      displayName: 'あなた',
+      source: 'form',
+      isOwner: true,
+    });
+  });
+});
+
+describe('buildBondAwareSystemPrompt', () => {
+  it('appends context only when it exists', () => {
+    expect(buildBondAwareSystemPrompt('base', '')).toBe('base');
+    expect(buildBondAwareSystemPrompt('base', 'regular viewer')).toContain(
+      'regular viewer',
+    );
+  });
+});
+
+describe('formatBondStage', () => {
+  it('uses plain Japanese labels for built-in stages', () => {
+    expect(formatBondStage('stranger')).toBe('知り合ったばかり');
+    expect(formatBondStage('companion')).toBe('相棒');
+  });
+});
+
+describe('getBondContextDisplayName', () => {
+  it('does not expose an external display name to the system prompt context', () => {
+    expect(getBondContextDisplayName('youtube')).toBe('YouTube視聴者');
+    expect(getBondContextDisplayName('twitch')).toBe('Twitch視聴者');
+    expect(getBondContextDisplayName('form')).toBe('あなた');
+  });
+});

--- a/packages/core/examples/react-vrm-app/src/lib/kizunaBond.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/kizunaBond.ts
@@ -1,0 +1,58 @@
+export type BondSource = 'form' | 'youtube' | 'twitch';
+
+export interface BondIdentity {
+  userId: string;
+  displayName: string;
+  source: BondSource;
+  isOwner: boolean;
+}
+
+export interface BondToast {
+  id: number;
+  userId: string;
+  displayName: string;
+  pointsAdded: number;
+  previousIntimacy: number;
+  nextIntimacy: number;
+  previousStage: string;
+  nextStage: string;
+  leveledUp: boolean;
+  newLevel?: number;
+}
+
+export function createBondIdentity(
+  source: BondSource,
+  displayName: string,
+): BondIdentity {
+  const normalizedName = displayName.trim() || '匿名の視聴者';
+  return {
+    userId: source === 'form' ? 'form:owner' : `${source}:${normalizedName}`,
+    displayName: source === 'form' ? 'あなた' : normalizedName,
+    source,
+    isOwner: source === 'form',
+  };
+}
+
+export function buildBondAwareSystemPrompt(
+  basePrompt: string,
+  bondContext: string,
+): string {
+  return bondContext
+    ? `${basePrompt}\n\nCurrent viewer relationship:\n${bondContext}`
+    : basePrompt;
+}
+
+export function getBondContextDisplayName(source: BondSource): string {
+  if (source === 'form') return 'あなた';
+  return source === 'youtube' ? 'YouTube視聴者' : 'Twitch視聴者';
+}
+
+export function formatBondStage(stage: string): string {
+  const labels: Record<string, string> = {
+    stranger: '知り合ったばかり',
+    acquaintance: '知り合い',
+    regular: '常連',
+    companion: '相棒',
+  };
+  return labels[stage] ?? stage;
+}

--- a/packages/core/examples/react-vrm-app/src/lib/kizunaStorage.test.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/kizunaStorage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  KizunaManager,
+  LocalStorageProvider,
+  createDefaultKizunaConfig,
+} from '@aituber-onair/kizuna';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attemptKizunaStorageClear,
+  clearKizunaStorage,
+  KIZUNA_STORAGE_KEY,
+  tryCreateKizunaStorageProvider,
+} from './kizunaStorage';
+
+describe('tryCreateKizunaStorageProvider', () => {
+  it('returns the provider when storage is available', () => {
+    const provider = { remove: vi.fn() };
+
+    const result = tryCreateKizunaStorageProvider(() => provider, vi.fn());
+
+    expect(result).toBe(provider);
+  });
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const error = new Error('localStorage is unavailable');
+    const onUnavailable = vi.fn();
+
+    const result = tryCreateKizunaStorageProvider(() => {
+      throw error;
+    }, onUnavailable);
+
+    expect(result).toBeUndefined();
+    expect(onUnavailable).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('clearKizunaStorage', () => {
+  it('removes only the VRM Kizuna storage key', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+
+    await clearKizunaStorage({ remove });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(KIZUNA_STORAGE_KEY);
+  });
+
+  it('does nothing when persistence is unavailable', async () => {
+    await expect(clearKizunaStorage(null)).resolves.toBeUndefined();
+  });
+});
+
+describe('attemptKizunaStorageClear', () => {
+  it('retains a failed provider so the next reset retries removal', async () => {
+    const error = new Error('remove failed');
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const storageProvider = { remove };
+
+    const firstAttempt = await attemptKizunaStorageClear(storageProvider);
+    const secondAttempt = await attemptKizunaStorageClear(
+      firstAttempt.storageProvider,
+    );
+
+    expect(firstAttempt).toEqual({
+      storageCleared: false,
+      storageProvider,
+      error,
+    });
+    expect(secondAttempt).toEqual({
+      storageCleared: true,
+      storageProvider,
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, KIZUNA_STORAGE_KEY);
+    expect(remove).toHaveBeenNthCalledWith(2, KIZUNA_STORAGE_KEY);
+  });
+});
+
+describe('Kizuna localStorage persistence', () => {
+  it('restores saved bond data in a new manager', async () => {
+    localStorage.clear();
+    const now = Date.parse('2026-08-16T00:00:00Z');
+    const config = createDefaultKizunaConfig();
+    config.now = () => now;
+    const storageProvider = new LocalStorageProvider();
+    const manager = new KizunaManager(
+      config,
+      storageProvider,
+      KIZUNA_STORAGE_KEY,
+    );
+
+    await manager.processInteraction({
+      userId: 'form:owner',
+      kind: 'message',
+      message: 'hello',
+      isOwner: true,
+      timestamp: now,
+    });
+    const savedSnapshot = manager.getBondSnapshot('form:owner');
+    manager.destroy();
+
+    const restoredManager = new KizunaManager(
+      config,
+      new LocalStorageProvider(),
+      KIZUNA_STORAGE_KEY,
+    );
+    await restoredManager.initialize();
+
+    expect(restoredManager.getBondSnapshot('form:owner')).toEqual(
+      savedSnapshot,
+    );
+    restoredManager.destroy();
+    localStorage.clear();
+  });
+});

--- a/packages/core/examples/react-vrm-app/src/lib/kizunaStorage.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/kizunaStorage.ts
@@ -1,0 +1,46 @@
+export const KIZUNA_STORAGE_KEY = 'react-vrm-bond';
+
+interface KizunaStorageRemover {
+  remove: (key: string) => Promise<void>;
+}
+
+export type KizunaStorageClearResult<T extends KizunaStorageRemover> =
+  | {
+      storageCleared: true;
+      storageProvider: T | null;
+    }
+  | {
+      storageCleared: false;
+      storageProvider: T | null;
+      error: unknown;
+    };
+
+export function tryCreateKizunaStorageProvider<T>(
+  createStorageProvider: () => T,
+  onUnavailable: (error: unknown) => void,
+): T | undefined {
+  try {
+    return createStorageProvider();
+  } catch (error) {
+    onUnavailable(error);
+    return undefined;
+  }
+}
+
+export async function clearKizunaStorage(
+  storageProvider: KizunaStorageRemover | null,
+): Promise<void> {
+  if (!storageProvider) return;
+  await storageProvider.remove(KIZUNA_STORAGE_KEY);
+}
+
+export async function attemptKizunaStorageClear<
+  T extends KizunaStorageRemover,
+>(storageProvider: T | null): Promise<KizunaStorageClearResult<T>> {
+  try {
+    await clearKizunaStorage(storageProvider);
+    return { storageCleared: true, storageProvider };
+  } catch (error) {
+    return { storageCleared: false, storageProvider, error };
+  }
+}

--- a/packages/core/examples/react-vrm-app/src/lib/serialTaskQueue.test.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/serialTaskQueue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialTaskQueue } from './serialTaskQueue';
+
+describe('createSerialTaskQueue', () => {
+  it('runs overlapping tasks in request order', async () => {
+    const enqueue = createSerialTaskQueue();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('continues after a rejected task', async () => {
+    const enqueue = createSerialTaskQueue();
+    const first = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const second = enqueue(async () => 'completed');
+
+    await expect(first).rejects.toThrow('expected failure');
+    await expect(second).resolves.toBe('completed');
+  });
+});

--- a/packages/core/examples/react-vrm-app/src/lib/serialTaskQueue.ts
+++ b/packages/core/examples/react-vrm-app/src/lib/serialTaskQueue.ts
@@ -1,0 +1,14 @@
+export type SerialTaskQueue = <T>(task: () => Promise<T>) => Promise<T>;
+
+export function createSerialTaskQueue(): SerialTaskQueue {
+  let tail: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/packages/core/examples/react-vrm-app/src/styles/app.css
+++ b/packages/core/examples/react-vrm-app/src/styles/app.css
@@ -188,6 +188,200 @@ body {
   margin-bottom: 4px;
 }
 
+.settings-kizuna-field > label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1.45;
+}
+
+.settings-kizuna-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: #e94560;
+}
+
+.settings-kizuna-reset {
+  margin-top: 10px;
+}
+
+.settings-kizuna-reset-confirmation {
+  padding: 9px;
+  border: 1px solid rgba(233, 69, 96, 0.55);
+  border-radius: 7px;
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.settings-kizuna-reset-confirmation p {
+  margin: 0 0 8px;
+  color: #f2c4cc;
+  font-size: 0.75rem;
+}
+
+.settings-kizuna-reset-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.settings-kizuna-reset-button {
+  border-color: rgba(233, 69, 96, 0.75);
+  color: #ffd7de;
+}
+
+.settings-kizuna-reset-status {
+  margin: 7px 0 0;
+  font-size: 0.72rem;
+}
+
+.settings-kizuna-reset-status.is-success {
+  color: #8fd8ad;
+}
+
+.settings-kizuna-reset-status.is-error {
+  color: #ff9aab;
+}
+
+/* ── Kizuna bond notifications ── */
+
+.bond-toast-stack {
+  position: fixed;
+  z-index: 900;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: min(350px, calc(100vw - 28px));
+  gap: 10px;
+  pointer-events: none;
+}
+
+.bond-toast {
+  position: relative;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #31567f;
+  border-radius: 13px;
+  background: rgba(20, 32, 60, 0.96);
+  box-shadow: 0 18px 44px -20px rgba(0, 0, 0, 0.72);
+  color: #f4f7fb;
+  pointer-events: auto;
+  animation: bond-toast-enter 280ms ease-out both;
+}
+
+.bond-toast-highlight {
+  border-color: #f0b84f;
+  box-shadow: 0 18px 44px -20px rgba(240, 184, 79, 0.6);
+}
+
+.bond-toast-decreased {
+  border-color: rgba(179, 71, 87, 0.55);
+  background: rgba(255, 246, 247, 0.97);
+}
+
+.bond-toast-decreased .bond-toast-heading span {
+  color: #9e3045;
+  background: rgba(179, 71, 87, 0.12);
+}
+
+.bond-toast-decreased .bond-toast-track i {
+  background: linear-gradient(90deg, #8c4054, #c85a68);
+}
+
+.bond-toast-dismiss {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #9cacbf;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.bond-toast-heading {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding-right: 24px;
+}
+
+.bond-toast-heading strong {
+  overflow: hidden;
+  font-size: 0.88rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bond-toast-heading span {
+  flex: 0 0 auto;
+  color: #ff8799;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.bond-toast p {
+  margin: 5px 0 8px;
+  color: #dce5ef;
+  font-size: 0.78rem;
+}
+
+.bond-toast-track {
+  height: 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #253957;
+}
+
+.bond-toast-track i {
+  display: block;
+  width: var(--bond-to);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7189ff, #e94560);
+  box-shadow: 0 0 16px rgba(233, 69, 96, 0.52);
+  animation: bond-toast-stretch 900ms cubic-bezier(0.2, 0.9, 0.22, 1.16)
+    both;
+}
+
+.bond-toast-highlight .bond-toast-track i {
+  background: linear-gradient(90deg, #e94560, #f0b84f);
+}
+
+.bond-toast small {
+  display: block;
+  margin-top: 7px;
+  color: #9cacbf;
+  font-size: 0.68rem;
+}
+
+@keyframes bond-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+}
+
+@keyframes bond-toast-stretch {
+  from {
+    width: var(--bond-from);
+  }
+  to {
+    width: var(--bond-to);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bond-toast,
+  .bond-toast-track i {
+    animation-duration: 0.01ms;
+  }
+}
+
 .settings-field select,
 .settings-field textarea,
 .settings-field input[type="password"],

--- a/packages/core/examples/react-vrm-app/src/types/settings.ts
+++ b/packages/core/examples/react-vrm-app/src/types/settings.ts
@@ -173,6 +173,10 @@ export interface ManneriSettings {
   minMessageLength: number;
 }
 
+export interface KizunaSettings {
+  enabled: boolean;
+}
+
 export interface VisualSettings {
   backgroundMode: 'default' | 'green';
   layoutMode: 'chat' | 'broadcast';
@@ -197,4 +201,5 @@ export interface AppSettings {
   stream: StreamSettings;
   commentIntelligence: CommentIntelligenceSettings;
   manneri: ManneriSettings;
+  kizuna: KizunaSettings;
 }


### PR DESCRIPTION
## Summary

Only `react-pngtuber-app` tracked viewer relationships, and even there the bond state lived in memory, so every page reload wiped it. This brings Kizuna to all seven avatar examples and makes the bonds survive a reload.

- **Persist bonds in `localStorage`.** `KizunaManager` already supported this; the examples were passing `undefined` as the storage provider, which made the save/load paths no-ops. Each example now passes a `LocalStorageProvider` under its own key and falls back to in-memory operation with a warning where `localStorage` is unavailable.
- **Port the whole Kizuna feature** to the VRM, Live2D, PuruPuru, Inochi2D, PSD and pet examples: bond identities for the chat form, YouTube and Twitch, intimacy toasts, and a two-step reset control.
- **Rebuild the system prompt before every core request** in those examples, so the current viewer's bond context is injected and never leaks into vision or untracked requests. Core requests are serialized per example so the prompt and the active identity stay in sync while the form and live comment flows overlap.
- **Fix three pre-existing `react-hooks` failures** in the PuruPuru example, which ships a newer plugin version than its siblings.

## Notes

- The pet example gets message points only. It has no screenplay emotion extraction and its default system prompt asks for no emotion tags, so response emotions would always be constant. Bonds still advance through messages, and the bond context omits the favorite emotion line while it is empty. No emotion pipeline was introduced for the sake of reaction points.
- Initialization now happens on mount and before each interaction. Without it the first interaction after a reload reads its "previous" snapshot before persisted data is restored, and the toast reports a jump from no contact.
- A reset that fails to clear storage keeps the failed provider so the next reset retries the removal, rather than reporting success while reloading the old bonds.
- Storage keys are per example (`react-<app>-bond`) so bonds do not bleed between examples served from one origin.
- Symbol names, UI strings, class names and ARIA labels are identical across the examples; the only difference between them is the storage key value.
- Switching the TTS engine away from MiniMax now also drops the cached voice list. Previously the effect returned early and the stale list survived.

## Verification

- Per example: `npm run build`, `npm run test`, `npm run lint`
- Repository wide, in order: `npm run fmt`, `npm run lint`, `npm run test`, `npm run build`
- In a real browser for every example: enabling Kizuna, sending a message, confirming the bond is written, reloading and confirming it is restored unchanged, sending again and confirming the update, then resetting and confirming only that key is removed. No browser dialogs are used, and no page errors were raised.
- For the PuruPuru hook changes: the default avatar still renders on load, clearing a user avatar still restores the default, a stale default load no longer overwrites a user avatar, and the MiniMax voice list clears on engine and API key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)