### PR TITLE
fix(core-examples): natural VRM lighting and newer three stack in node-vrm-newsdesk

### DIFF
--- a/packages/core/examples/node-vrm-newsdesk/README.ja.md
+++ b/packages/core/examples/node-vrm-newsdesk/README.ja.md
@@ -130,6 +130,12 @@ VRMA の再生速度を `0`〜`3` で調整し、`0` では口パクとまばた
 既定値はそれぞれ `0.39` と `0.845` です。これらのカメラ設定の後に、従来どおり
 `avatarLayout` の拡大率と比率アンカーが適用されます。
 
+レンダラーは three.js r182 の物理ベース光量単位に合わせた、柔らかい環境光と
+指向性キーライトを使います。モデルごとに
+`avatarLighting.ambientIntensity` と
+`avatarLighting.directionalIntensity` で調整でき、既定値はそれぞれ `1.4` と
+`2.35` です。
+
 ## 描画の仕組み
 
 Node は TTS、WAV/RMS 解析、まばたき時刻、背景、チャプター、字幕、ffmpeg を
@@ -140,6 +146,10 @@ Node は TTS、WAV/RMS 解析、まばたき時刻、背景、チャプター、
 PNG として取得し、`@napi-rs/canvas` でオーバーレイと合成して RGBA を ffmpeg へ
 送ります。
 
+光量単位と VRM ランタイムを再現可能にするため、描画スタックは three.js
+`0.182.0`、`@pixiv/three-vrm` `3.4.5`、
+`@pixiv/three-vrm-animation` `3.4.5` の組み合わせへ固定しています。
+
 縦型キャンバスのカメラ距離はモデルの表示高を基準にします。横方向の超過を
 検出した場合は小さな上限付き安全補正だけを加え、幅広いバインド姿勢によって
 ニュース映像が全身構図へ戻ることを防ぎます。
@@ -147,7 +157,7 @@ PNG として取得し、`@napi-rs/canvas` でオーバーレイと合成して 
 Chromium はまず SwiftShader 指定で起動し、WebGL 初期化に失敗した場合だけ既定 GL
 で再試行します。最終 JSON には使用した GL モードとブラウザフレームの平均時間を
 出力します。このサンプルの基準レンダリングでは、初回フレームのウォームアップを
-含めて `240.8` ms/frame でした。Linux CI では Playwright Chromium とシステム依存が
+含めて `249.2` ms/frame でした。Linux CI では Playwright Chromium とシステム依存が
 必要です。権限のある
 コンテナでは通常 `npx playwright install --with-deps chromium` を使います。
 

--- a/packages/core/examples/node-vrm-newsdesk/README.md
+++ b/packages/core/examples/node-vrm-newsdesk/README.md
@@ -132,6 +132,11 @@ Portrait renders default to a bust-up camera. Optional
 the model upward). The defaults are `0.39` and `0.845`. These camera controls
 run before the existing `avatarLayout` scale and fractional anchors.
 
+The renderer uses a soft ambient fill plus a directional key tuned for
+three.js r182's physically based light units. Per-model overrides are
+available as `avatarLighting.ambientIntensity` and
+`avatarLighting.directionalIntensity`; the defaults are `1.4` and `2.35`.
+
 ## How rendering works
 
 Node remains responsible for TTS, WAV/RMS analysis, blink timing, backgrounds,
@@ -142,6 +147,10 @@ animation by a fixed time step, applies the `aa` and `blink` expressions, and
 renders a transparent 1080x1920 frame. Node captures the frame as PNG and
 composites it with `@napi-rs/canvas` before streaming RGBA to ffmpeg.
 
+The rendering stack is pinned together at three.js `0.182.0`,
+`@pixiv/three-vrm` `3.4.5`, and `@pixiv/three-vrm-animation` `3.4.5` so its
+lighting units and VRM runtime remain reproducible.
+
 On portrait canvases the camera distance is driven by visible model height.
 A detected horizontal overflow can add a small bounded safety pullback, but a
 wide bind pose cannot force the news shot back to a full-body composition.
@@ -150,7 +159,7 @@ Chromium starts with SwiftShader flags for a predictable headless WebGL path
 and retries with default GL if WebGL initialization fails. The final JSON
 summary reports the selected GL mode and average browser-frame time. On the
 reference render used to validate this example, the measured result was
-`240.8` ms/frame (including the first-frame warm-up). Linux CI needs the
+`249.2` ms/frame (including the first-frame warm-up). Linux CI needs the
 Playwright Chromium binary
 and its system dependencies; `npx playwright install --with-deps chromium` is
 the usual container setup when elevated package installation is available.

--- a/packages/core/examples/node-vrm-newsdesk/docs/script-format.md
+++ b/packages/core/examples/node-vrm-newsdesk/docs/script-format.md
@@ -24,6 +24,10 @@ are resolved relative to the script file.
     "visibleHeightRatio": 0.39,
     "lookAtHeightRatio": 0.845
   },
+  "avatarLighting": {
+    "ambientIntensity": 1.4,
+    "directionalIntensity": 2.35
+  },
   "motion": { "intensity": 1 },
   "blinkSeed": 42,
   "lines": [
@@ -56,6 +60,11 @@ are resolved relative to the script file.
   `lookAtHeightRatio` moves the model upward. Valid ranges are `0.1`–`2` and
   `0`–`1.5`, respectively. `avatarLayout` is applied afterward and keeps its
   existing scale/anchor semantics.
+- `avatarLighting` (optional): model-light overrides for the soft ambient fill
+  and directional key. The defaults are `ambientIntensity: 1.4` and
+  `directionalIntensity: 2.35`; each accepts `0`–`10`. Lighting units follow
+  three.js r182's physically based defaults, so values copied from pre-r155
+  legacy-light projects will usually be too dim.
 - `motion.intensity`: VRMA playback-rate multiplier clamped from 0 through 3;
   `0` freezes the animation while lip-sync and blinking continue.
 - `blinkSeed`: deterministic blink schedule seed.

--- a/packages/core/examples/node-vrm-newsdesk/harness/main.ts
+++ b/packages/core/examples/node-vrm-newsdesk/harness/main.ts
@@ -23,7 +23,10 @@ import {
   createVRMAnimationClip,
   type VRMAnimation,
 } from '@pixiv/three-vrm-animation';
-import { DEFAULT_AVATAR_FRAMING } from '../src/types.js';
+import {
+  DEFAULT_AVATAR_FRAMING,
+  DEFAULT_AVATAR_LIGHTING,
+} from '../src/types.js';
 
 const DEFAULT_VISIBLE_WIDTH_RATIO = 0.72;
 const PORTRAIT_MAX_WIDTH_DISTANCE_RATIO = 1.12;
@@ -39,6 +42,10 @@ interface HarnessLoadOptions {
   avatarFraming?: {
     visibleHeightRatio?: number;
     lookAtHeightRatio?: number;
+  };
+  avatarLighting?: {
+    ambientIntensity?: number;
+    directionalIntensity?: number;
   };
 }
 
@@ -62,6 +69,10 @@ export interface HarnessDiagnostics {
     visibleHeightRatio: number;
     lookAtHeightRatio: number;
     portraitWidthAdjusted: boolean;
+  };
+  avatarLighting: {
+    ambientIntensity: number;
+    directionalIntensity: number;
   };
 }
 
@@ -156,8 +167,14 @@ async function load(options: HarnessLoadOptions): Promise<HarnessDiagnostics> {
     0.1,
     30,
   );
-  const ambientLight = new AmbientLight(0xffffff, 1.0);
-  const directionalLight = new DirectionalLight(0xffffff, 0.9);
+  const ambientIntensity =
+    options.avatarLighting?.ambientIntensity ??
+    DEFAULT_AVATAR_LIGHTING.ambientIntensity;
+  const directionalIntensity =
+    options.avatarLighting?.directionalIntensity ??
+    DEFAULT_AVATAR_LIGHTING.directionalIntensity;
+  const ambientLight = new AmbientLight(0xffffff, ambientIntensity);
+  const directionalLight = new DirectionalLight(0xffffff, directionalIntensity);
   directionalLight.position.set(1.0, 1.8, 1.2);
   scene.add(ambientLight, directionalLight);
 
@@ -254,6 +271,10 @@ async function load(options: HarnessLoadOptions): Promise<HarnessDiagnostics> {
       visibleHeightRatio,
       lookAtHeightRatio,
       portraitWidthAdjusted,
+    },
+    avatarLighting: {
+      ambientIntensity,
+      directionalIntensity,
     },
   };
 }

--- a/packages/core/examples/node-vrm-newsdesk/package-lock.json
+++ b/packages/core/examples/node-vrm-newsdesk/package-lock.json
@@ -12,11 +12,11 @@
         "@mozilla/readability": "^0.6.0",
         "@napi-rs/canvas": "^1.0.3",
         "@openai/codex-sdk": "^0.146.0",
-        "@pixiv/three-vrm": "^1.0.10",
-        "@pixiv/three-vrm-animation": "^3.4.5",
+        "@pixiv/three-vrm": "3.4.5",
+        "@pixiv/three-vrm-animation": "3.4.5",
         "linkedom": "^0.18.13",
         "playwright": "^1.55.0",
-        "three": "^0.151.3"
+        "three": "0.182.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -1088,187 +1088,169 @@
       }
     },
     "node_modules/@pixiv/three-vrm": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm/-/three-vrm-1.0.10.tgz",
-      "integrity": "sha512-aEqDVbo4ZKH1AYZ/K9oXIqiMTzmU9mbNqmjt1ovTpOF/0sw/zWTj69ZAPpd04cvpLCApQm4g+UjpU+XBP3mllA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm/-/three-vrm-3.4.5.tgz",
+      "integrity": "sha512-LbdlsLG2b4hvgjfUKObkl/wxkBeTwIqHJsPJMJTO4JU7mQ3KUwcwdclzoqW6ipQfz2e/QAsv+IzF40pGwaYSnA==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/three-vrm-core": "1.0.10",
-        "@pixiv/three-vrm-materials-hdr-emissive-multiplier": "1.0.10",
-        "@pixiv/three-vrm-materials-mtoon": "1.0.10",
-        "@pixiv/three-vrm-materials-v0compat": "1.0.10",
-        "@pixiv/three-vrm-node-constraint": "1.0.10",
-        "@pixiv/three-vrm-springbone": "1.0.10"
+        "@pixiv/three-vrm-core": "3.4.5",
+        "@pixiv/three-vrm-materials-hdr-emissive-multiplier": "3.4.5",
+        "@pixiv/three-vrm-materials-mtoon": "3.4.5",
+        "@pixiv/three-vrm-materials-v0compat": "3.4.5",
+        "@pixiv/three-vrm-node-constraint": "3.4.5",
+        "@pixiv/three-vrm-springbone": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-animation": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-animation/-/three-vrm-animation-3.5.5.tgz",
-      "integrity": "sha512-Q0kEtmftxfv0iCUHQkJH2jAr1zmT9ywYXnAzhxnLPMYCsx0Kken3J3U2GJF9PdGZmLlKpoK0LFEXVdD/L7ZA4Q==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-animation/-/three-vrm-animation-3.4.5.tgz",
+      "integrity": "sha512-lG13OHGQ698Nby7SBGiPLcQLvReV/omZkJooR/0upB5qK6Idu8smZeQczmo+zweRPrc/QWbNHDo9vO5rU52gig==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/three-vrm-core": "3.5.5",
-        "@pixiv/types-vrmc-vrm-1.0": "3.5.5",
-        "@pixiv/types-vrmc-vrm-animation-1.0": "3.5.5"
+        "@pixiv/three-vrm-core": "3.4.5",
+        "@pixiv/types-vrmc-vrm-1.0": "3.4.5",
+        "@pixiv/types-vrmc-vrm-animation-1.0": "3.4.5"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
-    },
-    "node_modules/@pixiv/three-vrm-animation/node_modules/@pixiv/three-vrm-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-3.5.5.tgz",
-      "integrity": "sha512-jjaXZbMVRsk2HAGVxqDLmSJyGOJqbMcJpuTHR1TY/TN1FxiKdAzSqdr/ZUcczYipNf8IL9vDT9NX2XmWj+ybRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixiv/types-vrm-0.0": "3.5.5",
-        "@pixiv/types-vrmc-vrm-1.0": "3.5.5"
-      },
-      "peerDependencies": {
-        "three": ">=0.137"
-      }
-    },
-    "node_modules/@pixiv/three-vrm-animation/node_modules/@pixiv/types-vrm-0.0": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-3.5.5.tgz",
-      "integrity": "sha512-2S/0jswMjJTwL9ky8YzDR0CIaP6ZmE+HFuyW/0h+SA+awELf+J7WGgC8lTLM1MXzokO7Z2YVljU2F0fEhlKDIQ==",
-      "license": "MIT"
     },
     "node_modules/@pixiv/three-vrm-core": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-1.0.10.tgz",
-      "integrity": "sha512-2JRJiUr8eSasn+HrBt0rI2UhT9adm7oIFt/AROOEEDB9qOP4I/vs6657Gf1xWcvxsI1OiS2aSkBcfTeKeOP0FQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-3.4.5.tgz",
+      "integrity": "sha512-w52JUwNUbeuGBLqc7/wVMGrN2jgyz67kQ3OplFT4ACF9qlepALXwUBrQJPlkf1Qtqrfbdd50kYJTQ2EO4m8Ang==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "1.0.0",
-        "@pixiv/types-vrmc-vrm-1.0": "1.0.0"
+        "@pixiv/types-vrm-0.0": "3.4.5",
+        "@pixiv/types-vrmc-vrm-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
-    "node_modules/@pixiv/three-vrm-core/node_modules/@pixiv/types-vrmc-vrm-1.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-1.0.0.tgz",
-      "integrity": "sha512-aYy/LyFU6ijzAXHtg+r2TfMKrsT0/amtK4wYEPZa901FZhyvNCYtmUPUA1a1VroIO9pyKC2fd6DlLwWhYenQFg==",
-      "license": "MIT"
-    },
     "node_modules/@pixiv/three-vrm-materials-hdr-emissive-multiplier": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-hdr-emissive-multiplier/-/three-vrm-materials-hdr-emissive-multiplier-1.0.10.tgz",
-      "integrity": "sha512-Vb/CwpoMlPiQe2Sq/BTYVoeWSQb/4jUgIHUrpWmN1U4jGb3b7aiSC3kfFWxitty6O+pHXTY/Ivg2mKvaYbAUuw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-hdr-emissive-multiplier/-/three-vrm-materials-hdr-emissive-multiplier-3.4.5.tgz",
+      "integrity": "sha512-nFC1Cmc6oBmTaLBVBmvYTk1qDT+YOuCD/0P6AK6BPTG+zypMdJ1Cj2aTNjDK6Sx0NCrOdWUZ1sh0CITDcKsOFg==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0"
+        "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-materials-mtoon": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-mtoon/-/three-vrm-materials-mtoon-1.0.10.tgz",
-      "integrity": "sha512-hATf06sn5FlxryLu5n5KitGwwN8424iDuwy5ojOnjKdtWm9pxwx/QtzJ7/glIFZm8PBVBcubG7N7I/QA+JOZkA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-mtoon/-/three-vrm-materials-mtoon-3.4.5.tgz",
+      "integrity": "sha512-3f4b4dFu+zg6ZmpJsRDLFBwRczS5AeBjRP2SLRbYNg9/WfqhiwB1S6BqB44cUI4jY92MgCeWOztYgtjuDx9RGQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "1.0.0",
-        "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
+        "@pixiv/types-vrm-0.0": "3.4.5",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-materials-v0compat": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-v0compat/-/three-vrm-materials-v0compat-1.0.10.tgz",
-      "integrity": "sha512-9il6jaDwe72TZ5aAYTEhF+ZcSxDgHY66MNxHt4uDhqSmJn9mjKw3h7jC/0jPg6QnC+cWIGi2yNg54Svvjaypqw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-v0compat/-/three-vrm-materials-v0compat-3.4.5.tgz",
+      "integrity": "sha512-zCGr60qT8sPBKqle2SptGqy0novxXb4LtIBPunDwfIDDkg0pt0WxRcWTCEHMRI+FiEfy1fwV6qTO0Aeev+Q6vw==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "1.0.0",
-        "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
+        "@pixiv/types-vrm-0.0": "3.4.5",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-node-constraint": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-node-constraint/-/three-vrm-node-constraint-1.0.10.tgz",
-      "integrity": "sha512-nkxesoXCNowmLxqTk9S3gNw4cYSVIgm/ISzjmwBVNzNzFymHhSOBdpJo/3Vi7vSwUSdKuK2/e0OKvRqsEQnSdw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-node-constraint/-/three-vrm-node-constraint-3.4.5.tgz",
+      "integrity": "sha512-E7G0qFVYRxib52Ksrz0XpC8+hCC7IOHFniN5ka+Gplo1j60zly2pkEZdN7t8a2zq0F9Ofe5KaESp2EJy4PnkFw==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0"
+        "@pixiv/types-vrmc-node-constraint-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "@types/three": "^0.151.0",
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-springbone": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-springbone/-/three-vrm-springbone-1.0.10.tgz",
-      "integrity": "sha512-oUakIbfna/32P/m0QfQuTeN3Snm/vlMk7vz0n2S7SWXadp7bFIVxOa+frwFyWICzD4ISwuAIW+tqfUeoWliS1g==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-springbone/-/three-vrm-springbone-3.4.5.tgz",
+      "integrity": "sha512-AHmSeoWY1QHTUa6kKkyPDVVsQm1uRpaUxL8l6JsrONUCReZRPo4oGwyOkipY3zKIF76n9pP7q3DE07qwlqhAFQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "1.0.0",
-        "@pixiv/types-vrmc-springbone-1.0": "1.0.0"
+        "@pixiv/types-vrm-0.0": "3.4.5",
+        "@pixiv/types-vrmc-springbone-1.0": "3.4.5",
+        "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.4.5"
       },
       "peerDependencies": {
-        "three": "^0.151.3"
+        "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/types-vrm-0.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-1.0.0.tgz",
-      "integrity": "sha512-3jnj/lpoLuzfsAAkqyTRiazxY88RhKFsDZkPmaFgPduDbIveFpzD153StHULO115w69I9VZ5i3ipJ6j7f0BjfA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-3.4.5.tgz",
+      "integrity": "sha512-hVTxAaEBEQoheNDt6KcFoSx6dGDF3L8a7MeNdubHEHKJWWS0YaLtPISDScdoX/5sXPVu+sjBLsRCHX7R5Vgi4A==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0/-/types-vrmc-materials-hdr-emissive-multiplier-1.0-1.0.0.tgz",
-      "integrity": "sha512-ussIML1MNbWIRehgQDoduy1zXTenubwDdGVekOhN0NO5ovVwVr4VVhLAvWr5gDVIwEliPGafJRqmHpWzmRTtEA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0/-/types-vrmc-materials-hdr-emissive-multiplier-1.0-3.4.5.tgz",
+      "integrity": "sha512-6LFX8XI52OT90RfNueCuJRE1WXugtdvFkagkmLvTFNenROWUJn54cZzwmqfzDcDaD2oVzRFjrJRrqFc6vfe91A==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-materials-mtoon-1.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-mtoon-1.0/-/types-vrmc-materials-mtoon-1.0-1.0.0.tgz",
-      "integrity": "sha512-JCqPiJZh7zccZxh28AGebvmBzch1Ql2IhU5n7nertLinPaIeVaYyWjHFJnxNVpn12nhTOYAsWpcUoOKeQWITmg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-mtoon-1.0/-/types-vrmc-materials-mtoon-1.0-3.4.5.tgz",
+      "integrity": "sha512-2evuadidd+X+3RuTnytNqoEq6Fk/O1VnnrpidFt44oPUL5SlVBKWMRyNfogXuUPBZnkZMdGIfUt9i20yoIImwQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-node-constraint-1.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-node-constraint-1.0/-/types-vrmc-node-constraint-1.0-1.0.0.tgz",
-      "integrity": "sha512-fNKPRMk0j87p5IKiSsxFI3inM0kx1oiIX7GBnai+pPxXNGj8zgEHbHtPbhw2kTrRX+Fqs+HTn5U5oiZPnM4YQQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-node-constraint-1.0/-/types-vrmc-node-constraint-1.0-3.4.5.tgz",
+      "integrity": "sha512-+LvtUqy3o2Ua1xablpId3Mby5ieTICGV+Mmi5fLNa/gkW1XhFk5ZDdfkv5r2dUjU0XkJsATrHFEROkSst6j2uQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-springbone-1.0": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-1.0/-/types-vrmc-springbone-1.0-1.0.0.tgz",
-      "integrity": "sha512-0gLtp3WT2WdCeJIQAPB9baU4w+xrIOLqIr/HgyVlJNmIICZoCdqMC+hu4cJwmPbJNBZsokD5A279Gwbr0pUy4g==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-1.0/-/types-vrmc-springbone-1.0-3.4.5.tgz",
+      "integrity": "sha512-D/notEbNfGEuE+5Nia8RfTRAYHx8RSO8vJGnTbDM3/O7v6rr2XR62hwDjQda7mh2JL2oQKM3U2E1Fvx4shQaLA==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-springbone-extended-collider-1.0": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-extended-collider-1.0/-/types-vrmc-springbone-extended-collider-1.0-3.4.5.tgz",
+      "integrity": "sha512-e/dTjBwHCDpUE//FmSMkcDrXKl9iY8Tr3QNxQrWZDHKNvPoGvNvjsFsSjtVBniZe9FsVI7gou1qIZbdULE1jIg==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-vrm-1.0": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-3.5.5.tgz",
-      "integrity": "sha512-WnemHHo2375BcBdumEhvrupZzsMSzTfdWlokmV9sUX2oC+OAQqJFfBjLF8ppkOhzHpl4MAPJqEfuhBJtNPm9ww==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-3.4.5.tgz",
+      "integrity": "sha512-6OIA1IinZ7h8DdxW8aToWowfHgr8qJ31cx2so7Tdj65eOIi59ohvskbWy3SFDG9Zt2tvN/M7Rr9W2rkb8LMFUA==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-vrm-animation-1.0": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-animation-1.0/-/types-vrmc-vrm-animation-1.0-3.5.5.tgz",
-      "integrity": "sha512-pyow6wBLdRZbLQbtHqu8uvYG+NXJbwIiLVK6pM6UvtaYotecOv43t6qIdMLYuieV+F+bEJcdfOLFZZVolrOOcQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-animation-1.0/-/types-vrmc-vrm-animation-1.0-3.4.5.tgz",
+      "integrity": "sha512-pUyhddl1DAb+jhCHLvbVIMeKUCfR5nzRV30qJ7Pvu2o6MToPlI6KvDnYVgFDx0k7g3rJKmTm6vbPpqMP6OgRxQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrmc-vrm-1.0": "3.5.5"
+        "@pixiv/types-vrmc-vrm-1.0": "2.0.3"
       }
+    },
+    "node_modules/@pixiv/types-vrmc-vrm-animation-1.0/node_modules/@pixiv/types-vrmc-vrm-1.0": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-2.0.3.tgz",
+      "integrity": "sha512-RMP34Bk1qLFQv/CRB1Zqvn2qMFfWQfP2Hms5QrrfoBsW9XroZdEe0zPLNbGmUPYh4F7VtBb+B7+RCuymRtpehA==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.4",
@@ -1643,33 +1625,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/stats.js": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
-      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/three": {
-      "version": "0.151.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.151.0.tgz",
-      "integrity": "sha512-hwOyN4szaikHsNzqbYLBfGvXi+TA/1TIKvK3ujJi+cQXzYzE5ZymzlDnOA6/cTSozY1juPFE3u5agToVQKb9TQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "fflate": "~0.6.9",
-        "lil-gui": "~0.17.0"
-      }
-    },
-    "node_modules/@types/webxr": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
-      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -2106,13 +2061,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
-      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2291,13 +2239,6 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lil-gui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/linkedom": {
       "version": "0.18.13",
@@ -2791,9 +2732,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.151.3",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.151.3.tgz",
-      "integrity": "sha512-+vbuqxFy8kzLeO5MgpBHUvP/EAiecaDwDuOPPDe6SbrZr96kccF0ktLngXc7xA7bzyd3N0t2f6mw3Z9y6JCojQ==",
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/packages/core/examples/node-vrm-newsdesk/package.json
+++ b/packages/core/examples/node-vrm-newsdesk/package.json
@@ -23,11 +23,11 @@
     "@mozilla/readability": "^0.6.0",
     "@napi-rs/canvas": "^1.0.3",
     "@openai/codex-sdk": "^0.146.0",
-    "@pixiv/three-vrm": "^1.0.10",
-    "@pixiv/three-vrm-animation": "^3.4.5",
+    "@pixiv/three-vrm": "3.4.5",
+    "@pixiv/three-vrm-animation": "3.4.5",
     "linkedom": "^0.18.13",
     "playwright": "^1.55.0",
-    "three": "^0.151.3"
+    "three": "0.182.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/packages/core/examples/node-vrm-newsdesk/prompts/newsdesk.md
+++ b/packages/core/examples/node-vrm-newsdesk/prompts/newsdesk.md
@@ -24,6 +24,7 @@ Analyze the document before writing. Return this exact outer structure:
     "background": { "color": "..." },
     "avatarLayout": { "scale": 1, "x": 0, "y": 0 },
     "avatarFraming": { "visibleHeightRatio": 0.39, "lookAtHeightRatio": 0.845 },
+    "avatarLighting": { "ambientIntensity": 1.4, "directionalIntensity": 2.35 },
     "motion": { "intensity": 1 },
     "blinkSeed": 1,
     "lines": []
@@ -91,6 +92,10 @@ The `script` object must follow this schema example:
   "avatarFraming": {
     "visibleHeightRatio": 0.39,
     "lookAtHeightRatio": 0.845
+  },
+  "avatarLighting": {
+    "ambientIntensity": 1.4,
+    "directionalIntensity": 2.35
   },
   "motion": {
     "intensity": 1

--- a/packages/core/examples/node-vrm-newsdesk/src/gen/cli.ts
+++ b/packages/core/examples/node-vrm-newsdesk/src/gen/cli.ts
@@ -10,7 +10,7 @@ import type {
   ScriptVoice,
   TimedText,
 } from '../types.js';
-import { DEFAULT_AVATAR_FRAMING } from '../types.js';
+import { DEFAULT_AVATAR_FRAMING, DEFAULT_AVATAR_LIGHTING } from '../types.js';
 import {
   concatWavs,
   createMouthValues,
@@ -491,6 +491,10 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       avatarFraming: {
         ...DEFAULT_AVATAR_FRAMING,
         ...script.avatarFraming,
+      },
+      avatarLighting: {
+        ...DEFAULT_AVATAR_LIGHTING,
+        ...script.avatarLighting,
       },
       motion: {
         intensity: normalizeMotionIntensity(script.motion?.intensity),

--- a/packages/core/examples/node-vrm-newsdesk/src/gen/vrmAvatar.ts
+++ b/packages/core/examples/node-vrm-newsdesk/src/gen/vrmAvatar.ts
@@ -28,6 +28,10 @@ export interface VrmAvatarDiagnostics {
     lookAtHeightRatio: number;
     portraitWidthAdjusted: boolean;
   };
+  avatarLighting: {
+    ambientIntensity: number;
+    directionalIntensity: number;
+  };
   launchMode: 'swiftshader' | 'default-gl';
   captureMode: 'playwright-png-screenshot';
 }
@@ -78,6 +82,10 @@ interface BrowserLoadDiagnostics {
     visibleHeightRatio: number;
     lookAtHeightRatio: number;
     portraitWidthAdjusted: boolean;
+  };
+  avatarLighting: {
+    ambientIntensity: number;
+    directionalIntensity: number;
   };
 }
 
@@ -184,7 +192,13 @@ async function launchSession(
         typeof (window as unknown as { load?: unknown }).load === 'function',
     );
     const loaded = await page.evaluate(
-      async ({ width, height, hasAnimation, avatarFraming }) => {
+      async ({
+        width,
+        height,
+        hasAnimation,
+        avatarFraming,
+        avatarLighting,
+      }) => {
         const harnessWindow = window as unknown as {
           load(options: {
             vrmUrl: string;
@@ -195,6 +209,10 @@ async function launchSession(
               visibleHeightRatio: number;
               lookAtHeightRatio: number;
             };
+            avatarLighting: {
+              ambientIntensity: number;
+              directionalIntensity: number;
+            };
           }): Promise<BrowserLoadDiagnostics>;
         };
         return harnessWindow.load({
@@ -203,6 +221,7 @@ async function launchSession(
           width,
           height,
           avatarFraming,
+          avatarLighting,
         });
       },
       {
@@ -210,6 +229,7 @@ async function launchSession(
         height: config.height,
         hasAnimation: Boolean(config.avatarAnimation),
         avatarFraming: config.avatarFraming,
+        avatarLighting: config.avatarLighting,
       },
     );
     return {

--- a/packages/core/examples/node-vrm-newsdesk/src/script-gen/schema.ts
+++ b/packages/core/examples/node-vrm-newsdesk/src/script-gen/schema.ts
@@ -12,6 +12,7 @@ const TOP_LEVEL_FIELDS = new Set([
   'telop',
   'avatarLayout',
   'avatarFraming',
+  'avatarLighting',
   'motion',
   'blinkSeed',
   'lines',
@@ -183,6 +184,31 @@ function validateAvatarFraming(framing: unknown, errors: string[]): void {
   );
 }
 
+function validateAvatarLighting(lighting: unknown, errors: string[]): void {
+  if (!isObject(lighting)) {
+    errors.push('script.avatarLighting must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    lighting,
+    new Set(['ambientIntensity', 'directionalIntensity']),
+    'script.avatarLighting',
+    errors,
+  );
+  validateOptionalNumber(
+    lighting.ambientIntensity,
+    'script.avatarLighting.ambientIntensity',
+    errors,
+    { min: 0, max: 10 },
+  );
+  validateOptionalNumber(
+    lighting.directionalIntensity,
+    'script.avatarLighting.directionalIntensity',
+    errors,
+    { min: 0, max: 10 },
+  );
+}
+
 function validateMotion(motion: unknown, errors: string[]): void {
   if (!isObject(motion)) {
     errors.push('script.motion must be an object.');
@@ -263,6 +289,8 @@ export function validateScript(script: unknown): string[] {
   validateAvatarLayout(script.avatarLayout, errors);
   if (script.avatarFraming !== undefined)
     validateAvatarFraming(script.avatarFraming, errors);
+  if (script.avatarLighting !== undefined)
+    validateAvatarLighting(script.avatarLighting, errors);
   requireFiniteNumber(script.blinkSeed, 'script.blinkSeed', errors);
   validateMotion(script.motion, errors);
   validateLines(script.lines, errors);

--- a/packages/core/examples/node-vrm-newsdesk/src/types.ts
+++ b/packages/core/examples/node-vrm-newsdesk/src/types.ts
@@ -38,6 +38,18 @@ export const DEFAULT_AVATAR_FRAMING = {
   lookAtHeightRatio: 0.845,
 } as const;
 
+export interface ScriptAvatarLighting {
+  /** Strength of the shadow-filling ambient light. */
+  ambientIntensity?: number;
+  /** Strength of the directional key light. */
+  directionalIntensity?: number;
+}
+
+export const DEFAULT_AVATAR_LIGHTING = {
+  ambientIntensity: 1.4,
+  directionalIntensity: 2.35,
+} as const;
+
 export interface ScriptMotion {
   /** VRMA playback-rate multiplier clamped to 0..3. */
   intensity?: number;
@@ -74,6 +86,7 @@ export interface NewsdeskScript {
   telop?: string;
   avatarLayout?: ScriptAvatarLayout;
   avatarFraming?: ScriptAvatarFraming;
+  avatarLighting?: ScriptAvatarLighting;
   motion?: ScriptMotion;
   blinkSeed?: number;
   lines: ScriptLine[];
@@ -98,6 +111,10 @@ export interface RenderConfig {
   avatarFraming: {
     visibleHeightRatio: number;
     lookAtHeightRatio: number;
+  };
+  avatarLighting: {
+    ambientIntensity: number;
+    directionalIntensity: number;
   };
   motion: { intensity: number };
   blinkSeed: number;

--- a/packages/core/examples/node-vrm-newsdesk/tests/e2e/gen.test.ts
+++ b/packages/core/examples/node-vrm-newsdesk/tests/e2e/gen.test.ts
@@ -125,6 +125,10 @@ it('renders changing VRM frames into a vertical H.264/AAC video', async () => {
         lookAtHeightRatio: number;
         portraitWidthAdjusted: boolean;
       };
+      avatarLighting: {
+        ambientIntensity: number;
+        directionalIntensity: number;
+      };
     };
   };
 
@@ -142,6 +146,10 @@ it('renders changing VRM frames into a vertical H.264/AAC video', async () => {
     visibleHeightRatio: 0.39,
     lookAtHeightRatio: 0.845,
     portraitWidthAdjusted: true,
+  });
+  expect(summary.avatarDiagnostics.avatarLighting).toEqual({
+    ambientIntensity: 1.4,
+    directionalIntensity: 2.35,
   });
 
   const firstTimings = await readFile(timingsPath, 'utf8');

--- a/packages/core/examples/node-vrm-newsdesk/tests/gen-unit.test.ts
+++ b/packages/core/examples/node-vrm-newsdesk/tests/gen-unit.test.ts
@@ -27,6 +27,10 @@ const diagnostics: VrmAvatarDiagnostics = {
     lookAtHeightRatio: 0.845,
     portraitWidthAdjusted: true,
   },
+  avatarLighting: {
+    ambientIntensity: 1.4,
+    directionalIntensity: 2.35,
+  },
   launchMode: 'swiftshader',
   captureMode: 'playwright-png-screenshot',
 };
@@ -143,6 +147,10 @@ function createConfig(): RenderConfig {
     avatarFraming: {
       visibleHeightRatio: 0.39,
       lookAtHeightRatio: 0.845,
+    },
+    avatarLighting: {
+      ambientIntensity: 1.4,
+      directionalIntensity: 2.35,
     },
     motion: { intensity: 2 },
     blinkSeed: 42,

--- a/packages/core/examples/node-vrm-newsdesk/tests/script-gen.test.ts
+++ b/packages/core/examples/node-vrm-newsdesk/tests/script-gen.test.ts
@@ -45,6 +45,10 @@ const validScript: NewsdeskScript = {
     visibleHeightRatio: 0.39,
     lookAtHeightRatio: 0.845,
   },
+  avatarLighting: {
+    ambientIntensity: 1.4,
+    directionalIntensity: 2.35,
+  },
   motion: { intensity: 1 },
   blinkSeed: 42,
   lines: [
@@ -187,6 +191,24 @@ describe('strict schema and provenance', () => {
       }).join('\n'),
     ).toMatch(
       /visibleHeightRatio must be at least 0.1|lookAtHeightRatio must be at most 1.5|extra is not allowed/,
+    );
+  });
+
+  it('validates optional avatar lighting overrides', () => {
+    expect(
+      validateScript({ ...validScript, avatarLighting: undefined }),
+    ).toEqual([]);
+    expect(
+      validateScript({
+        ...validScript,
+        avatarLighting: {
+          ambientIntensity: -0.1,
+          directionalIntensity: 10.1,
+          extra: true,
+        },
+      }).join('\n'),
+    ).toMatch(
+      /ambientIntensity must be at least 0|directionalIntensity must be at most 10|extra is not allowed/,
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #322. The VRM skin rendered almost pure white because `AmbientLight 1.0` + `DirectionalLight 0.9` overexposed the MToon materials (face sample: every channel clipped at 255).

- Align the harness renderer stack with `react-vrm-app`'s lockfile: three 0.182.0, `@pixiv/three-vrm` 3.4.5, `@pixiv/three-vrm-animation` 3.4.5 (single deduped three tree).
- Retune default lighting for three's physically based light units: soft ambient fill + directional key, giving a natural warm skin tone with hair / iris / neck detail on the dark background.
- Add optional script `avatarLighting` (`ambientIntensity`, `directionalIntensity`, schema-validated) so users can adjust per model; documented in `docs/script-format.md`, the prompt, and README en/ja.

## Verification

- Example: fmt / lint / typecheck / test (20/20) / build / test:e2e (1/1, real Chromium) pass; root fmt → lint → test → build pass.
- Re-rendered `samples/hello-sine.json`, `samples/hello-newsdesk.json` (AivisSpeech), and a 34 s generated news script; inspected frames: natural skin, blink, lip-sync, VRMA idle, overlays unchanged. Face sample mean RGB went from 255/255/254.8 (all channels clipped) to 255/253.6/239.6.
- public-release-check (diff): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
