### PR TITLE
feat(core): add agent sub-entry for Agent SDK chat providers

### DIFF
--- a/.claude/skills/sync-core-after-chat-upgrade/SKILL.md
+++ b/.claude/skills/sync-core-after-chat-upgrade/SKILL.md
@@ -42,6 +42,11 @@ Collect missing inputs before editing:
 3. Update core public exports:
    - Edit `packages/core/src/index.ts` to re-export newly relevant chat
      constants/types/providers that should be available from core.
+   - When Chat exposes an opt-in, side-effectful sub-entry, mirror it through a
+     dedicated Core sub-entry instead of importing it from Core's main entry.
+     For example, `@aituber-onair/core/agent` mirrors
+     `@aituber-onair/chat/agent` while keeping agent provider registration out
+     of `@aituber-onair/core`.
    - Keep ordering consistent with nearby export groups.
 4. Update core examples when `update_examples` is `true`:
    - `packages/core/examples/react-basic/src/constants/*.ts`:
@@ -121,6 +126,8 @@ npm --prefix packages/core/examples/coding-agent run build
 - The target Chat version is already published to npm before the Core release
   PR is prepared.
 - Required new chat constants/features are re-exported from core.
+- Opt-in Chat sub-entries are reachable through matching Core sub-entries
+  without adding their runtime side effects to Core's main entry.
 - Core examples can select/use newly propagated models as needed.
 - Core docs reflect the updated provider/model coverage.
 - Core version/changelog and all core example lockfiles that embed local core

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Minor Changes
+
+- Added the Node.js-only `@aituber-onair/core/agent` entry for Codex SDK,
+  Claude Agent SDK, and Copilot SDK providers. Agent providers can now be used
+  through `createAgentChatService()` or `AITuberOnAirCore` without an API key,
+  while the main Core entry remains free of agent-provider registration side
+  effects.
+
 ### Patch Changes
 
 - Added `AITuberOnAirCore.updateChatOptions()` to update chat processor

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,6 +27,7 @@ It specializes in generating response text and audio from text or image inputs, 
 - [Event System](#event-system)
 - [Supported Speech Engines](#supported-speech-engines)
 - [AI Provider System](#ai-provider-system)
+- [Agent SDK providers (Codex / Claude Agent SDK / Copilot)](#agent-sdk-providers-codex--claude-agent-sdk--copilot)
 - [Memory & Persistence](#memory--persistence)
 - [Examples](#examples)
 - [Integration with Existing Applications](#integration-with-existing-applications)
@@ -1506,6 +1507,84 @@ const aituberCore = new AITuberOnAirCore({
   // Other options...
 });
 ```
+
+## Agent SDK providers (Codex / Claude Agent SDK / Copilot)
+
+Agent SDK providers use local subscription authentication instead of API keys.
+They are available from the Node.js-only `@aituber-onair/core/agent` entry and
+are kept out of the main entry so browser applications do not load or register
+them.
+
+The `./agent` subpath is resolved through package `exports`. TypeScript
+consumers must use `moduleResolution: "node16"`, `"nodenext"`, or `"bundler"`;
+legacy `"node"` resolution cannot resolve it. This is the same requirement as
+`@aituber-onair/chat/agent`.
+
+Install only the SDK package that matches the provider your application uses:
+
+```bash
+npm install @aituber-onair/core @openai/codex-sdk
+# or
+npm install @aituber-onair/core @anthropic-ai/claude-agent-sdk
+# or
+npm install @aituber-onair/core @github/copilot-sdk
+```
+
+The current provider-to-package mappings are `codex-sdk` to
+`@openai/codex-sdk`, `claude-agent-sdk` to
+`@anthropic-ai/claude-agent-sdk`, and `copilot-sdk` to
+`@github/copilot-sdk`. These SDKs are loaded dynamically and are not
+dependencies of `@aituber-onair/core`.
+
+Use `createAgentChatService` when you only need a standalone chat service:
+
+```typescript
+import { createAgentChatService } from '@aituber-onair/core/agent';
+
+const service = createAgentChatService('codex-sdk', {
+  workingDirectory: process.cwd(),
+  skipGitRepoCheck: true,
+});
+
+const result = await service.chatOnce(
+  [{ role: 'user', content: 'Give me one short news headline.' }],
+  false,
+);
+```
+
+The same entry registers the providers for `AITuberOnAirCore`, so the full
+Core flow does not need an API key:
+
+```typescript
+import { AITuberOnAirCore } from '@aituber-onair/core/agent';
+
+const core = new AITuberOnAirCore({
+  chatProvider: 'codex-sdk',
+  chatOptions: {
+    systemPrompt: 'You are a concise news presenter.',
+  },
+  providerOptions: {
+    workingDirectory: process.cwd(),
+    skipGitRepoCheck: true,
+  },
+  voiceOptions: {
+    engineType: 'aivisSpeech',
+    speaker: '888753760',
+  },
+});
+
+await core.processChat('What should we cover today?');
+```
+
+Current limitations apply to the Agent SDK provider group as a whole: it is
+Node.js-only and text-only, and Core tools, vision chat, and MCP servers are not
+supported. Streaming capability follows the underlying chat provider metadata;
+currently Codex SDK returns a completed response, while Claude Agent SDK and
+Copilot SDK can forward partial text when their SDKs emit it. Core memory
+summarization is not supported with Agent SDK providers; enabling
+`memoryOptions.enableSummarization` throws a clear initialization error.
+Missing SDK packages or unavailable local authentication are reported at
+runtime with the underlying SDK error details.
 
 ## Memory & Persistence
 

--- a/packages/core/README_ja.md
+++ b/packages/core/README_ja.md
@@ -26,6 +26,7 @@
 - [イベントシステム](#イベントシステム)
 - [音声エンジン対応](#音声エンジン対応)
 - [AIプロバイダーシステム](#AIプロバイダーシステム)
+- [Agent SDKプロバイダー（Codex / Claude Agent SDK / Copilot）](#agent-sdkプロバイダーcodex--claude-agent-sdk--copilot)
 - [メモリと永続化](#メモリと永続化)
 - [応用例](#応用例)
 - [既存アプリケーションとの統合](#既存アプリケーションとの統合)
@@ -1498,6 +1499,80 @@ const aituberCore = new AITuberOnAirCore({
   // その他のオプション...
 });
 ```
+
+## Agent SDKプロバイダー（Codex / Claude Agent SDK / Copilot）
+
+Agent SDKプロバイダーはAPIキーではなく、ローカルのサブスクリプション認証を
+使用します。Node.js専用の`@aituber-onair/core/agent`エントリから利用でき、
+ブラウザアプリが読み込み・登録しないようmainエントリからは分離されています。
+
+`./agent`サブパスはpackage `exports`を通して解決されます。TypeScript利用側では
+`moduleResolution: "node16"`、`"nodenext"`、`"bundler"`のいずれかが必要で、
+従来の`"node"`では解決できません。これは`@aituber-onair/chat/agent`と同じ要件です。
+
+アプリで使用するプロバイダーに対応するSDKパッケージだけをインストールしてください。
+
+```bash
+npm install @aituber-onair/core @openai/codex-sdk
+# または
+npm install @aituber-onair/core @anthropic-ai/claude-agent-sdk
+# または
+npm install @aituber-onair/core @github/copilot-sdk
+```
+
+現在の対応は、`codex-sdk`が`@openai/codex-sdk`、
+`claude-agent-sdk`が`@anthropic-ai/claude-agent-sdk`、
+`copilot-sdk`が`@github/copilot-sdk`です。これらのSDKは動的に読み込まれ、
+`@aituber-onair/core`の依存関係には含まれません。
+
+単独のチャットサービスだけが必要な場合は`createAgentChatService`を使います。
+
+```typescript
+import { createAgentChatService } from '@aituber-onair/core/agent';
+
+const service = createAgentChatService('codex-sdk', {
+  workingDirectory: process.cwd(),
+  skipGitRepoCheck: true,
+});
+
+const result = await service.chatOnce(
+  [{ role: 'user', content: '短いニュース見出しを1つ作ってください。' }],
+  false,
+);
+```
+
+同じエントリが`AITuberOnAirCore`用のプロバイダーも登録するため、Core全体の
+フローでもAPIキーは不要です。
+
+```typescript
+import { AITuberOnAirCore } from '@aituber-onair/core/agent';
+
+const core = new AITuberOnAirCore({
+  chatProvider: 'codex-sdk',
+  chatOptions: {
+    systemPrompt: 'あなたは簡潔なニュースキャスターです。',
+  },
+  providerOptions: {
+    workingDirectory: process.cwd(),
+    skipGitRepoCheck: true,
+  },
+  voiceOptions: {
+    engineType: 'aivisSpeech',
+    speaker: '888753760',
+  },
+});
+
+await core.processChat('今日は何を取り上げますか？');
+```
+
+現在の制限はAgent SDKプロバイダー群に共通します。Node.js・テキストチャット専用で、
+Coreのtools、Vision chat、MCP serversには対応していません。ストリーミング可否は
+chat providerのcapability metadataに従い、現在Codex SDKは完了応答を返し、
+Claude Agent SDKとCopilot SDKは各SDKが出力する部分テキストを転送できます。
+Coreのメモリ要約はAgent SDKプロバイダーでは利用できず、
+`memoryOptions.enableSummarization`を有効にすると初期化時に明確なエラーを返します。
+SDKパッケージが未インストール、またはローカル認証が利用できない場合は、
+元のSDKエラー詳細を含む実行時エラーを返します。
 
 ## メモリと永続化
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+    "./agent": {
+      "types": "./dist/agent.d.ts",
+      "default": "./dist/agent.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "files": ["dist"],
   "scripts": {
     "build": "tsc --project tsconfig.json",

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,0 +1,31 @@
+/**
+ * Node.js entry point for Core with Agent SDK chat providers registered.
+ */
+export * from './index';
+
+export {
+  type AgentChatProviderName,
+  type AgentChatServiceOptionsByProvider,
+  ClaudeAgentSDKChatService,
+  type ClaudeAgentSDKChatServiceOptions,
+  ClaudeAgentSDKChatServiceProvider,
+  type ClaudeAgentSDKLoader,
+  CodexSDKChatService,
+  type CodexSDKChatServiceOptions,
+  CodexSDKChatServiceProvider,
+  type CodexSDKLoader,
+  CopilotSDKChatService,
+  type CopilotSDKChatServiceOptions,
+  CopilotSDKChatServiceProvider,
+  type CopilotSDKLoader,
+  createAgentChatService,
+  DEFAULT_CLAUDE_AGENT_SDK_MODEL,
+  DEFAULT_CODEX_SDK_MODEL,
+  DEFAULT_COPILOT_SDK_MODEL,
+  registerAgentChatProviders,
+  type RegisterAgentChatProvidersOptions,
+} from '@aituber-onair/chat/agent';
+
+import { registerAgentChatProviders } from '@aituber-onair/chat/agent';
+
+registerAgentChatProviders();

--- a/packages/core/src/core/AITuberOnAirCore.ts
+++ b/packages/core/src/core/AITuberOnAirCore.ts
@@ -22,6 +22,10 @@ import {
   PlamoChatServiceOptions,
   VisionSupportLevel,
 } from '@aituber-onair/chat';
+import type {
+  AgentChatProviderName,
+  AgentChatServiceOptionsByProvider,
+} from '@aituber-onair/chat/agent';
 import { OpenAISummarizer } from '../services/chat/providers/openai/OpenAISummarizer';
 import { GeminiSummarizer } from '../services/chat/providers/gemini/GeminiSummarizer';
 import { ClaudeSummarizer } from '../services/chat/providers/claude/ClaudeSummarizer';
@@ -84,9 +88,9 @@ export interface SpeechChunkingOptions {
 
 export interface AITuberOnAirCoreOptions {
   /** AI provider name */
-  chatProvider?: ChatProviderName;
-  /** AI API key */
-  apiKey: string;
+  chatProvider?: ChatProviderName | AgentChatProviderName;
+  /** AI API key (not used by Agent SDK providers) */
+  apiKey?: string;
   /** AI model name (default is provider's default model) */
   model?: string;
   /** ChatProcessor options */
@@ -102,10 +106,7 @@ export interface AITuberOnAirCoreOptions {
   /** Debug mode */
   debug?: boolean;
   /** ChatService provider-specific options (optional) */
-  providerOptions?: Omit<
-    ChatServiceOptionsByProvider[ChatProviderName],
-    'apiKey' | 'model' | 'tools'
-  >;
+  providerOptions?: CoreProviderOptions;
   /** Tools */
   tools?: {
     definition: ToolDefinition;
@@ -115,10 +116,37 @@ export interface AITuberOnAirCoreOptions {
   mcpServers?: MCPServerConfig[];
 }
 
-type ProviderOptionsByName<TProvider extends ChatProviderName> = Omit<
-  ChatServiceOptionsByProvider[TProvider],
+type CoreChatProviderName = ChatProviderName | AgentChatProviderName;
+
+type ChatServiceOptionsForProvider<TProvider extends CoreChatProviderName> =
+  TProvider extends ChatProviderName
+    ? ChatServiceOptionsByProvider[TProvider]
+    : TProvider extends AgentChatProviderName
+      ? AgentChatServiceOptionsByProvider[TProvider]
+      : never;
+
+type ProviderOptionsByName<TProvider extends CoreChatProviderName> = Omit<
+  ChatServiceOptionsForProvider<TProvider>,
   'apiKey' | 'model' | 'tools'
 >;
+
+type CoreProviderOptions = {
+  [TProvider in CoreChatProviderName]: ProviderOptionsByName<TProvider>;
+}[CoreChatProviderName];
+
+type CoreChatServiceOptions =
+  | ChatServiceOptionsByProvider[ChatProviderName]
+  | AgentChatServiceOptionsByProvider[AgentChatProviderName];
+
+function isAgentChatProviderName(
+  providerName: CoreChatProviderName,
+): providerName is AgentChatProviderName {
+  return (
+    providerName === 'codex-sdk' ||
+    providerName === 'claude-agent-sdk' ||
+    providerName === 'copilot-sdk'
+  );
+}
 
 /**
  * Event types for AITuberOnAirCore
@@ -192,7 +220,17 @@ export class AITuberOnAirCore extends EventEmitter {
     this.speechChunkSeparators = speechChunkingOptions.separators;
 
     // Determine provider name (default is 'openai')
-    const providerName: ChatProviderName = options.chatProvider || 'openai';
+    const providerName: CoreChatProviderName = options.chatProvider || 'openai';
+
+    if (
+      isAgentChatProviderName(providerName) &&
+      options.memoryOptions?.enableSummarization
+    ) {
+      throw new Error(
+        'Memory summarization is not supported with Agent SDK providers. ' +
+          'Disable memoryOptions.enableSummarization or use an API-based chat provider.',
+      );
+    }
 
     // Register tools
     options.tools?.forEach((t) =>
@@ -230,10 +268,13 @@ export class AITuberOnAirCore extends EventEmitter {
     }
 
     // Initialize ChatService
-    this.chatService = ChatServiceFactory.createChatService(
-      providerName,
-      chatServiceOptions,
-    );
+    const createChatService = ChatServiceFactory.createChatService.bind(
+      ChatServiceFactory,
+    ) as (
+      providerName: CoreChatProviderName,
+      options: CoreChatServiceOptions,
+    ) => ChatService;
+    this.chatService = createChatService(providerName, chatServiceOptions);
 
     // Initialize MemoryManager (optional)
     if (options.memoryOptions?.enableSummarization) {
@@ -241,19 +282,19 @@ export class AITuberOnAirCore extends EventEmitter {
 
       if (providerName === 'gemini') {
         summarizer = new GeminiSummarizer(
-          options.apiKey,
+          options.apiKey ?? '',
           options.model,
           options.memoryOptions.summaryPromptTemplate,
         );
       } else if (providerName === 'claude') {
         summarizer = new ClaudeSummarizer(
-          options.apiKey,
+          options.apiKey ?? '',
           options.model,
           options.memoryOptions.summaryPromptTemplate,
         );
       } else {
         summarizer = new OpenAISummarizer(
-          options.apiKey,
+          options.apiKey ?? '',
           options.model,
           options.memoryOptions.summaryPromptTemplate,
         );
@@ -289,14 +330,27 @@ export class AITuberOnAirCore extends EventEmitter {
   }
 
   private buildChatServiceOptions(
-    providerName: ChatProviderName,
+    providerName: CoreChatProviderName,
     baseOptions: {
-      apiKey: string;
+      apiKey?: string;
       model?: string;
       tools: ToolDefinition[];
     },
     providerOptions?: AITuberOnAirCoreOptions['providerOptions'],
-  ): ChatServiceOptionsByProvider[ChatProviderName] {
+  ): CoreChatServiceOptions {
+    if (isAgentChatProviderName(providerName)) {
+      return {
+        ...(baseOptions.apiKey !== undefined
+          ? { apiKey: baseOptions.apiKey }
+          : {}),
+        ...(baseOptions.model ? { model: baseOptions.model } : {}),
+        ...(baseOptions.tools.length > 0 ? { tools: baseOptions.tools } : {}),
+        ...(providerOptions as
+          | ProviderOptionsByName<AgentChatProviderName>
+          | undefined),
+      } as AgentChatServiceOptionsByProvider[AgentChatProviderName];
+    }
+
     switch (providerName) {
       case 'openai': {
         return {

--- a/packages/core/tests/agentEntry.test.ts
+++ b/packages/core/tests/agentEntry.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+type MockCodexCall = {
+  clientOptions?: Record<string, unknown>;
+  prompt?: string;
+  threadOptions?: Record<string, unknown>;
+};
+
+function createMockCodexSDK(reply: string, call: MockCodexCall) {
+  return {
+    Codex: class {
+      constructor(options?: Record<string, unknown>) {
+        call.clientOptions = options;
+      }
+
+      async startThread(options?: Record<string, unknown>) {
+        call.threadOptions = options;
+        return {
+          run: async (prompt: string) => {
+            call.prompt = prompt;
+            return { finalResponse: reply };
+          },
+        };
+      }
+    },
+  };
+}
+
+describe.sequential('Core Agent SDK entry', () => {
+  it('keeps agent provider registration out of the main entry', async () => {
+    vi.resetModules();
+
+    const { ChatServiceFactory } = await import('../src/index');
+
+    expect(ChatServiceFactory.getAvailableProviders()).not.toContain(
+      'codex-sdk',
+    );
+    expect(ChatServiceFactory.getAvailableProviders()).not.toContain(
+      'claude-agent-sdk',
+    );
+    expect(ChatServiceFactory.getAvailableProviders()).not.toContain(
+      'copilot-sdk',
+    );
+  });
+
+  it('registers agent providers and creates a service with an injected loader', async () => {
+    vi.resetModules();
+    const call: MockCodexCall = {};
+    const {
+      ChatServiceFactory,
+      createAgentChatService,
+      registerAgentChatProviders,
+    } = await import('../src/agent');
+
+    expect(ChatServiceFactory.getAvailableProviders()).toEqual(
+      expect.arrayContaining(['codex-sdk', 'claude-agent-sdk', 'copilot-sdk']),
+    );
+
+    registerAgentChatProviders({
+      codexSDKLoader: async () => createMockCodexSDK('created', call),
+    });
+    const service = createAgentChatService('codex-sdk', {
+      workingDirectory: '/tmp/core-agent-entry-test',
+      skipGitRepoCheck: true,
+    });
+
+    const result = await service.chatOnce(
+      [{ role: 'user', content: 'hello' }],
+      false,
+    );
+
+    expect(result.blocks).toEqual([{ type: 'text', text: 'created' }]);
+    expect(call.threadOptions).toEqual({
+      workingDirectory: '/tmp/core-agent-entry-test',
+      skipGitRepoCheck: true,
+    });
+    expect(call.prompt).toContain('User: hello');
+  });
+
+  it('runs AITuberOnAirCore with an agent provider and no API key', async () => {
+    const call: MockCodexCall = {};
+    const { AITuberOnAirCore, registerAgentChatProviders } = await import(
+      '../src/agent'
+    );
+    registerAgentChatProviders({
+      codexSDKLoader: async () => createMockCodexSDK('mocked reply', call),
+    });
+
+    const core = new AITuberOnAirCore({
+      chatProvider: 'codex-sdk',
+      chatOptions: { systemPrompt: 'You are a concise host.' },
+      providerOptions: {
+        workingDirectory: '/tmp/core-agent-integration-test',
+        skipGitRepoCheck: true,
+      },
+    });
+
+    const processed = await core.processChat('What is new?');
+
+    expect(processed).toBe(true);
+    expect(core.getChatHistory()).toEqual([
+      expect.objectContaining({ role: 'user', content: 'What is new?' }),
+      expect.objectContaining({ role: 'assistant', content: 'mocked reply' }),
+    ]);
+    expect(call.threadOptions).toEqual({
+      workingDirectory: '/tmp/core-agent-integration-test',
+      skipGitRepoCheck: true,
+    });
+    expect(call.prompt).toContain('System: You are a concise host.');
+    expect(call.prompt).toContain('User: What is new?');
+  });
+
+  it('rejects memory summarization with agent providers clearly', async () => {
+    const { AITuberOnAirCore } = await import('../src/agent');
+
+    expect(
+      () =>
+        new AITuberOnAirCore({
+          chatProvider: 'codex-sdk',
+          chatOptions: { systemPrompt: 'system' },
+          memoryOptions: {
+            enableSummarization: true,
+            shortTermDuration: 60_000,
+            midTermDuration: 240_000,
+            longTermDuration: 540_000,
+            maxMessagesBeforeSummarization: 20,
+          },
+        }),
+    ).toThrow('Memory summarization is not supported with Agent SDK providers');
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/skills/sync-core-after-chat-upgrade/SKILL.md
+++ b/skills/sync-core-after-chat-upgrade/SKILL.md
@@ -42,6 +42,11 @@ Collect missing inputs before editing:
 3. Update core public exports:
    - Edit `packages/core/src/index.ts` to re-export newly relevant chat
      constants/types/providers that should be available from core.
+   - When Chat exposes an opt-in, side-effectful sub-entry, mirror it through a
+     dedicated Core sub-entry instead of importing it from Core's main entry.
+     For example, `@aituber-onair/core/agent` mirrors
+     `@aituber-onair/chat/agent` while keeping agent provider registration out
+     of `@aituber-onair/core`.
    - Keep ordering consistent with nearby export groups.
 4. Update core examples when `update_examples` is `true`:
    - `packages/core/examples/react-basic/src/constants/*.ts`:
@@ -121,6 +126,8 @@ npm --prefix packages/core/examples/coding-agent run build
 - The target Chat version is already published to npm before the Core release
   PR is prepared.
 - Required new chat constants/features are re-exported from core.
+- Opt-in Chat sub-entries are reachable through matching Core sub-entries
+  without adding their runtime side effects to Core's main entry.
 - Core examples can select/use newly propagated models as needed.
 - Core docs reflect the updated provider/model coverage.
 - Core version/changelog and all core example lockfiles that embed local core


### PR DESCRIPTION
## Summary

- Add the Node.js-only `@aituber-onair/core/agent` entry mirroring `@aituber-onair/chat/agent`: re-exports the Core public API plus `createAgentChatService` / `registerAgentChatProviders` and the Codex SDK, Claude Agent SDK, and Copilot SDK service/provider classes, and registers the agent providers on import. The main `@aituber-onair/core` entry keeps no agent-registration side effect (verified: built `dist/index.js` has no `chat/agent` import).
- Add package `exports` (`.`, `./agent`, `./dist/*`, `./package.json`) while keeping existing deep imports working.
- `AITuberOnAirCore` accepts agent provider names, `apiKey` becomes optional, agent `providerOptions` are passed through, and memory summarization with an agent provider throws a clear error.
- Core `tsconfig` `moduleResolution: node → bundler` so the chat `./agent` exports subpath resolves for type imports (emit unchanged).
- Tests: registration isolation, injected-loader chat via the core entry, Core with `codex-sdk` and no API key (`processChat`), summarization guard.
- Docs: README (en/ja) section, CHANGELOG `Unreleased` → Minor Changes, `sync-core-after-chat-upgrade` skill (+ `.claude` mirror). No version bump in this PR.

Groundwork for a follow-up Node example (`packages/core/examples/node-purupuru-newsdesk`) that generates news videos with Codex sign-in instead of an API key.

## Verification

- Repo root: `npm run fmt` → `npm run lint` → `npm run test` → `npm run build` all pass.
- `npm -w @aituber-onair/core run typecheck` passes; `dist/agent.js` / `dist/agent.d.ts` emitted.
- Real smoke outside the repo (esbuild bundle importing `@aituber-onair/core/agent`, `@openai/codex-sdk` installed, signed-in Codex CLI): `createAgentChatService('codex-sdk').chatOnce()` and `new AITuberOnAirCore({ chatProvider: 'codex-sdk' })` → `processChat()` both return replies without an API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
