### PR TITLE
feat(core-examples): add node-inochi2d-newsdesk text-to-news-video example

### DIFF
--- a/docs/examples.ja.md
+++ b/docs/examples.ja.md
@@ -208,6 +208,9 @@ npm run dev
 - [`packages/core/examples/node-live2d-newsdesk`](../packages/core/examples/node-live2d-newsdesk):
   ヘッドレス Chromium で Cubism 4 Live2D を描画し、Core のチャット・音声を
   通してチャプター付き縦型アバターニュース動画を作る Node.js パイプライン。
+- [`packages/core/examples/node-inochi2d-newsdesk`](../packages/core/examples/node-inochi2d-newsdesk):
+  決定的な仮想時計の下で Inochi2D WASM bridge を駆動し、チャプター付き
+  縦型ニュース動画を作る Node.js パイプライン。
 
 ## Chat サンプル
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -208,6 +208,9 @@ npm run dev
 - [`packages/core/examples/node-live2d-newsdesk`](../packages/core/examples/node-live2d-newsdesk):
   Node.js pipeline that drives a headless-Chromium Cubism 4 Live2D renderer and
   produces a chaptered vertical avatar news video with Core chat and voice.
+- [`packages/core/examples/node-inochi2d-newsdesk`](../packages/core/examples/node-inochi2d-newsdesk):
+  Node.js pipeline that drives the Inochi2D WASM bridge under a deterministic
+  virtual clock and produces a chaptered vertical news video.
 
 ## Chat Examples
 

--- a/packages/core/examples/node-inochi2d-newsdesk/.gitignore
+++ b/packages/core/examples/node-inochi2d-newsdesk/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+work/
+models/
+*.mp4
+*.wav
+*.aiff
+*.timings.json
+*.inochi2d-gen.config.json
+.env
+.env.*

--- a/packages/core/examples/node-inochi2d-newsdesk/README.ja.md
+++ b/packages/core/examples/node-inochi2d-newsdesk/README.ja.md
@@ -1,0 +1,97 @@
+# Node Inochi2D ニュースデスク
+
+入力文書から、Inochi2D の司会者が話す1080x1920のチャプター付きニュース
+動画を生成する例です。Core chat / Core Agent SDK、音声、RMS 口パク、Node
+canvas のオーバーレイ、ffmpeg の流れは他の Node newsdesk 例と共通です。
+アバターは、隣接する `react-inochi2d-app` の未改変 WebAssembly bridge を
+headless Chromium 内で描画します。
+
+## 必要なもの
+
+- Node.js 22 以上
+- `PATH` 上の ffmpeg / ffprobe
+- Playwright 用 Chromium
+- このリポジトリ内の `react-inochi2d-app/public/inochi2d` 一式
+- `hello-newsdesk.json` のみ、`127.0.0.1:10101` の AivisSpeech
+
+```bash
+npm install
+npx playwright install chromium
+npm run build
+```
+
+サンプルは sibling の runtime、Aka モデル、motion を台本相対パスで参照し、
+この例へコピーも変更もしません。
+
+## サンプルを描画する
+
+外部音声サービスが不要な決定的 sine サンプル:
+
+```bash
+npm run gen -- \
+  --script samples/hello-sine.json \
+  --output work/hello-sine.mp4
+```
+
+それ以前の仮想フレームを順に進めて45フレーム目だけを書き出す例:
+
+```bash
+npm run gen -- \
+  --script samples/hello-sine.json \
+  --frame 45 \
+  --png work/frame45.png
+```
+
+AivisSpeech 起動時は `samples/hello-newsdesk.json` が Mao の speaker
+`888753760` を使います。全フィールドは
+[docs/script-format.md](docs/script-format.md) を参照してください。
+
+## 描画の仕組み
+
+runtime bridge は独自の rAF ループを持ち、`performance.now()`、
+`Date.now()`、`Math.random()` を参照します。bridge を import する前に、
+harness がこれらを仮想時計と `blinkSeed` で初期化した mulberry32 RNG に
+置き換えます。各 `renderFrame` は仮想時間を正確に `1 / 30` 秒進め、bridge
+の rAF キューを1回 flush し、描画1回と次フレーム予約1件を検証します。
+
+音声 RMS は React 例と同じ候補順で `Mouth:: Shape` vec2 を駆動し、瞬きは
+`setEyeBlinkValue` を優先します。`original_idle_calm_breath` をループし、
+`motion.intensity` を重みとして使います。既定カメラは React 例と同じ
+縦動画向け既定カメラは `scale: 0.65`、`x: 0`、`y: 1450` です。React 例の
+model-space offset を維持しつつ、より近い構図にしています。Node 側で透明スクリーンショットへ
+背景、チャプター、字幕を合成し、RGBA を ffmpeg へ渡します。
+
+CLI の `averageMsPerFrame` が実測ブラウザ描画時間です。ハードウェアと
+Playwright の描画モードに依存するため、固定ベンチマーク値ではありません。
+検証時の SwiftShader 描画は103フレーム平均で219.2 ms/frameでした。
+
+## Aka のクレジット
+
+この例は `react-inochi2d-app` に同梱された派生 Aka ファイルを参照します。
+
+- Title: Aka
+- Author: seagetch
+- Source: https://github.com/Inochi2D/example-models
+- License: Creative Commons Attribution 4.0 International
+- License URL: https://creativecommons.org/licenses/by/4.0/
+
+参照ファイルは `Aka.original-rig.inx` と `Aka.original.motion.json` です。
+この同梱版は AITuber OnAir Inochi2D 例向けに調整されています。変更点は、
+ブラウザ描画向け rig 調整、アバター動作用 helper rig、idle motion の調整、
+`public/inochi2d/manifest.json` による motion metadata 設定です。元モデルの
+クレジットとライセンスは sibling の `Aka.ATTRIBUTION.md` に保持されています。
+
+## 検証
+
+```bash
+npm run fmt
+npm run lint
+npm run typecheck
+npm test
+npm run build
+npm run test:e2e
+```
+
+E2E はリポジトリ内の Aka を2回描画し、timings JSON、H.264/AAC 構造、口の
+閉開フレームを確認します。MP4 の byte-stable 性は WebGL / ffmpeg 環境に
+依存するため、仮定せず検証マシン上の実測結果を報告します。

--- a/packages/core/examples/node-inochi2d-newsdesk/README.md
+++ b/packages/core/examples/node-inochi2d-newsdesk/README.md
@@ -1,0 +1,116 @@
+# Node Inochi2D Newsdesk
+
+This example turns source text into a chaptered 1080x1920 news video with an
+Inochi2D presenter. It shares the Core chat, Core Agent SDK, voice, RMS
+lip-sync, Node canvas overlay, and ffmpeg pipeline used by the other Node
+newsdesk examples. The avatar itself is rendered by the unmodified WebAssembly
+bridge from the sibling `react-inochi2d-app` example in headless Chromium.
+
+## Requirements
+
+- Node.js 22 or newer
+- ffmpeg and ffprobe on `PATH`
+- Chromium installed for Playwright
+- the sibling `react-inochi2d-app/public/inochi2d` assets in this repository
+- AivisSpeech on `127.0.0.1:10101` only for `hello-newsdesk.json`
+
+```bash
+npm install
+npx playwright install chromium
+npm run build
+```
+
+The samples reference the sibling runtime, Aka model, and Aka motion by
+script-relative paths. This example does not copy or modify those files.
+
+## Render a sample
+
+The sine sample is deterministic and needs no external voice service:
+
+```bash
+npm run gen -- \
+  --script samples/hello-sine.json \
+  --output work/hello-sine.mp4
+```
+
+Render a single frame while advancing every earlier virtual frame:
+
+```bash
+npm run gen -- \
+  --script samples/hello-sine.json \
+  --frame 45 \
+  --png work/frame45.png
+```
+
+When AivisSpeech is running, `samples/hello-newsdesk.json` uses Mao speaker
+`888753760`. See [docs/script-format.md](docs/script-format.md) for every field.
+
+## Generate a script from source text
+
+```bash
+npm run script-gen -- path/to/CHANGELOG.md --dry-run
+npm run script-gen -- path/to/CHANGELOG.md --output work/script.json
+```
+
+The default `codex-sdk` provider requires `@openai/codex-sdk`. OpenAI, Claude,
+and Gemini are also supported through their usual environment API keys. The
+generated model, motion, and runtime paths are generic local placeholders;
+replace them before rendering.
+
+## How rendering works
+
+The runtime bridge owns an rAF loop and reads `performance.now()`, `Date.now()`,
+and `Math.random()`. Before importing any bridge code, the harness replaces
+those APIs with a virtual clock and a mulberry32 RNG seeded by `blinkSeed`.
+Each `renderFrame` call advances exactly `1 / 30` second, flushes the bridge rAF
+queue once, and verifies that the bridge rendered one frame and queued one next
+frame. Nested callbacks stay queued for the next timestamp, matching browser
+rAF behavior.
+
+Audio RMS drives the `Mouth:: Shape` vec2 parameter using the same candidate
+order as the React example. Blink values prefer `setEyeBlinkValue`. The
+`original_idle_calm_breath` animation loops with `motion.intensity` as its
+weight. The portrait transform (`scale: 0.65`, `x: 0`, `y: 1450`) keeps the
+React example's model-space offset with a tighter vertical-video zoom. Node composites the
+transparent screenshot with the background, chapter label, and subtitle before
+streaming RGBA frames to ffmpeg.
+
+The generator reports measured browser-render time as `averageMsPerFrame`.
+Hardware and Playwright graphics mode affect this value, so measure it on the
+target machine rather than treating one recorded run as a benchmark. The
+verification SwiftShader render averaged 219.2 ms/frame for 103 frames.
+
+## Aka attribution
+
+This example references the derived Aka files bundled by
+`react-inochi2d-app`:
+
+- Title: Aka
+- Author: seagetch
+- Source: https://github.com/Inochi2D/example-models
+- License: Creative Commons Attribution 4.0 International
+- License URL: https://creativecommons.org/licenses/by/4.0/
+
+The referenced files are `Aka.original-rig.inx` and
+`Aka.original.motion.json`. This bundled version was adapted for the AITuber
+OnAir Inochi2D example. Changes include rig adjustments for browser rendering,
+helper rig controls for avatar motion, adapted idle motion data, and motion
+metadata configured through `public/inochi2d/manifest.json`. The original model
+attribution and license are preserved in the sibling
+`Aka.ATTRIBUTION.md` file.
+
+## Verification
+
+```bash
+npm run fmt
+npm run lint
+npm run typecheck
+npm test
+npm run build
+npm run test:e2e
+```
+
+The E2E test renders the repository's Aka asset twice, compares timing JSON,
+probes H.264/AAC structure, and checks closed/open mouth frames. MP4 byte
+stability can depend on the local WebGL and ffmpeg stack and is reported from
+the verification machine rather than assumed.

--- a/packages/core/examples/node-inochi2d-newsdesk/biome.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/biome.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "ignore": ["dist/**", "node_modules/**", "work/**", "assets/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/docs/script-format.md
+++ b/packages/core/examples/node-inochi2d-newsdesk/docs/script-format.md
@@ -1,0 +1,91 @@
+# `script.json` format
+
+A script is the JSON object consumed by `npm run gen`. Paths in the document
+are resolved relative to the script file.
+
+```json
+{
+  "avatar": "/path/to/inochi2d/models/avatar.inx",
+  "avatarMotion": "/path/to/inochi2d/models/avatar.motion.json",
+  "inochi2dRuntime": "/path/to/inochi2d/runtime",
+  "voice": {
+    "engine": "sine",
+    "options": {
+      "frequency": 440,
+      "secondsPerChar": 0.06,
+      "minDuration": 0.4
+    }
+  },
+  "leadIn": 0.1,
+  "leadOut": 0.2,
+  "defaultPauseAfter": 0.08,
+  "background": { "color": "#20242c" },
+  "avatarLayout": { "scale": 1, "x": 0.5, "y": 0.5 },
+  "avatarFraming": {
+    "scale": 0.65,
+    "x": 0,
+    "y": 1450
+  },
+  "motion": { "intensity": 1 },
+  "blinkSeed": 42,
+  "lines": [
+    {
+      "text": "こんにちは。",
+      "chapter": "ごあいさつ",
+      "pauseAfter": 0.08
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+- `avatar`: Inochi2D `.inx` file. Script-relative, absolute, and `~/...` paths
+  are accepted.
+- `avatarMotion` (optional): motion JSON passed to the runtime with the model.
+- `inochi2dRuntime`: directory containing `inochi_bridge.js`, `inochi2d.js`,
+  `inochi2d_bg.wasm`, and `secondary_motion.js`. The files are served read-only
+  to the harness and are not copied or modified.
+- `output` (optional): MP4 path. The CLI `--output` takes precedence.
+- `voice.engine`: `sine`, `say`, or `aituber-voice`.
+- `voice.options`: options passed to that engine. The `aituber-voice` engine
+  accepts Core `VoiceServiceOptions`; its audio is captured through `onPlay`.
+- `leadIn`, `leadOut`: silence in seconds.
+- `defaultPauseAfter`: default silence after each line.
+- `background.color` and optional `background.image`: canvas background.
+- `telop` (optional): title shown only while no line chapter is active.
+- `avatarLayout`: avatar `scale` and fractional `x`/`y` anchors.
+- `avatarFraming` (optional): Inochi2D camera transform in model space. The
+  portrait defaults are `scale: 0.65`, `x: 0`, and `y: 1450`. They retain the
+  React example's model-space offset with a tighter vertical-video zoom.
+  `avatarLayout` is applied afterward by the Node compositor.
+- `motion.intensity`: weight of the looping `original_idle_calm_breath`
+  animation, clamped from 0 through 3. Virtual time always advances at 30fps,
+  so the value does not affect deterministic timing.
+- `blinkSeed`: deterministic blink schedule seed.
+- `lines`: ordered narration and subtitle entries.
+
+Before the unmodified runtime bridge is imported, the harness replaces rAF,
+`performance.now()`, `Date.now()`, and `Math.random()` with a seeded virtual
+clock. Every requested video frame advances that clock exactly once. Normalized
+audio RMS drives `Mouth:: Shape` as a vec2 when available, the blink schedule
+uses `setEyeBlinkValue`, and the bridge renders one WebGL frame. Node then
+composites the transparent browser frame with the background, chapter, and
+subtitle.
+
+## Line fields
+
+- `text`: subtitle and narration unless `reading` is set.
+- `reading` (optional): pronunciation-only narration text.
+- `chapter` (optional): topic label shown until a later line changes it. The
+  first chapter also covers the lead-in.
+- `spoken` (optional): set to `false` for a silent subtitle.
+- `duration`: required in seconds when `spoken` is `false`.
+- `pauseAfter` (optional): silence after this line.
+
+Scripts produced by `script-gen` contain 3 to 12 lines, with each `text`
+limited to 35 Unicode characters. Every number and semantic-version token in
+`telop`, `chapter`, `text`, or `reading` must occur in the source or optional
+focus hint. Pure integers are compared without leading zeroes (for example,
+source `07` may appear as `7`), while dotted version and decimal tokens are
+compared unchanged.

--- a/packages/core/examples/node-inochi2d-newsdesk/harness/index.html
+++ b/packages/core/examples/node-inochi2d-newsdesk/harness/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inochi2D Newsdesk Render Harness</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+      }
+
+      canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="avatar"></canvas>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/packages/core/examples/node-inochi2d-newsdesk/harness/main.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/harness/main.ts
@@ -1,0 +1,306 @@
+import {
+  DEFAULT_AVATAR_FRAMING,
+  DEFAULT_IDLE_ANIMATION,
+} from '../src/types.js';
+import { installBrowserVirtualClock, VirtualClock } from './virtualClock.js';
+
+type MouthControl =
+  | {
+      kind: 'vec2';
+      parameterId: string;
+      idleX: number;
+      idleY: number;
+      openY: number;
+    }
+  | { kind: 'scalar'; parameterId: string; idleValue: number };
+
+const MOUTH_PARAMETER_CANDIDATES: readonly MouthControl[] = [
+  {
+    kind: 'vec2',
+    parameterId: 'Mouth:: Shape',
+    idleX: 1,
+    idleY: 0,
+    openY: 1,
+  },
+  { kind: 'scalar', parameterId: 'Mouth:: Open', idleValue: 0 },
+  { kind: 'scalar', parameterId: 'Mouth:: Openness', idleValue: 0 },
+  { kind: 'scalar', parameterId: 'Mouth Open', idleValue: 0 },
+] as const;
+const BLINK_PARAMETER_IDS = [
+  'Eye:: Left:: Blink',
+  'Eye:: Right:: Blink',
+  'Blink',
+] as const;
+
+interface Inochi2DDebugState {
+  activeAnimation?: { name?: string; kind?: string; loop?: boolean } | null;
+  blinkLayer?: { activeParameterIds?: string[] };
+  cameraTransform?: { x?: number; y?: number; scale?: number };
+  canvasDataset?: Record<string, string>;
+}
+
+interface Inochi2DController {
+  mount(canvas: HTMLCanvasElement): Promise<void> | void;
+  unmount(): Promise<void> | void;
+  loadModel(modelUrl: string, motionUrl?: string): Promise<void>;
+  setParameter(parameterId: string, value: number): Promise<void> | void;
+  setParameterVector?(
+    parameterId: string,
+    valueX: number,
+    valueY: number,
+  ): Promise<void> | void;
+  setEyeBlinkValue?(
+    valueLeft: number,
+    valueRight?: number,
+    options?: { durationMs?: number },
+  ): Promise<void> | void;
+  playAnimation?(
+    animationName: string,
+    options?: {
+      loop?: boolean;
+      restart?: boolean;
+      weight?: number;
+      kind?: 'manual' | 'idle' | 'reaction' | 'emotion';
+    },
+  ): Promise<void> | void;
+  setCameraTransform(x: number, y: number, scale: number): Promise<void> | void;
+  resize(
+    width: number,
+    height: number,
+    devicePixelRatio: number,
+  ): Promise<void> | void;
+  getDebugState?(): Inochi2DDebugState;
+}
+
+interface Inochi2DBridgeModule {
+  createInochi2DController(options: {
+    wasmUrl: string;
+    debug?: boolean;
+  }): Promise<Inochi2DController> | Inochi2DController;
+}
+
+interface HarnessLoadOptions {
+  bridgeUrl: string;
+  wasmUrl: string;
+  modelUrl: string;
+  motionUrl?: string;
+  width: number;
+  height: number;
+  blinkSeed: number;
+  avatarFraming?: { scale?: number; x?: number; y?: number };
+  idleAnimation?: string;
+  motionIntensity?: number;
+}
+
+interface HarnessFrameOptions {
+  time: number;
+  deltaSeconds: number;
+  mouth: number;
+  eyesClosed: boolean;
+}
+
+interface VirtualFrameDiagnostics {
+  timeMs: number;
+  callbacksPerFrame: number;
+  pendingCallbacks: number;
+}
+
+export interface HarnessDiagnostics {
+  runtime: string;
+  canvasSize: { width: number; height: number };
+  mouthParameterId: string;
+  mouthParameterKind: MouthControl['kind'];
+  eyeParameterIds: string[];
+  idleAnimation: string;
+  idleAnimationActive: boolean;
+  avatarFraming: { scale: number; x: number; y: number };
+  virtualClock: {
+    seed: number;
+    timeMs: number;
+    callbacksPerFrame: number;
+    pendingCallbacks: number;
+  };
+}
+
+interface HarnessState {
+  canvas: HTMLCanvasElement;
+  controller: Inochi2DController;
+  mouthControl: MouthControl;
+  seed: number;
+  lastCallbacksPerFrame: number;
+}
+
+declare global {
+  interface Window {
+    load(options: HarnessLoadOptions): Promise<HarnessDiagnostics>;
+    renderFrame(options: HarnessFrameOptions): Promise<VirtualFrameDiagnostics>;
+  }
+}
+
+const virtualClock = new VirtualClock();
+virtualClock.reset(0);
+installBrowserVirtualClock(virtualClock);
+
+let state: HarnessState | null = null;
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function resolveMouthControl(controller: Inochi2DController): MouthControl {
+  if (typeof controller.setParameterVector === 'function') {
+    return MOUTH_PARAMETER_CANDIDATES[0];
+  }
+  return MOUTH_PARAMETER_CANDIDATES.find(
+    (candidate) => candidate.kind === 'scalar',
+  ) as MouthControl;
+}
+
+async function setMouth(
+  controller: Inochi2DController,
+  control: MouthControl,
+  value: number,
+): Promise<void> {
+  const open = clamp01(value);
+  if (control.kind === 'vec2' && controller.setParameterVector) {
+    const y = control.idleY + (control.openY - control.idleY) * open;
+    await Promise.resolve(
+      controller.setParameterVector(control.parameterId, control.idleX, y),
+    );
+    return;
+  }
+  await Promise.resolve(controller.setParameter(control.parameterId, open));
+}
+
+async function setBlink(
+  controller: Inochi2DController,
+  eyesClosed: boolean,
+  deltaSeconds: number,
+): Promise<void> {
+  const value = eyesClosed ? 1 : 0;
+  if (controller.setEyeBlinkValue) {
+    await Promise.resolve(
+      controller.setEyeBlinkValue(value, value, {
+        durationMs: deltaSeconds * 1000 + 1,
+      }),
+    );
+    return;
+  }
+  await Promise.all(
+    BLINK_PARAMETER_IDS.map((parameterId) =>
+      Promise.resolve(controller.setParameter(parameterId, value)),
+    ),
+  );
+}
+
+function readDiagnostics(
+  current: HarnessState,
+  options: HarnessLoadOptions,
+): HarnessDiagnostics {
+  const debug = current.controller.getDebugState?.();
+  const framing = { ...DEFAULT_AVATAR_FRAMING, ...options.avatarFraming };
+  return {
+    runtime: debug?.canvasDataset?.inochi2dRuntime ?? 'inox2d-wasm-webgl2',
+    canvasSize: { width: current.canvas.width, height: current.canvas.height },
+    mouthParameterId: current.mouthControl.parameterId,
+    mouthParameterKind: current.mouthControl.kind,
+    eyeParameterIds: debug?.blinkLayer?.activeParameterIds ?? [
+      ...BLINK_PARAMETER_IDS,
+    ],
+    idleAnimation: options.idleAnimation ?? DEFAULT_IDLE_ANIMATION,
+    idleAnimationActive: Boolean(debug?.activeAnimation),
+    avatarFraming: framing,
+    virtualClock: {
+      seed: current.seed,
+      timeMs: virtualClock.now(),
+      callbacksPerFrame: current.lastCallbacksPerFrame,
+      pendingCallbacks: virtualClock.pendingAnimationFrames(),
+    },
+  };
+}
+
+async function load(options: HarnessLoadOptions): Promise<HarnessDiagnostics> {
+  if (state) await Promise.resolve(state.controller.unmount());
+  virtualClock.reset(options.blinkSeed);
+
+  const bridge = (await import(
+    /* @vite-ignore */ options.bridgeUrl
+  )) as Inochi2DBridgeModule;
+  if (typeof bridge.createInochi2DController !== 'function') {
+    throw new Error('Inochi2D bridge must export createInochi2DController().');
+  }
+
+  const canvas = document.querySelector<HTMLCanvasElement>('#avatar');
+  if (!canvas) throw new Error('Harness canvas was not found.');
+  canvas.width = options.width;
+  canvas.height = options.height;
+
+  const controller = await bridge.createInochi2DController({
+    wasmUrl: options.wasmUrl,
+    debug: true,
+  });
+  await Promise.resolve(controller.mount(canvas));
+  await Promise.resolve(controller.resize(options.width, options.height, 1));
+  await controller.loadModel(options.modelUrl, options.motionUrl);
+
+  const framing = { ...DEFAULT_AVATAR_FRAMING, ...options.avatarFraming };
+  await Promise.resolve(
+    controller.setCameraTransform(framing.x, framing.y, framing.scale),
+  );
+  const idleAnimation = options.idleAnimation ?? DEFAULT_IDLE_ANIMATION;
+  if (controller.playAnimation) {
+    await Promise.resolve(
+      controller.playAnimation(idleAnimation, {
+        loop: true,
+        restart: true,
+        weight: Math.max(0, Math.min(3, options.motionIntensity ?? 1)),
+        kind: 'idle',
+      }),
+    );
+  }
+
+  state = {
+    canvas,
+    controller,
+    mouthControl: resolveMouthControl(controller),
+    seed: options.blinkSeed,
+    lastCallbacksPerFrame: 0,
+  };
+  await renderFrame({
+    time: 0,
+    deltaSeconds: 0,
+    mouth: 0,
+    eyesClosed: false,
+  });
+  return readDiagnostics(state, options);
+}
+
+async function renderFrame(
+  options: HarnessFrameOptions,
+): Promise<VirtualFrameDiagnostics> {
+  if (!state) throw new Error('Call window.load before window.renderFrame.');
+  await setMouth(state.controller, state.mouthControl, options.mouth);
+  await setBlink(state.controller, options.eyesClosed, options.deltaSeconds);
+  virtualClock.advance(options.deltaSeconds);
+  const expectedTimeMs = options.time * 1000;
+  if (Math.abs(virtualClock.now() - expectedTimeMs) > 0.001) {
+    throw new Error(
+      `Virtual time mismatch: expected ${expectedTimeMs}, got ${virtualClock.now()}.`,
+    );
+  }
+  const callbacks = virtualClock.flushAnimationFrame();
+  if (callbacks !== 1 || virtualClock.pendingAnimationFrames() !== 1) {
+    throw new Error(
+      `Inochi2D bridge must render exactly once per virtual frame (flushed ${callbacks}, pending ${virtualClock.pendingAnimationFrames()}).`,
+    );
+  }
+  state.lastCallbacksPerFrame = callbacks;
+  return {
+    timeMs: virtualClock.now(),
+    callbacksPerFrame: callbacks,
+    pendingCallbacks: virtualClock.pendingAnimationFrames(),
+  };
+}
+
+window.load = load;
+window.renderFrame = renderFrame;

--- a/packages/core/examples/node-inochi2d-newsdesk/harness/virtualClock.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/harness/virtualClock.ts
@@ -1,0 +1,93 @@
+export type VirtualAnimationFrameCallback = (timestamp: number) => void;
+
+/** Deterministic mulberry32 random-number generator. */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+/**
+ * Browser-style virtual clock whose queued animation callbacks run only when
+ * the caller advances and flushes a frame.
+ */
+export class VirtualClock {
+  private timestampMs = 0;
+  private nextAnimationFrameId = 1;
+  private animationFrames = new Map<number, VirtualAnimationFrameCallback>();
+  private nextRandom = createSeededRandom(0);
+
+  /** Reset time, queued callbacks, callback IDs, and the seeded RNG. */
+  reset(seed: number, timestampMs = 0): void {
+    this.timestampMs = timestampMs;
+    this.nextAnimationFrameId = 1;
+    this.animationFrames.clear();
+    this.nextRandom = createSeededRandom(seed);
+  }
+
+  /** Current virtual time in milliseconds. */
+  now(): number {
+    return this.timestampMs;
+  }
+
+  /** Advance virtual time without executing animation callbacks. */
+  advance(deltaSeconds: number): void {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds < 0) {
+      throw new Error('Virtual clock deltaSeconds must be non-negative.');
+    }
+    this.timestampMs += deltaSeconds * 1000;
+  }
+
+  /** Queue a callback in browser requestAnimationFrame insertion order. */
+  requestAnimationFrame(callback: VirtualAnimationFrameCallback): number {
+    const id = this.nextAnimationFrameId;
+    this.nextAnimationFrameId += 1;
+    this.animationFrames.set(id, callback);
+    return id;
+  }
+
+  /** Cancel one queued callback. */
+  cancelAnimationFrame(id: number): void {
+    this.animationFrames.delete(id);
+  }
+
+  /** Number of callbacks waiting for the next virtual frame. */
+  pendingAnimationFrames(): number {
+    return this.animationFrames.size;
+  }
+
+  /**
+   * Flush all callbacks that were queued at the start of this frame. Callbacks
+   * scheduled during the flush remain queued for the next virtual timestamp,
+   * matching browser rAF semantics.
+   */
+  flushAnimationFrame(): number {
+    const callbacks = [...this.animationFrames.values()];
+    this.animationFrames.clear();
+    for (const callback of callbacks) callback(this.timestampMs);
+    return callbacks.length;
+  }
+
+  /** Return the next deterministic random value in the range [0, 1). */
+  random(): number {
+    return this.nextRandom();
+  }
+}
+
+/** Install one virtual clock into the browser before importing the bridge. */
+export function installBrowserVirtualClock(clock: VirtualClock): void {
+  window.requestAnimationFrame = (callback) =>
+    clock.requestAnimationFrame(callback);
+  window.cancelAnimationFrame = (id) => clock.cancelAnimationFrame(id);
+  Object.defineProperty(window.performance, 'now', {
+    configurable: true,
+    value: () => clock.now(),
+  });
+  Date.now = () => Math.floor(clock.now());
+  Math.random = () => clock.random();
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/package-lock.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/package-lock.json
@@ -1,0 +1,3263 @@
+{
+  "name": "@aituber-onair/core-example-node-inochi2d-newsdesk",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aituber-onair/core-example-node-inochi2d-newsdesk",
+      "version": "0.0.0",
+      "dependencies": {
+        "@aituber-onair/core": "file:../..",
+        "@mozilla/readability": "^0.6.0",
+        "@napi-rs/canvas": "^1.0.3",
+        "@openai/codex-sdk": "^0.146.0",
+        "linkedom": "^0.18.13",
+        "playwright": "^1.55.0"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^22.15.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.8.3",
+        "vitest": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../..": {
+      "name": "@aituber-onair/core",
+      "version": "0.26.10",
+      "license": "MIT",
+      "dependencies": {
+        "@aituber-onair/chat": "^0.52.0",
+        "@aituber-onair/voice": "^0.20.0"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^18.15.0",
+        "@vitest/coverage-v8": "^1.3.1",
+        "typescript": "^5.0.0",
+        "vitest": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@pixiv/three-vrm": "^1.0.9"
+      }
+    },
+    "node_modules/@aituber-onair/core": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.7.tgz",
+      "integrity": "sha512-26wVFEgs6gbe7wmzCrud1pK8q6oOgcUu7OOF24BuazB8ZUCskU9ZSLrCjoWIFVxx09rjAxsXxPleaWowHvdPCA==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.7",
+        "@napi-rs/canvas-darwin-arm64": "1.0.7",
+        "@napi-rs/canvas-darwin-x64": "1.0.7",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.7",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.7",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.7",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.7",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.7"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.7.tgz",
+      "integrity": "sha512-d5p4hHTykc/9PjiBXkvCH/IC5hT5jH7BjQ1u8ITq+G8x4VmvveOHdy/4BWYcC3ebWRmrG9zEc/oCTy+Yf3iZ4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.7.tgz",
+      "integrity": "sha512-jKfZl2QDqBr6/Ap/8NKkX0Po9SFfVjUPBJbQQmYGVtQQIazWWIAO60riH3Mz2sOyysa2oJO39sLEfXerypu0vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.7.tgz",
+      "integrity": "sha512-v1asrnKBu0tD+sdSD2qVIUfhoXSrr8LFTn7z76pN+8xsiOrmFcAVty57R/5DB8ZNqNLKsUBDXFSrzf4Wt9NaSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.7.tgz",
+      "integrity": "sha512-c4Hcu4L5bXCgLY8jrZ2hy/Avl65MsbfH9DqNWrrd9InbpBZZF/rmrh7XkgmTUmOFcUrt/PaFSBinW2C0moDgcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.7.tgz",
+      "integrity": "sha512-OVW6T1x65BTVfWb//xylCoWxbdII+nzHu3L5T035aerBAnZ5e0nmeTMkMEO9qQrVJq4WcWW8hp+T0dF+JvJPUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.7.tgz",
+      "integrity": "sha512-KX/k1UO61XdKlXxhtIkq1ZUH8uP+NNK4vSrBcM2/4wWUUCZaG93BU5s0KuE9n+TFn0jEoqLSlXOuH1pYuV5dcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.7.tgz",
+      "integrity": "sha512-r+0Bg+fK8r2AsrbeT7JwBUAERZSjlyhfAMQfZE/zxYGmbswS92hN0FPjynVWbeuz5fIrLfZ6JA5pH8V6drN6qw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.7.tgz",
+      "integrity": "sha512-0tT9KzEcTfb6MWdUWIDfy6uq6UNF691r/9NfXxxl8s9+G5QrD7VP1UC+PAwzsCzJTClIKyidNau/grYTL+QmHw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.7.tgz",
+      "integrity": "sha512-rvT0xo1xA+C7e+U/2ngsxWsl9gC5knHU+z8KTT5VK0Zos4AQbWZvtjvegrmzxm4o2yHE32Lexj6CDEJNvuTczA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.7.tgz",
+      "integrity": "sha512-N6s3yoFFPUDkfRpjUiKERVYkli7ex5Sf0Bu/My6D6gOGYxYolC1KvL6x8U0aN+ScCWAzbkIWcMYR9g0OGsFuVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.7.tgz",
+      "integrity": "sha512-SKTNdBV/ljfhkPsLhXjm4x2PQ0ILpc0PhkBzRHuroJXidZUaF5yh0j3s3dIzB8PrRmW+nEASzyMTaWT3nH1ywQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.146.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1.tgz",
+      "integrity": "sha512-f51R56E/G15soLhf5l5pWUiM+mGHK0NdLozOtzjRoAa+bA20hgWrkyxE/fpwCnuGQM6XNdktHYtK9xQ7bPIbTA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.1-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-darwin-arm64.tgz",
+      "integrity": "sha512-zvXxiGRuKCOoFQyh7lRC2SHwomM2VNzHralyeP+i6fxLjQ5grpmnfJpnLs54+GkK7K5nEpkj7chqjlKbMELgZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-darwin-x64.tgz",
+      "integrity": "sha512-XQbemMBWH37hVL2vkoP+t//QyUmMjDRksf8YHmhAzHmt2oTTo8xyzH76LLFqMPCNpTdG755T8ZCbkpM0X2NJwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-linux-arm64.tgz",
+      "integrity": "sha512-2LhK2axFZKe6BbhlzGXCpVkSva1TikFYJIq6x7+xu0AdfmY855EV5lQ7lwFpjJfM5gAJqxcycttvE1ODoSoLaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-linux-x64.tgz",
+      "integrity": "sha512-XPWpWzJgGK1ygsUBMXgskEkr+uTVj/XOnnCP2UE9tQUXTWYRYElz7QW1YS3bxkN6Kev4CJQKbdJopVwh+0E/TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.146.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.146.1.tgz",
+      "integrity": "sha512-Sf7xkut0XctKaS3CC3PnYtXkCNfZZKZthx8NIQS5wXrngRyU1f8MxZsD6iWkZYRlHYJ1NZwi3vvPntVYrRxBQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.146.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-win32-arm64.tgz",
+      "integrity": "sha512-3UJf8sKefCbUgPPcgQRiCaKn9AsItuPl0ZL6erHWzT6UIemrdjt2WHiTNOw/7tVJRnUsG4A1LUrK2to9/SkwXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.1-win32-x64.tgz",
+      "integrity": "sha512-FfiNJysKpHkJ08Kn+571r701dgoZVZjqNUxrEZ/JJyu5hIzNTs4XBllAX6ynHkF8G9NebPEtaJz72zxbol/JPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/package.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@aituber-onair/core-example-node-inochi2d-newsdesk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "typecheck": "tsc --project tsconfig.dev.json",
+    "test": "npm run typecheck && vitest run",
+    "test:e2e": "npm run build && vitest run --config vitest.e2e.config.ts",
+    "test:watch": "vitest",
+    "fmt": "biome format . --write",
+    "fmt:check": "biome format .",
+    "lint": "biome lint .",
+    "script-gen": "node dist/script-gen.cjs",
+    "gen": "node dist/gen.cjs"
+  },
+  "dependencies": {
+    "@aituber-onair/core": "file:../..",
+    "@mozilla/readability": "^0.6.0",
+    "@napi-rs/canvas": "^1.0.3",
+    "@openai/codex-sdk": "^0.146.0",
+    "linkedom": "^0.18.13",
+    "playwright": "^1.55.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4",
+    "@types/node": "^22.15.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/prompts/newsdesk.md
+++ b/packages/core/examples/node-inochi2d-newsdesk/prompts/newsdesk.md
@@ -1,0 +1,118 @@
+# Inochi2D Newsdesk script instructions
+
+You turn arbitrary source text into a short Japanese news program for an
+AITuber OnAir host. Stay technically accurate and never invent a fact, number,
+name, date, or benefit that is not in the source text or optional focus hint.
+
+Return exactly one JSON object and nothing else. Do not use Markdown fences or
+explanatory text.
+
+Analyze the document before writing. Return this exact outer structure:
+
+```json
+{
+  "analysis": {
+    "docType": "release-notes, article, announcement, memo, or another concise type",
+    "title": "the source title or a concise factual title",
+    "keyFacts": ["facts selected from the source"]
+  },
+  "script": {
+    "avatar": "/path/to/inochi2d/models/avatar.inx",
+    "avatarMotion": "/path/to/inochi2d/models/avatar.motion.json",
+    "inochi2dRuntime": "/path/to/inochi2d/runtime",
+    "voice": { "engine": "...", "options": {} },
+    "background": { "color": "..." },
+    "avatarLayout": { "scale": 1, "x": 0.5, "y": 0.5 },
+    "avatarFraming": { "scale": 0.65, "x": 0, "y": 1450 },
+    "motion": { "intensity": 1 },
+    "blinkSeed": 1,
+    "lines": []
+  }
+}
+```
+
+Adapt the structure to the document type:
+
+- For release notes, put the package or product name and version in the first
+  chapter when they appear in the source or focus hint, then group changes by
+  topic.
+- For an article, select two to four central topics and give each topic a
+  chapter.
+- For other document types, choose concise chapters that reflect the source's
+  own structure and most important facts.
+
+Script requirements:
+
+- Follow the supplied `script.json` schema exactly.
+- Write 3 to 12 `lines`.
+- Keep each Japanese `lines[].text` to at most 35 Unicode characters.
+- In user-visible `script.lines[].chapter`, `script.lines[].text`,
+  `script.lines[].reading`, and `script.telop`, use only numbers, version
+  strings, names, and claims supported by the source text or focus hint.
+- Do not set a top-level `telop`. Instead, set `lines[].chapter` — a short
+  topic label (at most 14 characters) shown at the top of the screen while
+  that topic is being discussed. Set `chapter` on the first line and on each
+  line where the topic changes. Lines without `chapter` keep showing the
+  previous one.
+- Do not infer missing benefits, compatibility, dates, performance figures,
+  or breaking changes.
+- Use the local-file placeholders shown below. The CLI preserves placeholders
+  so the user can replace them with licensed local files after generation.
+- Use the deterministic `sine` voice so the result can be rendered without an
+  external voice service.
+- Keep the fixed render properties shown in the schema example. Their numeric
+  values are structural settings and are the only exception to the rule above.
+
+The `script` object must follow this schema example:
+
+```json
+{
+  "avatar": "/path/to/inochi2d/models/avatar.inx",
+  "avatarMotion": "/path/to/inochi2d/models/avatar.motion.json",
+  "inochi2dRuntime": "/path/to/inochi2d/runtime",
+  "voice": {
+    "engine": "sine",
+    "options": {
+      "frequency": 440,
+      "secondsPerChar": 0.01,
+      "minDuration": 0.2
+    }
+  },
+  "leadIn": 0.1,
+  "leadOut": 0.2,
+  "defaultPauseAfter": 0.08,
+  "background": {
+    "color": "#20242c"
+  },
+  "avatarLayout": {
+    "scale": 1,
+    "x": 0.5,
+    "y": 0.5
+  },
+  "avatarFraming": {
+    "scale": 0.65,
+    "x": 0,
+    "y": 1450
+  },
+  "motion": {
+    "intensity": 1
+  },
+  "blinkSeed": 42,
+  "lines": [
+    {
+      "text": "ここに最初の日本語告知文を書きます。",
+      "chapter": "最初の話題",
+      "pauseAfter": 0.08
+    },
+    {
+      "text": "ここに二番目の日本語告知文を書きます。",
+      "chapter": "ここに話題ラベル",
+      "pauseAfter": 0.08
+    },
+    {
+      "text": "ここに最後の日本語告知文を書きます。",
+      "pauseAfter": 0.08
+    }
+  ]
+}
+```

--- a/packages/core/examples/node-inochi2d-newsdesk/samples/hello-newsdesk.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/samples/hello-newsdesk.json
@@ -1,0 +1,48 @@
+{
+  "avatar": "../../react-inochi2d-app/public/inochi2d/models/Aka.original-rig.inx",
+  "avatarMotion": "../../react-inochi2d-app/public/inochi2d/models/Aka.original.motion.json",
+  "inochi2dRuntime": "../../react-inochi2d-app/public/inochi2d/runtime",
+  "voice": {
+    "engine": "aituber-voice",
+    "options": {
+      "engineType": "aivisSpeech",
+      "speaker": "888753760"
+    }
+  },
+  "leadIn": 0.05,
+  "leadOut": 0.08,
+  "defaultPauseAfter": 0.03,
+  "background": {
+    "color": "#20242c"
+  },
+  "avatarLayout": {
+    "scale": 1,
+    "x": 0.5,
+    "y": 0.5
+  },
+  "avatarFraming": {
+    "scale": 0.65,
+    "x": 0,
+    "y": 1450
+  },
+  "motion": {
+    "intensity": 1
+  },
+  "blinkSeed": 42,
+  "lines": [
+    {
+      "text": "こんにちは。",
+      "chapter": "ごあいさつ",
+      "pauseAfter": 0.03
+    },
+    {
+      "text": "ここは AITuber OnAir のニュースデスク。",
+      "chapter": "ニュースデスクとは",
+      "pauseAfter": 0.03
+    },
+    {
+      "text": "新しいリリースを私がお知らせします。",
+      "pauseAfter": 0.03
+    }
+  ]
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/samples/hello-sine.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/samples/hello-sine.json
@@ -1,0 +1,49 @@
+{
+  "avatar": "../../react-inochi2d-app/public/inochi2d/models/Aka.original-rig.inx",
+  "avatarMotion": "../../react-inochi2d-app/public/inochi2d/models/Aka.original.motion.json",
+  "inochi2dRuntime": "../../react-inochi2d-app/public/inochi2d/runtime",
+  "voice": {
+    "engine": "sine",
+    "options": {
+      "frequency": 440,
+      "secondsPerChar": 0.06,
+      "minDuration": 0.4
+    }
+  },
+  "leadIn": 0.1,
+  "leadOut": 0.2,
+  "defaultPauseAfter": 0.08,
+  "background": {
+    "color": "#20242c"
+  },
+  "avatarLayout": {
+    "scale": 1,
+    "x": 0.5,
+    "y": 0.5
+  },
+  "avatarFraming": {
+    "scale": 0.65,
+    "x": 0,
+    "y": 1450
+  },
+  "motion": {
+    "intensity": 1
+  },
+  "blinkSeed": 42,
+  "lines": [
+    {
+      "text": "こんにちは。",
+      "chapter": "ごあいさつ",
+      "pauseAfter": 0.08
+    },
+    {
+      "text": "ここは AITuber OnAir のニュースデスク。",
+      "chapter": "ニュースデスクとは",
+      "pauseAfter": 0.08
+    },
+    {
+      "text": "新しいリリースを私がお知らせします。",
+      "pauseAfter": 0.08
+    }
+  ]
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/scripts/build.mjs
+++ b/packages/core/examples/node-inochi2d-newsdesk/scripts/build.mjs
@@ -1,0 +1,52 @@
+import { copyFile, mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { build } from 'esbuild';
+
+const root = resolve(process.cwd());
+const distDir = resolve(root, 'dist');
+const harnessDistDir = resolve(distDir, 'harness');
+
+await Promise.all([
+  mkdir(distDir, { recursive: true }),
+  mkdir(harnessDistDir, { recursive: true }),
+]);
+
+// Bundle the Core integration like the coding-agent example. Native, DOM-heavy,
+// and runtime-loaded agent SDK dependencies remain external.
+await build({
+  entryPoints: {
+    'script-gen': resolve(root, 'src/script-gen/cli.ts'),
+    gen: resolve(root, 'src/gen/cli.ts'),
+  },
+  outdir: distDir,
+  outExtension: { '.js': '.cjs' },
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node22',
+  sourcemap: true,
+  logLevel: 'info',
+  external: [
+    '@napi-rs/canvas',
+    'linkedom',
+    '@mozilla/readability',
+    '@openai/codex-sdk',
+    'playwright',
+  ],
+});
+
+await build({
+  entryPoints: [resolve(root, 'harness/main.ts')],
+  outfile: resolve(harnessDistDir, 'main.js'),
+  bundle: true,
+  platform: 'browser',
+  format: 'esm',
+  target: 'chrome120',
+  sourcemap: true,
+  logLevel: 'info',
+});
+
+await copyFile(
+  resolve(root, 'harness/index.html'),
+  resolve(harnessDistDir, 'index.html'),
+);

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/audio.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/audio.ts
@@ -1,0 +1,206 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { runCommand } from './process.js';
+
+export const SAMPLE_RATE = 48000;
+const CHANNELS = 1;
+const BYTES_PER_SAMPLE = 2;
+const SMOOTH_FACTOR = 0.5;
+const RMS_CEILING = 0.12;
+
+export interface DecodedAudio {
+  samples: Float32Array;
+  sampleRate: number;
+  duration: number;
+}
+
+interface ChunkLocation {
+  offset: number;
+  size: number;
+}
+
+function writeString(buffer: Buffer, offset: number, value: string): void {
+  buffer.write(value, offset, value.length, 'ascii');
+}
+
+function findChunk(buffer: Buffer, id: string): ChunkLocation | null {
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString('ascii', offset, offset + 4);
+    const size = buffer.readUInt32LE(offset + 4);
+    if (chunkId === id) return { offset: offset + 8, size };
+    offset += 8 + size + (size % 2);
+  }
+  return null;
+}
+
+function writeWavHeader(buffer: Buffer, dataSize: number, sampleRate: number) {
+  writeString(buffer, 0, 'RIFF');
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  writeString(buffer, 8, 'WAVE');
+  writeString(buffer, 12, 'fmt ');
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(CHANNELS, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * CHANNELS * BYTES_PER_SAMPLE, 28);
+  buffer.writeUInt16LE(CHANNELS * BYTES_PER_SAMPLE, 32);
+  buffer.writeUInt16LE(16, 34);
+  writeString(buffer, 36, 'data');
+  buffer.writeUInt32LE(dataSize, 40);
+}
+
+/** Convert any ffmpeg-readable audio file to 48 kHz mono PCM16 WAV. */
+export async function normalizeToWav(
+  inputPath: string,
+  outputPath: string,
+): Promise<number> {
+  await runCommand('ffmpeg', [
+    '-y',
+    '-v',
+    'error',
+    '-i',
+    inputPath,
+    '-ac',
+    '1',
+    '-ar',
+    String(SAMPLE_RATE),
+    '-sample_fmt',
+    's16',
+    '-acodec',
+    'pcm_s16le',
+    outputPath,
+  ]);
+  return getWavDuration(outputPath);
+}
+
+/** Write float samples (-1..1) as a mono PCM16 WAV and return its duration. */
+export async function writePcm16Wav(
+  filePath: string,
+  samples: Float32Array,
+  sampleRate: number = SAMPLE_RATE,
+): Promise<number> {
+  const dataSize = samples.length * BYTES_PER_SAMPLE;
+  const buffer = Buffer.alloc(44 + dataSize);
+  writeWavHeader(buffer, dataSize, sampleRate);
+  for (let index = 0; index < samples.length; index += 1) {
+    const value = Math.max(-1, Math.min(1, samples[index]));
+    buffer.writeInt16LE(Math.round(value * 32767), 44 + index * 2);
+  }
+  await writeFile(filePath, buffer);
+  return samples.length / sampleRate;
+}
+
+export async function writeSilenceWav(
+  filePath: string,
+  durationSec: number,
+): Promise<number> {
+  const frames = Math.max(0, Math.round(durationSec * SAMPLE_RATE));
+  return writePcm16Wav(filePath, new Float32Array(frames));
+}
+
+async function readPcmData(filePath: string): Promise<Buffer> {
+  const buffer = await readFile(filePath);
+  if (
+    buffer.toString('ascii', 0, 4) !== 'RIFF' ||
+    buffer.toString('ascii', 8, 12) !== 'WAVE'
+  ) {
+    throw new Error(`Not a RIFF/WAVE file: ${filePath}`);
+  }
+  const fmt = findChunk(buffer, 'fmt ');
+  const data = findChunk(buffer, 'data');
+  if (!fmt || !data) throw new Error(`Invalid WAV file: ${filePath}`);
+  const audioFormat = buffer.readUInt16LE(fmt.offset);
+  const channels = buffer.readUInt16LE(fmt.offset + 2);
+  const sampleRate = buffer.readUInt32LE(fmt.offset + 4);
+  const bitsPerSample = buffer.readUInt16LE(fmt.offset + 14);
+  if (
+    audioFormat !== 1 ||
+    channels !== 1 ||
+    sampleRate !== SAMPLE_RATE ||
+    bitsPerSample !== 16
+  ) {
+    throw new Error(`WAV must be 48kHz mono PCM16: ${filePath}`);
+  }
+  return buffer.subarray(data.offset, data.offset + data.size);
+}
+
+/** Concatenate 48 kHz mono PCM16 WAV files and return the total duration. */
+export async function concatWavs(
+  inputPaths: string[],
+  outputPath: string,
+): Promise<number> {
+  const chunks: Buffer[] = [];
+  for (const inputPath of inputPaths) chunks.push(await readPcmData(inputPath));
+  const data = Buffer.concat(chunks);
+  const buffer = Buffer.alloc(44 + data.length);
+  writeWavHeader(buffer, data.length, SAMPLE_RATE);
+  data.copy(buffer, 44);
+  await writeFile(outputPath, buffer);
+  return data.length / (SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE);
+}
+
+export async function getWavDuration(filePath: string): Promise<number> {
+  const data = await readPcmData(filePath);
+  return data.length / (SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE);
+}
+
+/** Decode a PCM WAV (8/16/24/32-bit, any channel count) to mono floats. */
+export async function decodeWav(filePath: string): Promise<DecodedAudio> {
+  const buffer = await readFile(filePath);
+  const fmt = findChunk(buffer, 'fmt ');
+  const dataChunk = findChunk(buffer, 'data');
+  if (!fmt || !dataChunk) throw new Error(`Invalid WAV file: ${filePath}`);
+  const audioFormat = buffer.readUInt16LE(fmt.offset);
+  const channels = buffer.readUInt16LE(fmt.offset + 2);
+  const sampleRate = buffer.readUInt32LE(fmt.offset + 4);
+  const bitsPerSample = buffer.readUInt16LE(fmt.offset + 14);
+  if (audioFormat !== 1 || ![8, 16, 24, 32].includes(bitsPerSample)) {
+    throw new Error(`Unsupported WAV format: ${filePath}`);
+  }
+  const bytesPerSample = bitsPerSample / 8;
+  const data = buffer.subarray(
+    dataChunk.offset,
+    dataChunk.offset + dataChunk.size,
+  );
+  const frameCount = Math.floor(data.length / (bytesPerSample * channels));
+  const samples = new Float32Array(frameCount);
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    let sum = 0;
+    for (let channel = 0; channel < channels; channel += 1) {
+      const offset = (frame * channels + channel) * bytesPerSample;
+      if (bytesPerSample === 1) sum += (data.readUInt8(offset) - 128) / 128;
+      else if (bytesPerSample === 2) sum += data.readInt16LE(offset) / 32768;
+      else if (bytesPerSample === 3) sum += data.readIntLE(offset, 3) / 8388608;
+      else sum += data.readInt32LE(offset) / 2147483648;
+    }
+    samples[frame] = sum / channels;
+  }
+  return { samples, sampleRate, duration: frameCount / sampleRate };
+}
+
+/**
+ * Derive a normalized (0..1) mouth-open value per video frame from the RMS
+ * level of the audio within that frame, lightly smoothed across frames.
+ */
+export function createMouthValues(
+  audio: Pick<DecodedAudio, 'samples' | 'sampleRate'>,
+  fps: number,
+  totalFrames: number,
+): Float32Array {
+  const values = new Float32Array(totalFrames);
+  let smoothed = 0;
+  for (let frame = 0; frame < totalFrames; frame += 1) {
+    const start = Math.floor((frame / fps) * audio.sampleRate);
+    const end = Math.min(
+      audio.samples.length,
+      Math.floor(((frame + 1) / fps) * audio.sampleRate),
+    );
+    let sumSq = 0;
+    for (let index = start; index < end; index += 1)
+      sumSq += audio.samples[index] ** 2;
+    const rms = Math.sqrt(sumSq / Math.max(1, end - start));
+    smoothed = smoothed * SMOOTH_FACTOR + rms * (1 - SMOOTH_FACTOR);
+    values[frame] = Math.min(smoothed / RMS_CEILING, 1);
+  }
+  return values;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/blink.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/blink.ts
@@ -1,0 +1,46 @@
+function mulberry32(seed: number): () => number {
+  let value = seed >>> 0;
+  return () => {
+    value += 0x6d2b79f5;
+    let next = value;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Build a deterministic per-frame blink schedule (1 = eyes closed). Blinks
+ * happen every 2-6 seconds and last 0.1-0.2 seconds; very short clips still
+ * get one blink near the middle.
+ */
+export function createBlinkSchedule(
+  totalFrames: number,
+  fps: number,
+  seed = 42,
+): Uint8Array {
+  const closed = new Uint8Array(totalFrames);
+  const random = mulberry32(seed);
+  let cursor = 0;
+  while (cursor < totalFrames) {
+    const start = Math.round(cursor + (2 + random() * 4) * fps);
+    const end = Math.min(
+      totalFrames,
+      start + Math.max(1, Math.round((0.1 + random() * 0.1) * fps)),
+    );
+    for (let frame = start; frame < end; frame += 1) closed[frame] = 1;
+    cursor = end;
+  }
+  if (
+    totalFrames >= Math.max(1, Math.round(fps * 0.5)) &&
+    !closed.includes(1)
+  ) {
+    const start = Math.max(0, Math.floor(totalFrames / 2));
+    const end = Math.min(
+      totalFrames,
+      start + Math.max(1, Math.round(fps * 0.12)),
+    );
+    for (let frame = start; frame < end; frame += 1) closed[frame] = 1;
+  }
+  return closed;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/cli.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/cli.ts
@@ -1,0 +1,592 @@
+#!/usr/bin/env node
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Writable } from 'node:stream';
+import { resolveFrom } from '../paths.js';
+import type {
+  NewsdeskScript,
+  RenderConfig,
+  ScriptLine,
+  ScriptVoice,
+  TimedText,
+} from '../types.js';
+import { DEFAULT_AVATAR_FRAMING } from '../types.js';
+import {
+  concatWavs,
+  createMouthValues,
+  decodeWav,
+  writeSilenceWav,
+} from './audio.js';
+import { createBlinkSchedule } from './blink.js';
+import * as aituberVoiceEngine from './engines/aituberVoice.js';
+import * as sayEngine from './engines/say.js';
+import * as sineEngine from './engines/sine.js';
+import type { SynthesisResult, VoiceEngine } from './engines/types.js';
+import { assertFfmpeg, encodeMp4, writeFrame } from './ffmpeg.js';
+import {
+  createRenderer,
+  type MotionDiagnostics,
+  type MouthState,
+  resolveMouthState,
+} from './renderer.js';
+import {
+  createInochi2DAvatar,
+  type Inochi2DAvatarDiagnostics,
+} from './inochi2dAvatar.js';
+
+const ENGINES: Record<ScriptVoice['engine'], VoiceEngine> = {
+  say: sayEngine,
+  sine: sineEngine,
+  'aituber-voice': aituberVoiceEngine,
+};
+
+export interface GenArgs {
+  script: string | null;
+  output: string | null;
+  dryRun: boolean;
+  keepTemp: boolean;
+  renderOnly: boolean;
+  frame: number | null;
+  png: string | null;
+  help: boolean;
+}
+
+interface GenerationPaths {
+  outputPath: string;
+  outputDir: string;
+  wavPath: string;
+  timingsPath: string;
+  configPath: string;
+  tempDir: string;
+}
+
+interface LineTiming extends TimedText {
+  index: number;
+  chapter: string | null;
+  spoken: boolean;
+  durationSec: number;
+  subtitleStart: number;
+  subtitleEnd: number;
+}
+
+interface SynthesisSummary {
+  segments: string[];
+  subtitles: TimedText[];
+  chapters: TimedText[];
+  timings: LineTiming[];
+  duration: number;
+  voice: ScriptVoice;
+}
+
+interface RenderSummary {
+  output?: string;
+  png?: string;
+  frame?: number;
+  frames?: number;
+  totalFrames?: number;
+  duration?: number;
+  mouthFrames: Record<MouthState, number>;
+  mouthExampleFrames: Record<MouthState, number | null>;
+  stateFrames: Record<string, number>;
+  blinkFrames?: number;
+  blinkExampleFrame: number | null;
+  averageMsPerFrame: number;
+  avatarDiagnostics: Inochi2DAvatarDiagnostics;
+  motionSamples: Array<
+    MotionDiagnostics & {
+      frame: number;
+      time: number;
+      mouthValue: number;
+    }
+  >;
+}
+
+function takeValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--'))
+    throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+/** Parse video generation CLI arguments. */
+export function parseArgs(argv: string[]): GenArgs {
+  const args: GenArgs = {
+    script: null,
+    output: null,
+    dryRun: false,
+    keepTemp: false,
+    renderOnly: false,
+    frame: null,
+    png: null,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--script')
+      args.script = takeValue(argv, index++, argument);
+    else if (argument === '--output')
+      args.output = takeValue(argv, index++, argument);
+    else if (argument === '--dry-run') args.dryRun = true;
+    else if (argument === '--keep-temp') args.keepTemp = true;
+    else if (argument === '--render-only') args.renderOnly = true;
+    else if (argument === '--frame')
+      args.frame = Number(takeValue(argv, index++, argument));
+    else if (argument === '--png')
+      args.png = takeValue(argv, index++, argument);
+    else if (argument === '--help' || argument === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  return args;
+}
+
+function usage(): string {
+  return `Usage:
+  npm run gen -- --script <script.json> [--output <video.mp4>]
+  npm run gen -- --script <script.json> [--output <video.mp4>] --dry-run
+  npm run gen -- --script <script.json> [--output <video.mp4>] --render-only
+  npm run gen -- --script <script.json> --frame 45 --png work/frame45.png`;
+}
+
+function validateArgs(args: GenArgs): asserts args is GenArgs & {
+  script: string;
+} {
+  if (!args.script) throw new Error('--script is required.');
+  if ((args.frame === null) !== (args.png === null))
+    throw new Error('--frame and --png must be used together.');
+  if (args.frame !== null && (!Number.isFinite(args.frame) || args.frame < 0))
+    throw new Error('--frame must be a non-negative number.');
+  if (args.dryRun && args.png)
+    throw new Error('--dry-run cannot be combined with --frame/--png.');
+  if (args.renderOnly && (args.dryRun || args.png)) {
+    throw new Error(
+      '--render-only cannot be combined with --dry-run or --frame/--png.',
+    );
+  }
+}
+
+function normalizeMotionIntensity(value: unknown): number {
+  const intensity = Number(value ?? 1);
+  return Number.isFinite(intensity) ? Math.max(0, Math.min(3, intensity)) : 1;
+}
+
+function createPaths(
+  scriptPath: string,
+  scriptOutput: string | undefined,
+  cliOutput: string | null,
+): GenerationPaths {
+  const outputPath = cliOutput
+    ? path.resolve(cliOutput)
+    : resolveFrom(scriptPath, scriptOutput || 'out.mp4');
+  const parsed = path.parse(outputPath);
+  return {
+    outputPath,
+    outputDir: parsed.dir,
+    wavPath: path.join(parsed.dir, `${parsed.name}.wav`),
+    timingsPath: path.join(parsed.dir, `${parsed.name}.timings.json`),
+    configPath: path.join(
+      parsed.dir,
+      `${parsed.name}.inochi2d-gen.config.json`,
+    ),
+    tempDir: path.join(
+      parsed.dir,
+      `.inochi2d-gen-${parsed.name}-${process.pid}`,
+    ),
+  };
+}
+
+function requireFiniteDuration(line: ScriptLine, index: number): number {
+  if (
+    typeof line.duration !== 'number' ||
+    !Number.isFinite(line.duration) ||
+    line.duration < 0
+  ) {
+    throw new Error(
+      `lines[${index}].duration is required when spoken is false.`,
+    );
+  }
+  return line.duration;
+}
+
+async function synthesizeLines(
+  script: NewsdeskScript,
+  tempDir: string,
+): Promise<SynthesisSummary> {
+  const voice: ScriptVoice = script.voice || {
+    engine: 'say',
+    options: { voice: 'Kyoko', rate: 200 },
+  };
+  const engine = ENGINES[voice.engine];
+  if (!engine) {
+    throw new Error(
+      `Unsupported voice engine "${voice.engine}". Supported: ${Object.keys(ENGINES).join(', ')}`,
+    );
+  }
+  const segments: string[] = [];
+  const subtitles: TimedText[] = [];
+  const chapters: TimedText[] = [];
+  const timings: LineTiming[] = [];
+  let cursor = 0;
+  const defaultPause = Number(script.defaultPauseAfter ?? 0.35);
+
+  if (Number(script.leadIn ?? 0) > 0) {
+    const wavPath = path.join(tempDir, 'lead-in.wav');
+    const durationSec = await writeSilenceWav(wavPath, Number(script.leadIn));
+    segments.push(wavPath);
+    cursor += durationSec;
+  }
+
+  for (let index = 0; index < script.lines.length; index += 1) {
+    const line = script.lines[index];
+    if (typeof line.text !== 'string' || !line.text) {
+      throw new Error(`lines[${index}].text must be a non-empty string.`);
+    }
+    const workDir = path.join(
+      tempDir,
+      `line-${String(index + 1).padStart(3, '0')}`,
+    );
+    await mkdir(workDir, { recursive: true });
+    const spoken = line.spoken !== false;
+    const start = cursor;
+    let result: SynthesisResult;
+    if (spoken) {
+      result = await engine.synthesize(
+        line.reading || line.text,
+        voice.options || {},
+        workDir,
+      );
+    } else {
+      const wavPath = path.join(workDir, 'silence.wav');
+      result = {
+        wavPath,
+        durationSec: await writeSilenceWav(
+          wavPath,
+          requireFiniteDuration(line, index),
+        ),
+      };
+    }
+    segments.push(result.wavPath);
+    cursor += result.durationSec;
+    const end = cursor;
+    const subtitleStart = Math.max(0, start - 0.05);
+    const subtitleEnd = end + 0.15;
+    subtitles.push({ text: line.text, start: subtitleStart, end: subtitleEnd });
+    if (typeof line.chapter === 'string' && line.chapter.trim()) {
+      const previous = chapters.at(-1);
+      if (previous) previous.end = subtitleStart;
+      chapters.push({
+        text: line.chapter,
+        start: chapters.length === 0 ? 0 : subtitleStart,
+        end: 0,
+      });
+    }
+    timings.push({
+      index,
+      text: line.text,
+      chapter: typeof line.chapter === 'string' ? line.chapter : null,
+      spoken,
+      start,
+      end,
+      durationSec: result.durationSec,
+      subtitleStart,
+      subtitleEnd,
+    });
+    const pause = Number(line.pauseAfter ?? defaultPause);
+    if (pause > 0) {
+      const wavPath = path.join(workDir, 'pause.wav');
+      segments.push(wavPath);
+      cursor += await writeSilenceWav(wavPath, pause);
+    }
+  }
+
+  if (Number(script.leadOut ?? 0) > 0) {
+    const wavPath = path.join(tempDir, 'lead-out.wav');
+    segments.push(wavPath);
+    cursor += await writeSilenceWav(wavPath, Number(script.leadOut));
+  }
+  const finalChapter = chapters.at(-1);
+  if (finalChapter) finalChapter.end = cursor + 1;
+  return {
+    segments,
+    subtitles,
+    chapters,
+    timings,
+    duration: cursor,
+    voice,
+  };
+}
+
+async function render(
+  config: RenderConfig,
+  args: GenArgs,
+): Promise<RenderSummary> {
+  const audio = await decodeWav(config.audio);
+  const avatar = await createInochi2DAvatar(config);
+  // ffmpeg uses `-shortest`, so a partial trailing frame would be dropped when
+  // the WAV ends. Count only complete frames so the summary matches the MP4.
+  const totalFrames = Math.max(1, Math.floor(config.duration * config.fps));
+  const mouthValues = createMouthValues(audio, config.fps, totalFrames);
+  const blink = createBlinkSchedule(totalFrames, config.fps, config.blinkSeed);
+  const renderer = await createRenderer(config, avatar);
+  const targetFrame =
+    args.png && args.frame !== null
+      ? Math.max(0, Math.min(totalFrames - 1, Math.floor(args.frame)))
+      : null;
+  const mouthFrames: Record<MouthState, number> = {
+    closed: 0,
+    open: 0,
+  };
+  const mouthExampleFrames: Record<MouthState, number | null> = {
+    closed: null,
+    open: null,
+  };
+  const stateFrames: Record<string, number> = {
+    mouth_closed_eyes_open: 0,
+    mouth_closed_eyes_closed: 0,
+    mouth_open_eyes_open: 0,
+    mouth_open_eyes_closed: 0,
+  };
+  let blinkExampleFrame: number | null = null;
+  const samples: RenderSummary['motionSamples'] = [];
+  let avatarFrameMs = 0;
+  let renderedFrames = 0;
+  const sampleFrames = new Set([
+    0,
+    Math.floor(totalFrames / 3),
+    Math.floor((totalFrames * 2) / 3),
+    totalFrames - 1,
+  ]);
+
+  const renderOne = async (frame: number): Promise<void> => {
+    const mouthState = resolveMouthState(mouthValues[frame]);
+    const eyesClosed = Boolean(blink[frame]);
+    if (eyesClosed) blinkExampleFrame ??= frame;
+    mouthFrames[mouthState] += 1;
+    mouthExampleFrames[mouthState] ??= frame;
+    stateFrames[`mouth_${mouthState}_eyes_${eyesClosed ? 'closed' : 'open'}`] +=
+      1;
+    const diagnostics = await renderer.render(
+      frame,
+      mouthValues[frame],
+      eyesClosed,
+    );
+    avatarFrameMs += diagnostics.avatarFrameMs;
+    renderedFrames += 1;
+    if (sampleFrames.has(frame)) {
+      samples.push({
+        frame,
+        time: frame / config.fps,
+        mouthValue: mouthValues[frame],
+        ...diagnostics,
+      });
+    }
+  };
+
+  const summaryFields = () => ({
+    mouthFrames,
+    mouthExampleFrames,
+    stateFrames,
+    blinkExampleFrame,
+    averageMsPerFrame:
+      renderedFrames === 0 ? 0 : avatarFrameMs / renderedFrames,
+    avatarDiagnostics: avatar.diagnostics,
+    motionSamples: samples,
+  });
+
+  try {
+    if (args.png && targetFrame !== null) {
+      for (let frame = 0; frame <= targetFrame; frame += 1) {
+        await renderOne(frame);
+      }
+      const pngPath = path.resolve(args.png);
+      await mkdir(path.dirname(pngPath), { recursive: true });
+      await writeFile(pngPath, renderer.canvas.toBuffer('image/png'));
+      return {
+        png: pngPath,
+        frame: targetFrame,
+        totalFrames,
+        ...summaryFields(),
+      };
+    }
+
+    await encodeMp4({
+      config,
+      writeFrames: async (stdin: Writable) => {
+        for (let frame = 0; frame < totalFrames; frame += 1) {
+          await renderOne(frame);
+          await writeFrame(stdin, renderer.rgba());
+          if ((frame + 1) % config.fps === 0 || frame === totalFrames - 1) {
+            console.error(
+              `Rendered ${frame + 1}/${totalFrames} Inochi2D frames ` +
+                `(${(avatarFrameMs / renderedFrames).toFixed(1)} ms/frame).`,
+            );
+          }
+        }
+      },
+    });
+    return {
+      output: config.output,
+      frames: totalFrames,
+      duration: totalFrames / config.fps,
+      blinkFrames: blink.reduce((sum, value) => sum + value, 0),
+      ...summaryFields(),
+    };
+  } finally {
+    await avatar.close();
+  }
+}
+
+function parseScript(raw: string): NewsdeskScript {
+  const value = JSON.parse(raw) as Partial<NewsdeskScript>;
+  if (!Array.isArray(value.lines) || value.lines.length === 0)
+    throw new Error('script.json must include a non-empty lines array.');
+  if (typeof value.avatar !== 'string' || value.avatar.trim() === '') {
+    throw new Error('script.json must include an Inochi2D .inx avatar path.');
+  }
+  if (!value.avatar.toLowerCase().endsWith('.inx')) {
+    throw new Error('script.json avatar must point to an .inx file.');
+  }
+  if (
+    typeof value.inochi2dRuntime !== 'string' ||
+    value.inochi2dRuntime.trim() === ''
+  ) {
+    throw new Error(
+      'script.json must include the local Inochi2D runtime directory.',
+    );
+  }
+  if (
+    value.avatarMotion !== undefined &&
+    (typeof value.avatarMotion !== 'string' ||
+      !value.avatarMotion.toLowerCase().endsWith('.json'))
+  ) {
+    throw new Error('script.json avatarMotion must point to a JSON file.');
+  }
+  return value as NewsdeskScript;
+}
+
+/** Execute the video generation CLI. */
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  validateArgs(args);
+
+  const scriptPath = path.resolve(args.script);
+  const script = parseScript(await readFile(scriptPath, 'utf8'));
+  const paths = createPaths(scriptPath, script.output, args.output);
+  await mkdir(paths.outputDir, { recursive: true });
+  await assertFfmpeg();
+
+  if (args.renderOnly) {
+    const config = JSON.parse(
+      await readFile(paths.configPath, 'utf8'),
+    ) as RenderConfig;
+    const result = await render(config, args);
+    console.log(
+      JSON.stringify(
+        {
+          audio: config.audio,
+          config: paths.configPath,
+          output: config.output,
+          duration: config.duration,
+          renderOnly: true,
+          render: result,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  await mkdir(paths.tempDir, { recursive: true });
+  try {
+    const synthesis = await synthesizeLines(script, paths.tempDir);
+    await concatWavs(synthesis.segments, paths.wavPath);
+    const config: RenderConfig = {
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      background: {
+        color: '#20242c',
+        ...script.background,
+      },
+      avatarLayout: {
+        scale: 1,
+        x: 0.5,
+        y: 0.5,
+        ...script.avatarLayout,
+      },
+      avatarFraming: {
+        ...DEFAULT_AVATAR_FRAMING,
+        ...script.avatarFraming,
+      },
+      avatarMotion: script.avatarMotion
+        ? resolveFrom(scriptPath, script.avatarMotion)
+        : null,
+      inochi2dRuntime: resolveFrom(scriptPath, script.inochi2dRuntime),
+      motion: {
+        intensity: normalizeMotionIntensity(script.motion?.intensity),
+      },
+      blinkSeed: Number(script.blinkSeed ?? 42),
+      avatar: resolveFrom(scriptPath, script.avatar),
+      audio: paths.wavPath,
+      output: paths.outputPath,
+      telop: script.telop || '',
+      subtitles: synthesis.subtitles,
+      chapters: synthesis.chapters,
+      duration: synthesis.duration,
+    };
+    if (config.background.image) {
+      config.background.image = resolveFrom(
+        scriptPath,
+        config.background.image,
+      );
+    }
+    await writeFile(paths.configPath, JSON.stringify(config, null, 2), 'utf8');
+    await writeFile(
+      paths.timingsPath,
+      JSON.stringify(
+        {
+          script: scriptPath,
+          voice: synthesis.voice,
+          audio: paths.wavPath,
+          output: paths.outputPath,
+          duration: synthesis.duration,
+          lines: synthesis.timings,
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const result = args.dryRun ? null : await render(config, args);
+    console.log(
+      JSON.stringify(
+        {
+          audio: paths.wavPath,
+          timings: paths.timingsPath,
+          config: paths.configPath,
+          output: args.dryRun || args.png ? null : paths.outputPath,
+          duration: synthesis.duration,
+          dryRun: args.dryRun,
+          render: result,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (!args.keepTemp)
+      await rm(paths.tempDir, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.stack : String(error));
+    process.exit(1);
+  });
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/aituberVoice.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/aituberVoice.ts
@@ -1,0 +1,86 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  VoiceEngineAdapter,
+  type AudioPlayOptions,
+  type VoiceServiceOptions,
+} from '@aituber-onair/core';
+import { normalizeToWav } from '../audio.js';
+import type { SynthesisResult } from './types.js';
+
+const DEFAULT_AIVIS_SPEECH_URL = 'http://127.0.0.1:10101';
+
+interface AdapterOptions extends Record<string, unknown> {
+  engineType?: string;
+  aivisSpeechApiUrl?: string;
+  onPlay?: (
+    audioBuffer: ArrayBuffer,
+    options?: AudioPlayOptions,
+  ) => Promise<void>;
+}
+
+/** Synthesize through Core's VoiceEngineAdapter and capture its onPlay audio. */
+export async function synthesize(
+  text: string,
+  rawOptions: Record<string, unknown>,
+  workDir: string,
+): Promise<SynthesisResult> {
+  await mkdir(workDir, { recursive: true });
+  const options = rawOptions as AdapterOptions;
+  if (options.engineType === 'aivisSpeech') {
+    await assertAivisSpeechAvailable(
+      options.aivisSpeechApiUrl || DEFAULT_AIVIS_SPEECH_URL,
+    );
+  }
+
+  const sourceWavPath = path.join(workDir, 'adapter.wav');
+  const wavPath = path.join(workDir, 'voice.wav');
+  let audioBuffer: ArrayBuffer | null = null;
+  const callerOnPlay = options.onPlay;
+  const adapter = new VoiceEngineAdapter({
+    ...options,
+    onPlay: async (buffer: ArrayBuffer, playOptions?: AudioPlayOptions) => {
+      audioBuffer = buffer;
+      await callerOnPlay?.(buffer, playOptions);
+    },
+  } as unknown as VoiceServiceOptions);
+
+  try {
+    await adapter.speakText(text);
+  } catch (error) {
+    if (options.engineType === 'aivisSpeech') {
+      const url = options.aivisSpeechApiUrl || DEFAULT_AIVIS_SPEECH_URL;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `AivisSpeech synthesis failed at ${url}. Confirm AivisSpeech is ` +
+          `running and the speaker/style ID is installed.\n${message}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (!audioBuffer) {
+    throw new Error(
+      `VoiceEngineAdapter (${options.engineType || 'unknown'}) returned no audio buffer.`,
+    );
+  }
+  await writeFile(sourceWavPath, Buffer.from(audioBuffer));
+  const durationSec = await normalizeToWav(sourceWavPath, wavPath);
+  return { wavPath, durationSec };
+}
+
+async function assertAivisSpeechAvailable(url: string): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5_000);
+  try {
+    await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot connect to AivisSpeech at ${url}.\nStart AivisSpeech: 1) launch the AivisSpeech application, 2) wait for its API server to start, 3) confirm aivisSpeechApiUrl and retry.\n${message}`,
+      { cause: error },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/say.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/say.ts
@@ -1,0 +1,51 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { normalizeToWav } from '../audio.js';
+import { runCommand } from '../process.js';
+import type { SynthesisResult } from './types.js';
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function assertVoiceAvailable(voice: string): Promise<void> {
+  let output: Awaited<ReturnType<typeof runCommand>>;
+  try {
+    output = await runCommand('say', ['-v', '?']);
+  } catch {
+    throw new Error(
+      'macOS say command is not available. This engine requires macOS.',
+    );
+  }
+  if (!new RegExp(`^${escapeRegExp(voice)}\\s+`, 'm').test(output.stdout))
+    throw new Error(`Voice "${voice}" is not installed.`);
+}
+
+/** Synthesize speech with the macOS `say` command. */
+export async function synthesize(
+  text: string,
+  options: Record<string, unknown>,
+  workDir: string,
+): Promise<SynthesisResult> {
+  await mkdir(workDir, { recursive: true });
+  const voice = String(options.voice ?? 'Kyoko');
+  const rateValue = Number(options.rate ?? 200);
+  const rate = Number.isFinite(rateValue) ? rateValue : 200;
+  await assertVoiceAvailable(voice);
+  const textPath = path.join(workDir, 'input.txt');
+  const aiffPath = path.join(workDir, 'voice.aiff');
+  const wavPath = path.join(workDir, 'voice.wav');
+  await writeFile(textPath, text, 'utf8');
+  await runCommand('say', [
+    '-v',
+    voice,
+    '-r',
+    String(rate),
+    '-f',
+    textPath,
+    '-o',
+    aiffPath,
+  ]);
+  const durationSec = await normalizeToWav(aiffPath, wavPath);
+  return { wavPath, durationSec };
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/sine.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/sine.ts
@@ -1,0 +1,49 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { SAMPLE_RATE, writePcm16Wav } from '../audio.js';
+import type { SynthesisResult } from './types.js';
+
+function numberOption(
+  options: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
+  const value = Number(options[key] ?? fallback);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/** Generate deterministic gated sine-wave speech for tests and demos. */
+export async function synthesize(
+  text: string,
+  options: Record<string, unknown>,
+  workDir: string,
+): Promise<SynthesisResult> {
+  await mkdir(workDir, { recursive: true });
+  const frequency = numberOption(options, 'frequency', 440);
+  const secondsPerChar = numberOption(options, 'secondsPerChar', 0.08);
+  const durationSec = Math.max(
+    numberOption(options, 'minDuration', 0.5),
+    Array.from(text.replace(/\s/g, '')).length * secondsPerChar,
+  );
+  const frames = Math.round(durationSec * SAMPLE_RATE);
+  const samples = new Float32Array(frames);
+  const amplitude = numberOption(options, 'amplitude', 0.22);
+  for (let index = 0; index < frames; index += 1) {
+    const time = index / SAMPLE_RATE;
+    const gate = Math.floor(time / 0.09) % 2 === 0 ? 1 : 0.15;
+    const fadeIn = Math.min(1, index / Math.round(SAMPLE_RATE * 0.02));
+    const fadeOut = Math.min(
+      1,
+      (frames - index) / Math.round(SAMPLE_RATE * 0.02),
+    );
+    samples[index] =
+      Math.sin(2 * Math.PI * frequency * time) *
+      amplitude *
+      gate *
+      fadeIn *
+      fadeOut;
+  }
+  const wavPath = path.join(workDir, 'voice.wav');
+  const actualDuration = await writePcm16Wav(wavPath, samples, SAMPLE_RATE);
+  return { wavPath, durationSec: actualDuration };
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/types.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/engines/types.ts
@@ -1,0 +1,12 @@
+export interface SynthesisResult {
+  wavPath: string;
+  durationSec: number;
+}
+
+export interface VoiceEngine {
+  synthesize(
+    text: string,
+    options: Record<string, unknown>,
+    workDir: string,
+  ): Promise<SynthesisResult>;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/ffmpeg.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/ffmpeg.ts
@@ -1,0 +1,110 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import type { Writable } from 'node:stream';
+import type { RenderConfig } from '../types.js';
+
+export function assertFfmpeg(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('ffmpeg', ['-version'], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    child.on('error', () =>
+      reject(new Error('ffmpeg is not installed or not on PATH.')),
+    );
+    child.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error('ffmpeg check failed.')),
+    );
+  });
+}
+
+/** Write one raw RGBA frame, waiting for back-pressure to clear. */
+export async function writeFrame(
+  stream: Writable,
+  frame: Buffer,
+): Promise<void> {
+  if (!stream.write(frame)) await once(stream, 'drain');
+}
+
+export interface EncodeMp4Options {
+  config: RenderConfig;
+  writeFrames: (stdin: Writable) => Promise<void>;
+}
+
+/**
+ * Encode raw RGBA frames from stdin plus the narration WAV into an H.264/AAC
+ * MP4. Encoder flags are chosen for deterministic output so the same script
+ * renders byte-identically.
+ */
+export function encodeMp4({
+  config,
+  writeFrames,
+}: EncodeMp4Options): Promise<void> {
+  const args = [
+    '-y',
+    '-v',
+    'error',
+    '-f',
+    'rawvideo',
+    '-pixel_format',
+    'rgba',
+    '-video_size',
+    `${config.width}x${config.height}`,
+    '-framerate',
+    String(config.fps),
+    '-i',
+    'pipe:0',
+    '-i',
+    config.audio,
+    '-map',
+    '0:v:0',
+    '-map',
+    '1:a:0',
+    '-map_metadata',
+    '-1',
+    '-c:v',
+    'libx264',
+    '-preset',
+    'medium',
+    '-crf',
+    '18',
+    '-pix_fmt',
+    'yuv420p',
+    '-r',
+    String(config.fps),
+    '-threads',
+    '1',
+    '-flags:v',
+    '+bitexact',
+    '-c:a',
+    'aac',
+    '-b:a',
+    '160k',
+    '-flags:a',
+    '+bitexact',
+    '-shortest',
+    '-movflags',
+    '+faststart',
+    config.output,
+  ];
+  return new Promise((resolve, reject) => {
+    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`ffmpeg exited with code ${code}\n${stderr}`)),
+    );
+    Promise.resolve()
+      .then(() => writeFrames(child.stdin))
+      .then(() => child.stdin.end())
+      .catch((error: Error) => {
+        child.stdin.destroy(error);
+        child.kill('SIGTERM');
+        reject(error);
+      });
+  });
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/inochi2dAvatar.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/inochi2dAvatar.ts
@@ -1,0 +1,424 @@
+import { createReadStream } from 'node:fs';
+import { access, realpath, stat } from 'node:fs/promises';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import type { AddressInfo } from 'node:net';
+import { type Image, loadImage } from '@napi-rs/canvas';
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from 'playwright';
+import { resolveProjectRoot } from '../paths.js';
+import { DEFAULT_IDLE_ANIMATION, type RenderConfig } from '../types.js';
+
+const REQUIRED_RUNTIME_FILES = [
+  'inochi_bridge.js',
+  'inochi2d.js',
+  'inochi2d_bg.wasm',
+  'secondary_motion.js',
+] as const;
+const SWIFTSHADER_ARGS = [
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+];
+
+export interface Inochi2DAvatarDiagnostics {
+  runtime: string;
+  canvasSize: { width: number; height: number };
+  mouthParameterId: string;
+  mouthParameterKind: 'vec2' | 'scalar';
+  eyeParameterIds: string[];
+  idleAnimation: string;
+  idleAnimationActive: boolean;
+  avatarFraming: { scale: number; x: number; y: number };
+  virtualClock: {
+    seed: number;
+    timeMs: number;
+    callbacksPerFrame: number;
+    pendingCallbacks: number;
+  };
+  launchMode: 'swiftshader' | 'default-gl';
+  captureMode: 'playwright-png-screenshot';
+}
+
+export interface Inochi2DFrameInput {
+  frameNumber: number;
+  time: number;
+  deltaSeconds: number;
+  mouth: number;
+  eyesClosed: boolean;
+}
+
+export interface Inochi2DAvatarFrame {
+  image: Image;
+  elapsedMs: number;
+}
+
+export interface Inochi2DFrameSource {
+  width: number;
+  height: number;
+  diagnostics: Inochi2DAvatarDiagnostics;
+  renderFrame(input: Inochi2DFrameInput): Promise<Inochi2DAvatarFrame>;
+  close(): Promise<void>;
+}
+
+interface HarnessServer {
+  server: Server;
+  origin: string;
+}
+
+interface BrowserSession {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  diagnostics: Inochi2DAvatarDiagnostics;
+}
+
+type BrowserLoadDiagnostics = Omit<
+  Inochi2DAvatarDiagnostics,
+  'launchMode' | 'captureMode'
+>;
+
+function contentType(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (lower.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (lower.endsWith('.json')) return 'application/json; charset=utf-8';
+  if (lower.endsWith('.wasm')) return 'application/wasm';
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  return 'application/octet-stream';
+}
+
+async function sendFile(
+  response: ServerResponse,
+  filePath: string,
+): Promise<void> {
+  try {
+    const metadata = await stat(filePath);
+    if (!metadata.isFile()) {
+      response.writeHead(404);
+      response.end('File unavailable.');
+      return;
+    }
+    response.writeHead(200, {
+      'Content-Type': contentType(filePath),
+      'Content-Length': metadata.size,
+      'Cache-Control': 'no-store',
+    });
+    createReadStream(filePath).pipe(response);
+  } catch (error) {
+    response.writeHead(
+      (error as NodeJS.ErrnoException).code === 'ENOENT' ? 404 : 500,
+    );
+    response.end('File unavailable.');
+  }
+}
+
+/** Resolve a URL beneath one read-only root, rejecting every escape attempt. */
+export function resolveLocalAssetPath(
+  rootDirectory: string,
+  routePrefix: string,
+  requestPath: string,
+): string | null {
+  if (!requestPath.startsWith(routePrefix)) return null;
+  let relative: string;
+  try {
+    relative = decodeURIComponent(requestPath.slice(routePrefix.length));
+  } catch {
+    return null;
+  }
+  const normalized = relative.replaceAll('\\', '/');
+  const segments = normalized.split('/');
+  if (
+    normalized === '' ||
+    path.isAbsolute(normalized) ||
+    segments.some(
+      (segment) => segment === '' || segment === '.' || segment === '..',
+    )
+  ) {
+    return null;
+  }
+  const root = path.resolve(rootDirectory);
+  const candidate = path.resolve(root, ...segments);
+  return candidate.startsWith(`${root}${path.sep}`) ? candidate : null;
+}
+
+/** Backward-friendly model-route helper used by the path security tests. */
+export function resolveModelAssetPath(
+  modelRoot: string,
+  requestPath: string,
+): string | null {
+  return resolveLocalAssetPath(modelRoot, '/model/', requestPath);
+}
+
+async function sendRootedFile(
+  response: ServerResponse,
+  rootDirectory: string,
+  routePrefix: string,
+  requestPath: string,
+): Promise<void> {
+  const candidate = resolveLocalAssetPath(
+    rootDirectory,
+    routePrefix,
+    requestPath,
+  );
+  if (!candidate) {
+    response.writeHead(403);
+    response.end('Invalid local asset path.');
+    return;
+  }
+  try {
+    const [rootRealPath, candidateRealPath] = await Promise.all([
+      realpath(rootDirectory),
+      realpath(candidate),
+    ]);
+    if (!candidateRealPath.startsWith(`${rootRealPath}${path.sep}`)) {
+      response.writeHead(403);
+      response.end('Local asset escapes its root.');
+      return;
+    }
+    await sendFile(response, candidateRealPath);
+  } catch (error) {
+    response.writeHead(
+      (error as NodeJS.ErrnoException).code === 'ENOENT' ? 404 : 500,
+    );
+    response.end('Local asset unavailable.');
+  }
+}
+
+async function startHarnessServer(
+  config: RenderConfig,
+): Promise<HarnessServer> {
+  const harnessDirectory = path.join(resolveProjectRoot(), 'dist', 'harness');
+  const modelRoot = path.dirname(config.avatar);
+  const motionRoot = config.avatarMotion
+    ? path.dirname(config.avatarMotion)
+    : null;
+  const server = createServer((request, response) => {
+    const url = new URL(request.url || '/', 'http://127.0.0.1');
+    if (request.method !== 'GET') {
+      response.writeHead(405);
+      response.end('Method not allowed.');
+      return;
+    }
+
+    if (url.pathname === '/' || url.pathname === '/harness/index.html') {
+      void sendFile(response, path.join(harnessDirectory, 'index.html'));
+    } else if (url.pathname === '/harness/main.js') {
+      void sendFile(response, path.join(harnessDirectory, 'main.js'));
+    } else if (url.pathname.startsWith('/runtime/')) {
+      void sendRootedFile(
+        response,
+        config.inochi2dRuntime,
+        '/runtime/',
+        url.pathname,
+      );
+    } else if (url.pathname.startsWith('/model/')) {
+      void sendRootedFile(response, modelRoot, '/model/', url.pathname);
+    } else if (motionRoot && url.pathname.startsWith('/motion/')) {
+      void sendRootedFile(response, motionRoot, '/motion/', url.pathname);
+    } else {
+      response.writeHead(404);
+      response.end('Not found.');
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    server.close();
+    throw new Error('The Inochi2D harness server did not expose an address.');
+  }
+  return { server, origin: `http://127.0.0.1:${address.port}` };
+}
+
+async function stopServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function launchSession(
+  origin: string,
+  config: RenderConfig,
+  launchMode: Inochi2DAvatarDiagnostics['launchMode'],
+): Promise<BrowserSession> {
+  const browser = await chromium.launch({
+    headless: true,
+    args: launchMode === 'swiftshader' ? SWIFTSHADER_ARGS : [],
+  });
+  const context = await browser.newContext({
+    viewport: { width: config.width, height: config.height },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  try {
+    await page.goto(`${origin}/harness/index.html`, { waitUntil: 'load' });
+    await page.waitForFunction(
+      () =>
+        typeof (window as unknown as { load?: unknown }).load === 'function',
+    );
+    const loaded = await page.evaluate(
+      async (options) => {
+        const harnessWindow = window as unknown as {
+          load(value: typeof options): Promise<BrowserLoadDiagnostics>;
+        };
+        return harnessWindow.load(options);
+      },
+      {
+        bridgeUrl: '/runtime/inochi_bridge.js',
+        wasmUrl: '/runtime/inochi2d_bg.wasm',
+        modelUrl: `/model/${encodeURIComponent(path.basename(config.avatar))}`,
+        motionUrl: config.avatarMotion
+          ? `/motion/${encodeURIComponent(path.basename(config.avatarMotion))}`
+          : undefined,
+        width: config.width,
+        height: config.height,
+        blinkSeed: config.blinkSeed,
+        avatarFraming: config.avatarFraming,
+        idleAnimation: DEFAULT_IDLE_ANIMATION,
+        motionIntensity: config.motion.intensity,
+      },
+    );
+    return {
+      browser,
+      context,
+      page,
+      diagnostics: {
+        ...(loaded as BrowserLoadDiagnostics),
+        launchMode,
+        captureMode: 'playwright-png-screenshot',
+      },
+    };
+  } catch (error) {
+    await browser.close();
+    throw error;
+  }
+}
+
+function isMissingBrowser(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Executable doesn't exist|playwright install/i.test(message);
+}
+
+async function connectBrowser(
+  origin: string,
+  config: RenderConfig,
+): Promise<BrowserSession> {
+  try {
+    return await launchSession(origin, config, 'swiftshader');
+  } catch (error) {
+    if (isMissingBrowser(error)) throw error;
+    console.error(
+      `SwiftShader Inochi2D harness failed; retrying default GL: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return launchSession(origin, config, 'default-gl');
+  }
+}
+
+async function requireLocalFile(
+  filePath: string,
+  label: string,
+): Promise<void> {
+  try {
+    const metadata = await stat(filePath);
+    if (!metadata.isFile()) throw new Error('not a file');
+  } catch (error) {
+    throw new Error(`${label} was not found at ${filePath}.`, { cause: error });
+  }
+}
+
+async function requireRuntime(runtimeDirectory: string): Promise<void> {
+  await Promise.all(
+    REQUIRED_RUNTIME_FILES.map((fileName) =>
+      requireLocalFile(
+        path.join(runtimeDirectory, fileName),
+        `Inochi2D runtime file ${fileName}`,
+      ),
+    ),
+  );
+  await access(runtimeDirectory);
+}
+
+/** Start one headless-Chromium Inochi2D frame source for a complete render. */
+export async function createInochi2DAvatar(
+  config: RenderConfig,
+): Promise<Inochi2DFrameSource> {
+  await requireRuntime(config.inochi2dRuntime);
+  await requireLocalFile(config.avatar, 'Inochi2D model');
+  if (!config.avatar.toLowerCase().endsWith('.inx')) {
+    throw new Error('Inochi2D avatar must point to an .inx file.');
+  }
+  if (config.avatarMotion) {
+    await requireLocalFile(config.avatarMotion, 'Inochi2D motion');
+    if (!config.avatarMotion.toLowerCase().endsWith('.json')) {
+      throw new Error('Inochi2D avatarMotion must point to a JSON file.');
+    }
+  }
+
+  const harness = await startHarnessServer(config);
+  let session: BrowserSession;
+  try {
+    session = await connectBrowser(harness.origin, config);
+  } catch (error) {
+    await stopServer(harness.server);
+    throw error;
+  }
+
+  let nextFrame = 0;
+  let closed = false;
+  return {
+    width: config.width,
+    height: config.height,
+    diagnostics: session.diagnostics,
+    async renderFrame(input) {
+      if (input.frameNumber !== nextFrame) {
+        throw new Error(
+          `Inochi2D frames must be sequential (expected ${nextFrame}, ` +
+            `got ${input.frameNumber}).`,
+        );
+      }
+      const startedAt = performance.now();
+      const virtualFrame = await session.page.evaluate(async (options) => {
+        const harnessWindow = window as unknown as {
+          renderFrame(value: typeof options): Promise<{
+            timeMs: number;
+            callbacksPerFrame: number;
+            pendingCallbacks: number;
+          }>;
+        };
+        return harnessWindow.renderFrame(options);
+      }, input);
+      session.diagnostics.virtualClock = {
+        seed: config.blinkSeed,
+        ...virtualFrame,
+      };
+      const png = await session.page.screenshot({
+        type: 'png',
+        omitBackground: true,
+      });
+      const image = await loadImage(png);
+      nextFrame += 1;
+      return { image, elapsedMs: performance.now() - startedAt };
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      await session.browser.close();
+      await stopServer(harness.server);
+    },
+  };
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/process.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/process.ts
@@ -1,0 +1,40 @@
+import { type SpawnOptions, spawn } from 'node:child_process';
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a command to completion and capture its output. */
+export function runCommand(
+  command: string,
+  args: string[],
+  options: SpawnOptions = {},
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...options,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(
+          new Error(
+            `${command} ${args.join(' ')} failed with code ${code}\n${stderr || stdout}`,
+          ),
+        );
+      }
+    });
+  });
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/gen/renderer.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/gen/renderer.ts
@@ -1,0 +1,274 @@
+import {
+  type Canvas,
+  type Image,
+  type SKRSContext2D,
+  createCanvas,
+  loadImage,
+} from '@napi-rs/canvas';
+import type { RenderConfig, ScriptAvatarLayout } from '../types.js';
+import type { Inochi2DFrameSource } from './inochi2dAvatar.js';
+
+/** A normalized RMS value at or above this level uses an open-mouth image. */
+export const MOUTH_OPEN_THRESHOLD = 0.45;
+const LINE_START_PROHIBITED = /^[、。！？）」』】〕］｝〉》]$/;
+
+export type MouthState = 'closed' | 'open';
+
+export interface MotionDiagnostics {
+  mouthState: MouthState;
+  eyesClosed: boolean;
+  avatarFrameMs: number;
+}
+
+export interface NewsdeskRenderer {
+  canvas: Canvas;
+  render(
+    frameNumber: number,
+    mouthValue: number,
+    eyesClosed: boolean,
+  ): Promise<MotionDiagnostics>;
+  rgba(): Buffer;
+}
+
+interface TextBoxOptions {
+  centerY: number;
+  fontSize: number;
+  maxWidth: number;
+  fill: string;
+  background: string;
+  maxLines: number;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+/** Create a sequential deterministic canvas renderer for a resolved config. */
+export async function createRenderer(
+  config: RenderConfig,
+  avatar: Inochi2DFrameSource,
+): Promise<NewsdeskRenderer> {
+  const canvas = createCanvas(config.width, config.height);
+  const context = canvas.getContext('2d');
+  const backgroundImage = config.background.image
+    ? await loadImage(config.background.image)
+    : null;
+  let nextFrame = 0;
+
+  return {
+    canvas,
+    async render(frameNumber, mouthValue, eyesClosed) {
+      if (frameNumber !== nextFrame) {
+        throw new Error(
+          `Frames must be rendered sequentially (expected ${nextFrame}, ` +
+            `got ${frameNumber}).`,
+        );
+      }
+      const mouthState = resolveMouthState(mouthValue);
+      const avatarFrame = await avatar.renderFrame({
+        frameNumber,
+        time: frameNumber / config.fps,
+        deltaSeconds: frameNumber === 0 ? 0 : 1 / config.fps,
+        mouth: Math.max(0, Math.min(1, mouthValue)),
+        eyesClosed,
+      });
+      drawBackground(context, canvas, config.background, backgroundImage);
+      drawAvatar(context, canvas, avatarFrame.image, config.avatarLayout);
+      drawTextOverlays(context, canvas, config, frameNumber / config.fps);
+      nextFrame += 1;
+      return {
+        mouthState,
+        eyesClosed,
+        avatarFrameMs: avatarFrame.elapsedMs,
+      };
+    },
+    rgba() {
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      return Buffer.from(
+        imageData.data.buffer,
+        imageData.data.byteOffset,
+        imageData.data.byteLength,
+      );
+    },
+  };
+}
+
+/** Map normalized RMS to the two available mouth states. */
+export function resolveMouthState(value: number): MouthState {
+  return value >= MOUTH_OPEN_THRESHOLD ? 'open' : 'closed';
+}
+
+function drawBackground(
+  context: SKRSContext2D,
+  canvas: Canvas,
+  background: RenderConfig['background'],
+  image: Image | null,
+): void {
+  context.save();
+  context.fillStyle = background.color || '#20242c';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  if (image) {
+    const scale = Math.max(
+      canvas.width / image.width,
+      canvas.height / image.height,
+    );
+    const width = image.width * scale;
+    const height = image.height * scale;
+    context.drawImage(
+      image,
+      (canvas.width - width) / 2,
+      (canvas.height - height) / 2,
+      width,
+      height,
+    );
+  }
+  context.restore();
+}
+
+function drawAvatar(
+  context: SKRSContext2D,
+  canvas: Canvas,
+  image: Image,
+  layout: ScriptAvatarLayout,
+): void {
+  const scale = Number(layout.scale);
+  const x = canvas.width * Number(layout.x);
+  const y = canvas.height * Number(layout.y);
+  const width = image.width * scale;
+  const height = image.height * scale;
+
+  context.save();
+  context.drawImage(image, x - width / 2, y - height / 2, width, height);
+  context.restore();
+}
+
+const CHAPTER_STYLE = {
+  centerY: 150,
+  fontSize: 62,
+  fill: '#ffffff',
+  background: 'rgba(196, 42, 62, 0.95)',
+  borderColor: 'rgba(255, 255, 255, 0.9)',
+  borderWidth: 5,
+  maxLines: 2,
+};
+
+function drawTextOverlays(
+  context: SKRSContext2D,
+  canvas: Canvas,
+  config: RenderConfig,
+  time: number,
+): void {
+  const chapter = config.chapters.find(
+    (entry) => time >= entry.start && time < entry.end,
+  );
+  if (chapter) {
+    drawTextBox(context, canvas, chapter.text, {
+      ...CHAPTER_STYLE,
+      maxWidth: canvas.width - 120,
+    });
+  } else if (config.telop) {
+    drawTextBox(context, canvas, config.telop, {
+      centerY: 150,
+      fontSize: 58,
+      maxWidth: canvas.width - 120,
+      fill: '#ffffff',
+      background: 'rgba(0, 0, 0, 0.62)',
+      maxLines: 2,
+    });
+  }
+  const subtitle = config.subtitles.find(
+    (entry) => time >= entry.start && time < entry.end,
+  );
+  if (subtitle) {
+    drawTextBox(context, canvas, subtitle.text, {
+      centerY: canvas.height - 235,
+      fontSize: 56,
+      maxWidth: canvas.width - 120,
+      fill: '#ffffff',
+      background: 'rgba(0, 0, 0, 0.72)',
+      maxLines: 3,
+    });
+  }
+}
+
+function drawTextBox(
+  context: SKRSContext2D,
+  canvas: Canvas,
+  text: string,
+  options: TextBoxOptions,
+): void {
+  context.save();
+  context.font = `700 ${options.fontSize}px "Hiragino Sans", "Yu Gothic", sans-serif`;
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.lineJoin = 'round';
+  const lines = wrapText(context, text, options.maxWidth, options.maxLines);
+  const lineHeight = options.fontSize * 1.32;
+  const boxWidth = Math.min(
+    options.maxWidth + 48,
+    Math.max(...lines.map((line) => context.measureText(line).width)) + 72,
+  );
+  const boxHeight = lines.length * lineHeight + 36;
+  const left = (canvas.width - boxWidth) / 2;
+  const top = options.centerY - boxHeight / 2;
+  roundedRect(context, left, top, boxWidth, boxHeight, 24);
+  context.fillStyle = options.background;
+  context.fill();
+  if (options.borderColor && options.borderWidth) {
+    context.strokeStyle = options.borderColor;
+    context.lineWidth = options.borderWidth;
+    context.stroke();
+  }
+  context.strokeStyle = '#111111';
+  context.lineWidth = 8;
+  context.fillStyle = options.fill;
+  lines.forEach((line, index) => {
+    const y = options.centerY + (index - (lines.length - 1) / 2) * lineHeight;
+    context.strokeText(line, canvas.width / 2, y, options.maxWidth);
+    context.fillText(line, canvas.width / 2, y, options.maxWidth);
+  });
+  context.restore();
+}
+
+function wrapText(
+  context: SKRSContext2D,
+  text: string,
+  maxWidth: number,
+  maxLines: number,
+): string[] {
+  const chars = Array.from(text);
+  const lines: string[] = [];
+  let current = '';
+  for (const char of chars) {
+    const overflows =
+      Boolean(current) && context.measureText(current + char).width > maxWidth;
+    if (char === '\n' || (overflows && !LINE_START_PROHIBITED.test(char))) {
+      lines.push(current);
+      current = char === '\n' ? '' : char;
+    } else {
+      current += char;
+    }
+  }
+  if (current || lines.length === 0) lines.push(current);
+  if (lines.length <= maxLines) return lines;
+  const visible = lines.slice(0, maxLines);
+  const finalLine = visible[maxLines - 1] ?? '';
+  visible[maxLines - 1] = `${finalLine.slice(0, -1)}…`;
+  return visible;
+}
+
+function roundedRect(
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  const resolvedRadius = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + resolvedRadius, y);
+  context.arcTo(x + width, y, x + width, y + height, resolvedRadius);
+  context.arcTo(x + width, y + height, x, y + height, resolvedRadius);
+  context.arcTo(x, y + height, x, y, resolvedRadius);
+  context.arcTo(x, y, x + width, y, resolvedRadius);
+  context.closePath();
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/paths.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/paths.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const PACKAGE_NAME = '@aituber-onair/core-example-node-inochi2d-newsdesk';
+
+let cachedRoot: string | null = null;
+
+/**
+ * Locate the example root (the directory holding `package.json`, `harness/`,
+ * and `prompts/`). The CLI runs from a bundled `dist/*.cjs` while tests import
+ * the TypeScript sources directly, so the root is discovered by walking up
+ * from the current module instead of assuming a fixed depth.
+ */
+export function resolveProjectRoot(startDir: string = __dirname): string {
+  if (cachedRoot) return cachedRoot;
+  let current = path.resolve(startDir);
+  for (;;) {
+    const candidate = path.join(current, 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as {
+          name?: string;
+        };
+        if (parsed.name === PACKAGE_NAME) {
+          cachedRoot = current;
+          return current;
+        }
+      } catch {
+        // Ignore unreadable package.json files and keep walking up.
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not locate the ${PACKAGE_NAME} project root.`);
+}
+
+export const AVATAR_PATH_PLACEHOLDER = '/path/to/inochi2d/models/avatar.inx';
+export const AVATAR_MOTION_PATH_PLACEHOLDER =
+  '/path/to/inochi2d/models/avatar.motion.json';
+export const INOCHI2D_RUNTIME_PATH_PLACEHOLDER = '/path/to/inochi2d/runtime';
+
+export function promptPath(): string {
+  return path.join(resolveProjectRoot(), 'prompts', 'newsdesk.md');
+}
+
+/** Expand a leading `~` without accepting other users' home shortcuts. */
+export function expandHomePath(value: string): string {
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+/** Resolve `value` relative to `baseFile`, expanding the current user's `~`. */
+export function resolveFrom(baseFile: string, value: string): string {
+  const expanded = expandHomePath(value);
+  if (path.isAbsolute(expanded)) return expanded;
+  return path.resolve(path.dirname(baseFile), expanded);
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/chat.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/chat.ts
@@ -1,0 +1,95 @@
+import {
+  ChatServiceFactory,
+  type Message,
+  type ToolChatCompletion,
+} from '@aituber-onair/core';
+
+export type ApiProvider = 'openai' | 'claude' | 'gemini';
+
+const API_KEY_ENV: Record<ApiProvider, string> = {
+  openai: 'OPENAI_API_KEY',
+  claude: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+};
+
+export const SUPPORTED_PROVIDERS = Object.freeze(
+  Object.keys(API_KEY_ENV) as ApiProvider[],
+);
+
+interface ChatServiceLike {
+  chatOnce(
+    messages: Message[],
+    stream: boolean,
+    onPartialResponse: (text: string) => void,
+    maxTokens?: number,
+  ): Promise<ToolChatCompletion>;
+}
+
+export interface ChatServiceFactoryLike {
+  createChatService(
+    provider: ApiProvider,
+    options: {
+      apiKey: string;
+      responseFormat?: { type: 'json_object' };
+    },
+  ): ChatServiceLike;
+  getAvailableProviders?(): string[];
+}
+
+export interface RequestScriptOptions {
+  provider: ApiProvider;
+  apiKey: string;
+  systemPrompt: string;
+  userPrompt: string;
+  factory?: ChatServiceFactoryLike;
+}
+
+/** Resolve the environment API key required by an API-based provider. */
+export function resolveApiKey(
+  provider: ApiProvider,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const variable = API_KEY_ENV[provider];
+  const value = environment[variable];
+  if (!value)
+    throw new Error(`${variable} is required for provider "${provider}".`);
+  return value;
+}
+
+/** Return Core's provider factory behind the small interface used by tests. */
+export function loadChatServiceFactory(): ChatServiceFactoryLike {
+  return ChatServiceFactory as unknown as ChatServiceFactoryLike;
+}
+
+/** Request a JSON newsdesk script through an API-key Core chat provider. */
+export async function requestScript({
+  provider,
+  apiKey,
+  systemPrompt,
+  userPrompt,
+  factory = loadChatServiceFactory(),
+}: RequestScriptOptions): Promise<string> {
+  const options: {
+    apiKey: string;
+    responseFormat?: { type: 'json_object' };
+  } = { apiKey };
+  if (provider === 'openai') {
+    options.responseFormat = { type: 'json_object' };
+  }
+  const service = factory.createChatService(provider, options);
+  const completion = await service.chatOnce(
+    [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ],
+    false,
+    () => {},
+    2_000,
+  );
+  const text = completion.blocks
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('');
+  if (!text.trim()) throw new Error(`Provider "${provider}" returned no text.`);
+  return text;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/cli.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/cli.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  type ApiProvider,
+  requestScript,
+  resolveApiKey,
+  SUPPORTED_PROVIDERS,
+} from './chat.js';
+import { requestScriptViaCodex } from './codex.js';
+import { ingestSource } from './ingest.js';
+import { buildUserPrompt } from './prompt.js';
+import { assertTokenProvenance, parseAndValidateScript } from './schema.js';
+import {
+  AVATAR_MOTION_PATH_PLACEHOLDER,
+  AVATAR_PATH_PLACEHOLDER,
+  INOCHI2D_RUNTIME_PATH_PLACEHOLDER,
+  promptPath,
+} from '../paths.js';
+import type { NewsdeskScript } from '../types.js';
+
+export type ScriptProvider = ApiProvider | 'codex-sdk';
+
+export interface ScriptGenArgs {
+  source: string | null;
+  focus: string | null;
+  output: string;
+  provider: ScriptProvider | string;
+  dryRun: boolean;
+  help: boolean;
+}
+
+function takeValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (value === undefined || (value.startsWith('--') && value !== '-'))
+    throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+/** Parse script generation CLI arguments. */
+export function parseArgs(argv: string[]): ScriptGenArgs {
+  const args: ScriptGenArgs = {
+    source: null,
+    focus: null,
+    output: 'script.json',
+    provider: 'codex-sdk',
+    dryRun: false,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--focus') args.focus = takeValue(argv, index++, argument);
+    else if (argument === '--output')
+      args.output = takeValue(argv, index++, argument);
+    else if (argument === '--provider')
+      args.provider = takeValue(argv, index++, argument);
+    else if (argument === '--dry-run') args.dryRun = true;
+    else if (argument === '--help' || argument === '-h') args.help = true;
+    else if (argument.startsWith('--'))
+      throw new Error(`Unknown argument: ${argument}`);
+    else if (args.source === null) args.source = argument;
+    else throw new Error(`Unexpected second input source: ${argument}`);
+  }
+  return args;
+}
+
+function usage(): string {
+  return `Usage:
+  npm run script-gen -- <file|URL|-> [--focus "..."] [--output <script.json>] \\
+    [--provider codex-sdk|openai|claude|gemini] [--dry-run]`;
+}
+
+function validateArgs(args: ScriptGenArgs): asserts args is ScriptGenArgs & {
+  source: string;
+  provider: ScriptProvider;
+} {
+  if (!args.source) throw new Error('An input file, URL, or - is required.');
+  const providers: ScriptProvider[] = [...SUPPORTED_PROVIDERS, 'codex-sdk'];
+  if (!providers.includes(args.provider as ScriptProvider)) {
+    throw new Error(
+      `Unsupported provider "${args.provider}". Supported: ${providers.join(', ')}`,
+    );
+  }
+}
+
+/** Return the adjacent analysis JSON path for an output script path. */
+export function analysisPathForOutput(outputPath: string): string {
+  return outputPath.endsWith('.json')
+    ? `${outputPath.slice(0, -'.json'.length)}.analysis.json`
+    : `${outputPath}.analysis.json`;
+}
+
+/** Replace model paths with explicit local-file placeholders. */
+export function normalizeScriptForOutput(
+  script: NewsdeskScript,
+  _outputPath: string,
+): NewsdeskScript {
+  return {
+    ...script,
+    avatar: AVATAR_PATH_PLACEHOLDER,
+    avatarMotion: AVATAR_MOTION_PATH_PLACEHOLDER,
+    inochi2dRuntime: INOCHI2D_RUNTIME_PATH_PLACEHOLDER,
+  };
+}
+
+/** Execute the script generation CLI. */
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  validateArgs(args);
+
+  const sourceText = await ingestSource(args.source);
+  const systemPrompt = await readFile(promptPath(), 'utf8');
+  const userPrompt = buildUserPrompt({ sourceText, focus: args.focus });
+
+  console.log('Source text:');
+  console.log(sourceText);
+
+  if (args.dryRun) {
+    console.log('\nSystem prompt:');
+    console.log(systemPrompt.trim());
+    console.log('\nUser input:');
+    console.log(userPrompt);
+    return;
+  }
+
+  const raw =
+    args.provider === 'codex-sdk'
+      ? await requestScriptViaCodex({ systemPrompt, userPrompt })
+      : await requestScript({
+          provider: args.provider,
+          apiKey: resolveApiKey(args.provider),
+          systemPrompt,
+          userPrompt,
+        });
+  const generated = parseAndValidateScript(raw);
+  assertTokenProvenance(generated.script, sourceText, args.focus ?? '');
+
+  const outputPath = path.resolve(args.output);
+  const analysisPath = analysisPathForOutput(outputPath);
+  const script = normalizeScriptForOutput(generated.script, outputPath);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await Promise.all([
+    writeFile(outputPath, `${JSON.stringify(script, null, 2)}\n`, 'utf8'),
+    writeFile(
+      analysisPath,
+      `${JSON.stringify(generated.analysis, null, 2)}\n`,
+      'utf8',
+    ),
+  ]);
+  console.log(
+    `Wrote ${path.relative(process.cwd(), outputPath) || path.basename(outputPath)}`,
+  );
+  console.log(
+    `Wrote ${path.relative(process.cwd(), analysisPath) || path.basename(analysisPath)}`,
+  );
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.stack : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/codex.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/codex.ts
@@ -1,0 +1,67 @@
+import {
+  createAgentChatService,
+  type Message,
+  type ToolChatCompletion,
+} from '@aituber-onair/core/agent';
+
+interface AgentChatServiceLike {
+  chatOnce(
+    messages: Message[],
+    stream: boolean,
+    onPartialResponse: (text: string) => void,
+    maxTokens?: number,
+  ): Promise<ToolChatCompletion>;
+}
+
+export interface AgentChatModuleLike {
+  createAgentChatService(
+    provider: 'codex-sdk',
+    options: { skipGitRepoCheck: boolean },
+  ): AgentChatServiceLike;
+}
+
+export interface RequestScriptViaCodexOptions {
+  systemPrompt: string;
+  userPrompt: string;
+  agentModule?: AgentChatModuleLike;
+}
+
+/** Return Core's Agent SDK entry behind the small interface used by tests. */
+export function loadAgentChatModule(): AgentChatModuleLike {
+  return { createAgentChatService } as unknown as AgentChatModuleLike;
+}
+
+/** Strip an optional Markdown fence around a JSON response. */
+export function extractJsonPayload(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/);
+  return fenced ? fenced[1].trim() : trimmed;
+}
+
+/**
+ * Generate a script through Core's `codex-sdk` agent provider. The provider
+ * uses the local Codex sign-in and does not require an API key.
+ */
+export async function requestScriptViaCodex({
+  systemPrompt,
+  userPrompt,
+  agentModule = loadAgentChatModule(),
+}: RequestScriptViaCodexOptions): Promise<string> {
+  const service = agentModule.createAgentChatService('codex-sdk', {
+    skipGitRepoCheck: true,
+  });
+  const completion = await service.chatOnce(
+    [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ],
+    false,
+    () => {},
+  );
+  const text = completion.blocks
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('');
+  if (!text.trim()) throw new Error('codex-sdk provider returned no text.');
+  return extractJsonPayload(text);
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/ingest.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/ingest.ts
@@ -1,0 +1,81 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { Readability } from '@mozilla/readability';
+import { parseHTML } from 'linkedom';
+
+const URL_PATTERN = /^https?:\/\//i;
+
+interface TextInput extends AsyncIterable<string | Buffer> {
+  setEncoding(encoding: BufferEncoding): void;
+}
+
+export interface IngestSourceOptions {
+  input?: TextInput;
+  fetchImpl?: typeof fetch;
+}
+
+function normalizeText(text: string): string {
+  return text.replaceAll('\r\n', '\n').replaceAll('\r', '\n').trim();
+}
+
+async function readStandardInput(stream: TextInput): Promise<string> {
+  stream.setEncoding('utf8');
+  let input = '';
+  for await (const chunk of stream) input += chunk.toString();
+  return normalizeText(input);
+}
+
+function extractArticleText(html: string, url: string): string {
+  const markup = /<(?:html|body)\b/i.test(html)
+    ? html
+    : `<!doctype html><html><body>${html}</body></html>`;
+  const { document } = parseHTML(markup);
+  const base = document.createElement('base');
+  base.setAttribute('href', url);
+  document.head?.prepend(base);
+  for (const element of Array.from(
+    document.querySelectorAll(
+      'nav, header, footer, aside, script, style, noscript',
+    ),
+  )) {
+    element.remove();
+  }
+
+  const fallbackText = document.body?.textContent ?? '';
+  const article = new Readability(document).parse();
+  const text = article?.textContent || fallbackText;
+  return normalizeText(text).replace(/\n{3,}/g, '\n\n');
+}
+
+async function readUrl(url: string, fetchImpl: typeof fetch): Promise<string> {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${url}: ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+  const body = await response.text();
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.startsWith('text/plain')) return normalizeText(body);
+  if (contentType.includes('html') || /<[^>]+>/.test(body)) {
+    return extractArticleText(body, url);
+  }
+  return normalizeText(body);
+}
+
+/** Read and normalize source text from a file, stdin (`-`), or HTTP(S) URL. */
+export async function ingestSource(
+  source: string,
+  {
+    input = process.stdin as TextInput,
+    fetchImpl = globalThis.fetch,
+  }: IngestSourceOptions = {},
+): Promise<string> {
+  let text: string;
+  if (source === '-') text = await readStandardInput(input);
+  else if (URL_PATTERN.test(source)) text = await readUrl(source, fetchImpl);
+  else text = normalizeText(await readFile(path.resolve(source), 'utf8'));
+
+  if (!text) throw new Error('The input source did not contain any text.');
+  return text;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/prompt.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/prompt.ts
@@ -1,0 +1,20 @@
+export interface BuildUserPromptOptions {
+  sourceText: string;
+  focus?: string | null;
+}
+
+/** Build the factual source prompt, optionally emphasizing one perspective. */
+export function buildUserPrompt({
+  sourceText,
+  focus,
+}: BuildUserPromptOptions): string {
+  const sections = [
+    'Turn the following source into a chaptered Japanese newsdesk script.',
+    'Treat the source text as the only factual authority.',
+  ];
+  if (focus) {
+    sections.push('', 'Center the script on this perspective:', focus);
+  }
+  sections.push('', 'Source text:', '', sourceText);
+  return sections.join('\n');
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/schema.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/script-gen/schema.ts
@@ -1,0 +1,393 @@
+import type { NewsdeskScript, ScriptLine } from '../types.js';
+
+const TOP_LEVEL_FIELDS = new Set([
+  'avatar',
+  'avatarMotion',
+  'inochi2dRuntime',
+  'output',
+  'voice',
+  'leadIn',
+  'leadOut',
+  'defaultPauseAfter',
+  'background',
+  'telop',
+  'avatarLayout',
+  'avatarFraming',
+  'avatarMotion',
+  'motion',
+  'blinkSeed',
+  'lines',
+]);
+const LINE_FIELDS = new Set([
+  'text',
+  'reading',
+  'spoken',
+  'duration',
+  'pauseAfter',
+  'chapter',
+]);
+const RESPONSE_FIELDS = new Set(['analysis', 'script']);
+const ANALYSIS_FIELDS = new Set(['docType', 'title', 'keyFacts']);
+const PROVENANCE_TOKEN_PATTERN =
+  /v?\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?|\d+(?:\.\d+)*/g;
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface ScriptAnalysis {
+  docType: string;
+  title: string;
+  keyFacts: string[];
+}
+
+export interface GeneratedScriptResponse {
+  analysis: ScriptAnalysis;
+  script: NewsdeskScript;
+}
+
+interface NumberRange {
+  min?: number;
+  max?: number;
+}
+
+function isObject(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function addUnknownFieldErrors(
+  value: UnknownRecord,
+  allowed: Set<string>,
+  valuePath: string,
+  errors: string[],
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) errors.push(`${valuePath}.${key} is not allowed.`);
+  }
+}
+
+function requireString(
+  value: unknown,
+  valuePath: string,
+  errors: string[],
+  options: { maxLength?: number } = {},
+): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    errors.push(`${valuePath} must be a non-empty string.`);
+    return;
+  }
+  if (options.maxLength && Array.from(value).length > options.maxLength) {
+    errors.push(
+      `${valuePath} must be at most ${options.maxLength} Unicode characters.`,
+    );
+  }
+}
+
+function requireFiniteNumber(
+  value: unknown,
+  valuePath: string,
+  errors: string[],
+  { min, max }: NumberRange = {},
+): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    errors.push(`${valuePath} must be a finite number.`);
+    return;
+  }
+  if (min !== undefined && value < min)
+    errors.push(`${valuePath} must be at least ${min}.`);
+  if (max !== undefined && value > max)
+    errors.push(`${valuePath} must be at most ${max}.`);
+}
+
+function validateOptionalNumber(
+  value: unknown,
+  valuePath: string,
+  errors: string[],
+  range: NumberRange,
+): void {
+  if (value !== undefined) requireFiniteNumber(value, valuePath, errors, range);
+}
+
+function validateVoice(voice: unknown, errors: string[]): void {
+  if (!isObject(voice)) {
+    errors.push('script.voice must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    voice,
+    new Set(['engine', 'options']),
+    'script.voice',
+    errors,
+  );
+  if (!['sine', 'say', 'aituber-voice'].includes(String(voice.engine))) {
+    errors.push(
+      'script.voice.engine must be "sine", "say", or "aituber-voice".',
+    );
+  }
+  if (!isObject(voice.options))
+    errors.push('script.voice.options must be an object.');
+}
+
+function validateBackground(background: unknown, errors: string[]): void {
+  if (!isObject(background)) {
+    errors.push('script.background must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    background,
+    new Set(['color', 'image']),
+    'script.background',
+    errors,
+  );
+  requireString(background.color, 'script.background.color', errors);
+  if (background.image !== undefined)
+    requireString(background.image, 'script.background.image', errors);
+}
+
+function validateAvatarLayout(layout: unknown, errors: string[]): void {
+  if (!isObject(layout)) {
+    errors.push('script.avatarLayout must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    layout,
+    new Set(['scale', 'x', 'y']),
+    'script.avatarLayout',
+    errors,
+  );
+  requireFiniteNumber(layout.scale, 'script.avatarLayout.scale', errors, {
+    min: 0.01,
+  });
+  requireFiniteNumber(layout.x, 'script.avatarLayout.x', errors);
+  requireFiniteNumber(layout.y, 'script.avatarLayout.y', errors);
+}
+
+function validateAvatarFraming(framing: unknown, errors: string[]): void {
+  if (!isObject(framing)) {
+    errors.push('script.avatarFraming must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    framing,
+    new Set(['scale', 'x', 'y']),
+    'script.avatarFraming',
+    errors,
+  );
+  validateOptionalNumber(framing.scale, 'script.avatarFraming.scale', errors, {
+    min: 0.01,
+    max: 2,
+  });
+  validateOptionalNumber(framing.x, 'script.avatarFraming.x', errors, {
+    min: -10_000,
+    max: 10_000,
+  });
+  validateOptionalNumber(framing.y, 'script.avatarFraming.y', errors, {
+    min: -10_000,
+    max: 10_000,
+  });
+}
+
+function validateMotion(motion: unknown, errors: string[]): void {
+  if (!isObject(motion)) {
+    errors.push('script.motion must be an object.');
+    return;
+  }
+  addUnknownFieldErrors(
+    motion,
+    new Set(['intensity']),
+    'script.motion',
+    errors,
+  );
+  requireFiniteNumber(motion.intensity, 'script.motion.intensity', errors, {
+    min: 0,
+    max: 3,
+  });
+}
+
+function validateLines(lines: unknown, errors: string[]): void {
+  if (!Array.isArray(lines)) {
+    errors.push('script.lines must be an array.');
+    return;
+  }
+  if (lines.length < 3 || lines.length > 12)
+    errors.push('script.lines must contain between 3 and 12 entries.');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line: unknown = lines[index];
+    const linePath = `script.lines[${index}]`;
+    if (!isObject(line)) {
+      errors.push(`${linePath} must be an object.`);
+      continue;
+    }
+    addUnknownFieldErrors(line, LINE_FIELDS, linePath, errors);
+    requireString(line.text, `${linePath}.text`, errors, { maxLength: 35 });
+    if (line.reading !== undefined)
+      requireString(line.reading, `${linePath}.reading`, errors);
+    if (line.chapter !== undefined)
+      requireString(line.chapter, `${linePath}.chapter`, errors, {
+        maxLength: 30,
+      });
+    if (line.spoken !== undefined && typeof line.spoken !== 'boolean')
+      errors.push(`${linePath}.spoken must be a boolean.`);
+    validateOptionalNumber(line.pauseAfter, `${linePath}.pauseAfter`, errors, {
+      min: 0,
+    });
+    validateOptionalNumber(line.duration, `${linePath}.duration`, errors, {
+      min: 0,
+    });
+    if (line.spoken === false && line.duration === undefined)
+      errors.push(`${linePath}.duration is required when spoken is false.`);
+  }
+}
+
+/** Return every strict schema violation in a candidate script. */
+export function validateScript(script: unknown): string[] {
+  const errors: string[] = [];
+  if (!isObject(script)) return ['script must be a JSON object.'];
+
+  addUnknownFieldErrors(script, TOP_LEVEL_FIELDS, 'script', errors);
+  requireString(script.avatar, 'script.avatar', errors);
+  if (
+    typeof script.avatar === 'string' &&
+    script.avatar.trim() !== '' &&
+    !script.avatar.toLowerCase().endsWith('.inx')
+  ) {
+    errors.push('script.avatar must point to an .inx file.');
+  }
+  if (script.avatarMotion !== undefined) {
+    requireString(script.avatarMotion, 'script.avatarMotion', errors);
+  }
+  if (
+    typeof script.avatarMotion === 'string' &&
+    script.avatarMotion.trim() !== '' &&
+    !script.avatarMotion.toLowerCase().endsWith('.json')
+  ) {
+    errors.push('script.avatarMotion must point to a JSON file.');
+  }
+  requireString(script.inochi2dRuntime, 'script.inochi2dRuntime', errors);
+  if (script.output !== undefined)
+    requireString(script.output, 'script.output', errors);
+  validateVoice(script.voice, errors);
+  validateOptionalNumber(script.leadIn, 'script.leadIn', errors, { min: 0 });
+  validateOptionalNumber(script.leadOut, 'script.leadOut', errors, { min: 0 });
+  validateOptionalNumber(
+    script.defaultPauseAfter,
+    'script.defaultPauseAfter',
+    errors,
+    { min: 0 },
+  );
+  validateBackground(script.background, errors);
+  if (script.telop !== undefined)
+    requireString(script.telop, 'script.telop', errors);
+  validateAvatarLayout(script.avatarLayout, errors);
+  if (script.avatarFraming !== undefined)
+    validateAvatarFraming(script.avatarFraming, errors);
+  requireFiniteNumber(script.blinkSeed, 'script.blinkSeed', errors);
+  validateMotion(script.motion, errors);
+  validateLines(script.lines, errors);
+  return errors;
+}
+
+/** Parse and strictly validate the analysis-plus-script model response. */
+export function parseAndValidateScript(raw: string): GeneratedScriptResponse {
+  let response: unknown;
+  try {
+    response = JSON.parse(raw.trim());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Generated response is not valid JSON: ${message}`, {
+      cause: error,
+    });
+  }
+
+  const errors: string[] = [];
+  if (!isObject(response)) {
+    errors.push('response must be a JSON object.');
+  } else {
+    addUnknownFieldErrors(response, RESPONSE_FIELDS, 'response', errors);
+    if (!isObject(response.analysis)) {
+      errors.push('response.analysis must be an object.');
+    } else {
+      addUnknownFieldErrors(
+        response.analysis,
+        ANALYSIS_FIELDS,
+        'response.analysis',
+        errors,
+      );
+      requireString(
+        response.analysis.docType,
+        'response.analysis.docType',
+        errors,
+      );
+      requireString(response.analysis.title, 'response.analysis.title', errors);
+      if (
+        !Array.isArray(response.analysis.keyFacts) ||
+        response.analysis.keyFacts.length === 0
+      ) {
+        errors.push('response.analysis.keyFacts must be a non-empty array.');
+      } else {
+        for (
+          let index = 0;
+          index < response.analysis.keyFacts.length;
+          index += 1
+        ) {
+          requireString(
+            response.analysis.keyFacts[index],
+            `response.analysis.keyFacts[${index}]`,
+            errors,
+          );
+        }
+      }
+    }
+    errors.push(...validateScript(response.script));
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `Generated response failed schema validation:\n- ${errors.join('\n- ')}`,
+    );
+  }
+  return response as unknown as GeneratedScriptResponse;
+}
+
+function announcementText(script: NewsdeskScript): string {
+  return [
+    script.telop,
+    ...script.lines.flatMap((line: ScriptLine) => [
+      line.chapter,
+      line.text,
+      line.reading,
+    ]),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join('\n');
+}
+
+function provenanceTokens(text: string): Set<string> {
+  return new Set(
+    (text.match(PROVENANCE_TOKEN_PATTERN) ?? []).map((token) => {
+      const withoutVersionPrefix = /^v\d/.test(token) ? token.slice(1) : token;
+      return /^\d+$/.test(withoutVersionPrefix)
+        ? withoutVersionPrefix.replace(/^0+(?=\d)/, '')
+        : withoutVersionPrefix;
+    }),
+  );
+}
+
+/** Reject numeric/version claims absent from both source text and focus. */
+export function assertTokenProvenance(
+  script: NewsdeskScript,
+  sourceText: string,
+  focus = '',
+): void {
+  const allowedTokens = provenanceTokens(`${sourceText}\n${focus}`);
+  const unsupportedTokens = [
+    ...new Set(
+      [...provenanceTokens(announcementText(script))].filter(
+        (token) => !allowedTokens.has(token),
+      ),
+    ),
+  ];
+  if (unsupportedTokens.length > 0) {
+    throw new Error(
+      `Generated script contains numeric token(s) not present in the source text or focus: ${unsupportedTokens.join(', ')}`,
+    );
+  }
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/src/types.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/src/types.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared types for the newsdesk video pipeline.
+ *
+ * A `NewsdeskScript` is the JSON document produced by `script-gen` and consumed
+ * by `gen`. Paths inside a script are resolved relative to the script file.
+ */
+
+export type VoiceEngineName = 'sine' | 'say' | 'aituber-voice';
+
+export interface ScriptVoice {
+  engine: VoiceEngineName;
+  options?: Record<string, unknown>;
+}
+
+export interface ScriptBackground {
+  color?: string;
+  /** Image path, relative to the script file. */
+  image?: string;
+}
+
+export interface ScriptAvatarLayout {
+  scale?: number;
+  /** Horizontal anchor as a fraction of the canvas width (0..1). */
+  x?: number;
+  /** Vertical anchor as a fraction of the canvas height (0..1). */
+  y?: number;
+}
+
+export interface ScriptAvatarFraming {
+  /** Inochi2D camera scale in model space. */
+  scale?: number;
+  /** Horizontal Inochi2D camera offset in model-space pixels. */
+  x?: number;
+  /** Vertical Inochi2D camera offset in model-space pixels. */
+  y?: number;
+}
+
+export const DEFAULT_AVATAR_FRAMING = {
+  scale: 0.65,
+  x: 0,
+  y: 1450,
+} as const;
+
+export const DEFAULT_IDLE_ANIMATION = 'original_idle_calm_breath';
+
+export interface ScriptMotion {
+  /** Weight applied to the looping Inochi2D idle animation, clamped to 0..3. */
+  intensity?: number;
+}
+
+export interface ScriptLine {
+  /** Subtitle text; also the narration unless `reading` is set. */
+  text: string;
+  /** Narration text used for pronunciation control. */
+  reading?: string;
+  /** Topic label shown at the top of the screen from this line on. */
+  chapter?: string;
+  /** Set to false for a silent subtitle. */
+  spoken?: boolean;
+  /** Required when `spoken` is false. */
+  duration?: number;
+  /** Silence after this line, in seconds. */
+  pauseAfter?: number;
+}
+
+export interface NewsdeskScript {
+  /** Inochi2D .inx file, relative to the script file or `~/...`. */
+  avatar: string;
+  /** Optional Inochi2D motion JSON, using the same path rules as `avatar`. */
+  avatarMotion?: string;
+  /** Directory containing the unmodified Inochi2D Web runtime bridge. */
+  inochi2dRuntime: string;
+  /** MP4 path, relative to the script file. `--output` takes precedence. */
+  output?: string;
+  voice?: ScriptVoice;
+  leadIn?: number;
+  leadOut?: number;
+  defaultPauseAfter?: number;
+  background?: ScriptBackground;
+  /** Fixed title used only while no line `chapter` is active. */
+  telop?: string;
+  avatarLayout?: ScriptAvatarLayout;
+  avatarFraming?: ScriptAvatarFraming;
+  motion?: ScriptMotion;
+  blinkSeed?: number;
+  lines: ScriptLine[];
+}
+
+export interface TimedText {
+  text: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Fully resolved render configuration written beside the output as
+ * `<name>.inochi2d-gen.config.json`. `--render-only` re-reads it.
+ */
+export interface RenderConfig {
+  width: number;
+  height: number;
+  fps: number;
+  background: { color: string; image?: string };
+  avatarLayout: { scale: number; x: number; y: number };
+  avatarFraming: {
+    scale: number;
+    x: number;
+    y: number;
+  };
+  /** Absolute optional motion JSON path. */
+  avatarMotion: string | null;
+  /** Absolute directory containing the Inochi2D Web runtime bridge. */
+  inochi2dRuntime: string;
+  motion: { intensity: number };
+  blinkSeed: number;
+  /** Absolute Inochi2D .inx model file. */
+  avatar: string;
+  /** Absolute path of the combined narration WAV. */
+  audio: string;
+  /** Absolute MP4 output path. */
+  output: string;
+  telop: string;
+  subtitles: TimedText[];
+  chapters: TimedText[];
+  duration: number;
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/tests/e2e/gen.test.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/tests/e2e/gen.test.ts
@@ -1,0 +1,272 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { createCanvas, loadImage } from '@napi-rs/canvas';
+
+const testDirectory = path.dirname(new URL(import.meta.url).pathname);
+const projectRoot = path.resolve(testDirectory, '..', '..');
+const workDirectory = path.join(projectRoot, 'work', 'test-gen-e2e');
+const fixtureScriptPath = path.join(
+  projectRoot,
+  'tests',
+  'fixtures',
+  'hello-sine.json',
+);
+const firstOutputPath = path.join(workDirectory, 'hello-first.mp4');
+const firstTimingsPath = path.join(workDirectory, 'hello-first.timings.json');
+const closedPngPath = path.join(workDirectory, 'mouth-closed.png');
+const openPngPath = path.join(workDirectory, 'mouth-open.png');
+const siblingAssets = [
+  path.resolve(
+    projectRoot,
+    '../react-inochi2d-app/public/inochi2d/runtime/inochi_bridge.js',
+  ),
+  path.resolve(
+    projectRoot,
+    '../react-inochi2d-app/public/inochi2d/runtime/inochi2d_bg.wasm',
+  ),
+  path.resolve(
+    projectRoot,
+    '../react-inochi2d-app/public/inochi2d/models/Aka.original-rig.inx',
+  ),
+  path.resolve(
+    projectRoot,
+    '../react-inochi2d-app/public/inochi2d/models/Aka.original.motion.json',
+  ),
+];
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface RenderSummary {
+  frames: number;
+  mouthFrames: { closed: number; open: number };
+  mouthExampleFrames: { closed: number | null; open: number | null };
+  stateFrames: Record<string, number>;
+  blinkFrames: number;
+  averageMsPerFrame: number;
+  avatarDiagnostics: {
+    runtime: string;
+    canvasSize: { width: number; height: number };
+    mouthParameterId: string;
+    mouthParameterKind: string;
+    eyeParameterIds: string[];
+    idleAnimation: string;
+    idleAnimationActive: boolean;
+    avatarFraming: { scale: number; x: number; y: number };
+    virtualClock: {
+      seed: number;
+      timeMs: number;
+      callbacksPerFrame: number;
+      pendingCallbacks: number;
+    };
+  };
+}
+
+function run(command: string, args: string[]): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else {
+        reject(
+          new Error(`${command} exited with code ${code}\n${stderr || stdout}`),
+        );
+      }
+    });
+  });
+}
+
+async function md5(filePath: string): Promise<string> {
+  return createHash('md5')
+    .update(await readFile(filePath))
+    .digest('hex');
+}
+
+async function readPixels(filePath: string): Promise<Uint8ClampedArray> {
+  const image = await loadImage(filePath);
+  const canvas = createCanvas(image.width, image.height);
+  const context = canvas.getContext('2d');
+  context.drawImage(image, 0, 0);
+  return context.getImageData(0, 0, image.width, image.height).data;
+}
+
+function changedPixelCount(
+  first: Uint8ClampedArray,
+  second: Uint8ClampedArray,
+): number {
+  let changed = 0;
+  for (let index = 0; index < first.length; index += 4) {
+    const difference = Math.max(
+      Math.abs(first[index] - second[index]),
+      Math.abs(first[index + 1] - second[index + 1]),
+      Math.abs(first[index + 2] - second[index + 2]),
+      Math.abs(first[index + 3] - second[index + 3]),
+    );
+    if (difference >= 12) changed += 1;
+  }
+  return changed;
+}
+
+function nonBackgroundPixelCount(pixels: Uint8ClampedArray): number {
+  let visible = 0;
+  for (let index = 0; index < pixels.length; index += 4) {
+    if (
+      pixels[index] !== 32 ||
+      pixels[index + 1] !== 36 ||
+      pixels[index + 2] !== 44
+    ) {
+      visible += 1;
+    }
+  }
+  return visible;
+}
+
+it('renders deterministic Inochi2D frames into a vertical H.264/AAC video', async () => {
+  expect(siblingAssets.every(existsSync)).toBe(true);
+  await rm(workDirectory, { recursive: true, force: true });
+  await mkdir(workDirectory, { recursive: true });
+
+  const firstRun = await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    fixtureScriptPath,
+    '--output',
+    firstOutputPath,
+  ]);
+  const firstTimings = await readFile(firstTimingsPath, 'utf8');
+  const firstMp4Md5 = await md5(firstOutputPath);
+  const secondRun = await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    fixtureScriptPath,
+    '--output',
+    firstOutputPath,
+  ]);
+  const summary = JSON.parse(firstRun.stdout).render as RenderSummary;
+  const secondSummary = JSON.parse(secondRun.stdout).render as RenderSummary;
+
+  expect((await stat(firstOutputPath)).size).toBeGreaterThan(0);
+  expect(summary.mouthFrames.closed).toBeGreaterThan(0);
+  expect(summary.mouthFrames.open).toBeGreaterThan(0);
+  expect(summary.blinkFrames).toBeGreaterThan(0);
+  expect(
+    summary.stateFrames.mouth_closed_eyes_closed +
+      summary.stateFrames.mouth_open_eyes_closed,
+  ).toBeGreaterThan(0);
+  expect(summary.averageMsPerFrame).toBeGreaterThan(0);
+  expect(secondSummary.frames).toBe(summary.frames);
+  expect(summary.avatarDiagnostics.runtime).toBe('inox2d-wasm-webgl2');
+  expect(summary.avatarDiagnostics.canvasSize).toEqual({
+    width: 1080,
+    height: 1920,
+  });
+  expect(summary.avatarDiagnostics.mouthParameterId).toBe('Mouth:: Shape');
+  expect(summary.avatarDiagnostics.mouthParameterKind).toBe('vec2');
+  expect(summary.avatarDiagnostics.eyeParameterIds).toEqual([
+    'Eye:: Left:: Blink',
+    'Eye:: Right:: Blink',
+  ]);
+  expect(summary.avatarDiagnostics.idleAnimation).toBe(
+    'original_idle_calm_breath',
+  );
+  expect(summary.avatarDiagnostics.idleAnimationActive).toBe(true);
+  expect(summary.avatarDiagnostics.avatarFraming).toEqual({
+    scale: 0.65,
+    x: 0,
+    y: 1450,
+  });
+  expect(summary.avatarDiagnostics.virtualClock).toMatchObject({
+    seed: 42,
+    callbacksPerFrame: 1,
+    pendingCallbacks: 1,
+  });
+  expect(summary.avatarDiagnostics.virtualClock.timeMs).toBeCloseTo(
+    ((summary.frames - 1) / 30) * 1000,
+    5,
+  );
+
+  expect(await readFile(firstTimingsPath, 'utf8')).toBe(firstTimings);
+
+  const probe = await run('ffprobe', [
+    '-v',
+    'error',
+    '-count_frames',
+    '-show_entries',
+    'stream=codec_type,codec_name,width,height,pix_fmt,r_frame_rate,nb_read_frames',
+    '-of',
+    'json',
+    firstOutputPath,
+  ]);
+  const streams = JSON.parse(probe.stdout).streams as Array<
+    Record<string, string | number>
+  >;
+  const video = streams.find((stream) => stream.codec_type === 'video');
+  const audio = streams.find((stream) => stream.codec_type === 'audio');
+  expect(video).toMatchObject({
+    codec_name: 'h264',
+    width: 1080,
+    height: 1920,
+    pix_fmt: 'yuv420p',
+    r_frame_rate: '30/1',
+    nb_read_frames: String(summary.frames),
+  });
+  expect(audio?.codec_name).toBe('aac');
+
+  const closedFrame = summary.mouthExampleFrames.closed;
+  const openFrame = summary.mouthExampleFrames.open;
+  expect(closedFrame).not.toBeNull();
+  expect(openFrame).not.toBeNull();
+  await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    fixtureScriptPath,
+    '--output',
+    path.join(workDirectory, 'closed-frame-source.mp4'),
+    '--frame',
+    String(closedFrame),
+    '--png',
+    closedPngPath,
+  ]);
+  await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    fixtureScriptPath,
+    '--output',
+    path.join(workDirectory, 'open-frame-source.mp4'),
+    '--frame',
+    String(openFrame),
+    '--png',
+    openPngPath,
+  ]);
+  const closedImage = await loadImage(closedPngPath);
+  const openImage = await loadImage(openPngPath);
+  expect(closedImage.width).toBe(1080);
+  expect(closedImage.height).toBe(1920);
+  expect(openImage.width).toBe(1080);
+  expect(openImage.height).toBe(1920);
+
+  const closedPixels = await readPixels(closedPngPath);
+  const openPixels = await readPixels(openPngPath);
+  expect(nonBackgroundPixelCount(closedPixels)).toBeGreaterThan(50_000);
+  expect(nonBackgroundPixelCount(openPixels)).toBeGreaterThan(50_000);
+  expect(changedPixelCount(closedPixels, openPixels)).toBeGreaterThan(500);
+
+  expect(await md5(firstOutputPath)).toBe(firstMp4Md5);
+});

--- a/packages/core/examples/node-inochi2d-newsdesk/tests/fixtures/CHANGELOG.md
+++ b/packages/core/examples/node-inochi2d-newsdesk/tests/fixtures/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.49.0] - 2026-07-25
+
+### Added
+
+- Added stable JSON output for the chat package.
+- Fixed 2 edge cases in release script generation.
+
+## [0.48.0] - 2026-07-20
+
+- Previous release.

--- a/packages/core/examples/node-inochi2d-newsdesk/tests/fixtures/hello-sine.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/tests/fixtures/hello-sine.json
@@ -1,0 +1,49 @@
+{
+  "avatar": "../../../react-inochi2d-app/public/inochi2d/models/Aka.original-rig.inx",
+  "avatarMotion": "../../../react-inochi2d-app/public/inochi2d/models/Aka.original.motion.json",
+  "inochi2dRuntime": "../../../react-inochi2d-app/public/inochi2d/runtime",
+  "voice": {
+    "engine": "sine",
+    "options": {
+      "frequency": 440,
+      "secondsPerChar": 0.006,
+      "minDuration": 0.12
+    }
+  },
+  "leadIn": 0.05,
+  "leadOut": 0.08,
+  "defaultPauseAfter": 0.03,
+  "background": {
+    "color": "#20242c"
+  },
+  "avatarLayout": {
+    "scale": 1,
+    "x": 0.5,
+    "y": 0.5
+  },
+  "avatarFraming": {
+    "scale": 0.65,
+    "x": 0,
+    "y": 1450
+  },
+  "motion": {
+    "intensity": 1
+  },
+  "blinkSeed": 42,
+  "lines": [
+    {
+      "text": "こんにちは。",
+      "chapter": "ごあいさつ",
+      "pauseAfter": 0.03
+    },
+    {
+      "text": "ここは AITuber OnAir のニュースデスク。",
+      "chapter": "ニュースデスクとは",
+      "pauseAfter": 0.03
+    },
+    {
+      "text": "新しいリリースを私がお知らせします。",
+      "pauseAfter": 0.03
+    }
+  ]
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/tests/gen-unit.test.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/tests/gen-unit.test.ts
@@ -1,0 +1,238 @@
+import { createCanvas, loadImage } from '@napi-rs/canvas';
+import { createMouthValues } from '../src/gen/audio.js';
+import { createBlinkSchedule } from '../src/gen/blink.js';
+import {
+  createRenderer,
+  MOUTH_OPEN_THRESHOLD,
+  resolveMouthState,
+} from '../src/gen/renderer.js';
+import {
+  resolveLocalAssetPath,
+  resolveModelAssetPath,
+  type Inochi2DAvatarDiagnostics,
+  type Inochi2DFrameInput,
+  type Inochi2DFrameSource,
+} from '../src/gen/inochi2dAvatar.js';
+import { VirtualClock } from '../harness/virtualClock.js';
+import { expandHomePath, resolveFrom } from '../src/paths.js';
+import type { RenderConfig } from '../src/types.js';
+
+const diagnostics: Inochi2DAvatarDiagnostics = {
+  runtime: 'inox2d-wasm-webgl2',
+  canvasSize: { width: 1_080, height: 1_920 },
+  mouthParameterId: 'Mouth:: Shape',
+  mouthParameterKind: 'vec2',
+  eyeParameterIds: ['Eye:: Left:: Blink', 'Eye:: Right:: Blink'],
+  idleAnimation: 'original_idle_calm_breath',
+  idleAnimationActive: true,
+  avatarFraming: {
+    scale: 0.65,
+    x: 0,
+    y: 1450,
+  },
+  virtualClock: {
+    seed: 42,
+    timeMs: 0,
+    callbacksPerFrame: 1,
+    pendingCallbacks: 1,
+  },
+  launchMode: 'swiftshader',
+  captureMode: 'playwright-png-screenshot',
+};
+
+describe('deterministic animation helpers', () => {
+  it('creates the same blink schedule for the same seed', () => {
+    const first = createBlinkSchedule(300, 30, 42);
+    const second = createBlinkSchedule(300, 30, 42);
+    const different = createBlinkSchedule(300, 30, 43);
+
+    expect(first).toEqual(second);
+    expect(first).not.toEqual(different);
+    expect(first.includes(1)).toBe(true);
+  });
+
+  it('flushes rAF callbacks in order and defers nested callbacks', () => {
+    const clock = new VirtualClock();
+    const calls: string[] = [];
+    clock.reset(42);
+    clock.requestAnimationFrame(() => {
+      calls.push('first');
+      clock.requestAnimationFrame(() => calls.push('nested'));
+    });
+    clock.requestAnimationFrame(() => calls.push('second'));
+
+    clock.advance(1 / 30);
+    expect(clock.flushAnimationFrame()).toBe(2);
+    expect(calls).toEqual(['first', 'second']);
+    expect(clock.pendingAnimationFrames()).toBe(1);
+    clock.advance(1 / 30);
+    expect(clock.flushAnimationFrame()).toBe(1);
+    expect(calls).toEqual(['first', 'second', 'nested']);
+  });
+
+  it('replays mulberry32 values from the same seed', () => {
+    const first = new VirtualClock();
+    const second = new VirtualClock();
+    const different = new VirtualClock();
+    first.reset(42);
+    second.reset(42);
+    different.reset(43);
+
+    const firstValues = [first.random(), first.random(), first.random()];
+    expect([second.random(), second.random(), second.random()]).toEqual(
+      firstValues,
+    );
+    expect([
+      different.random(),
+      different.random(),
+      different.random(),
+    ]).not.toEqual(firstValues);
+  });
+
+  it('keeps RMS normalized and applies the mouth reporting threshold', () => {
+    const empty = createMouthValues(
+      { samples: new Float32Array(), sampleRate: 48_000 },
+      30,
+      2,
+    );
+    const loud = createMouthValues(
+      { samples: new Float32Array(3_200).fill(1), sampleRate: 48_000 },
+      30,
+      2,
+    );
+
+    expect([...empty]).toEqual([0, 0]);
+    expect([...loud].every((value) => value >= 0 && value <= 1)).toBe(true);
+    expect(resolveMouthState(MOUTH_OPEN_THRESHOLD - 0.001)).toBe('closed');
+    expect(resolveMouthState(MOUTH_OPEN_THRESHOLD)).toBe('open');
+  });
+});
+
+describe('local Inochi2D paths', () => {
+  it('expands the current user home only for a leading tilde segment', () => {
+    expect(expandHomePath('~/models/avatar.inx')).not.toContain('~');
+    expect(expandHomePath('other/~/avatar.inx')).toBe('other/~/avatar.inx');
+    expect(resolveFrom('/tmp/scripts/news.json', '~/model.json')).toBe(
+      expandHomePath('~/model.json'),
+    );
+  });
+
+  it('keeps model asset requests inside the served model directory', () => {
+    expect(
+      resolveModelAssetPath('/models/avatar', '/model/textures/texture.png'),
+    ).toBe('/models/avatar/textures/texture.png');
+    expect(
+      resolveModelAssetPath('/models/avatar', '/model/../private.txt'),
+    ).toBeNull();
+    expect(
+      resolveModelAssetPath('/models/avatar', '/model/%2e%2e/private.txt'),
+    ).toBeNull();
+    expect(
+      resolveModelAssetPath('/models/avatar', '/model/..%5cprivate.txt'),
+    ).toBeNull();
+    expect(
+      resolveLocalAssetPath('/runtime', '/runtime/', '/runtime/inochi2d.js'),
+    ).toBe('/runtime/inochi2d.js');
+    expect(
+      resolveLocalAssetPath('/runtime', '/runtime/', '/runtime/%2e%2e/key'),
+    ).toBeNull();
+  });
+});
+
+describe('Inochi2D frame-source contract', () => {
+  it('passes mouth, blink, and fixed-step animation values sequentially', async () => {
+    const inputs: Inochi2DFrameInput[] = [];
+    const source = await createFakeFrameSource(inputs);
+    const renderer = await createRenderer(createConfig(), source);
+
+    await renderer.render(0, 0.75, true);
+    await renderer.render(1, 0.25, false);
+
+    expect(inputs).toEqual([
+      {
+        frameNumber: 0,
+        time: 0,
+        deltaSeconds: 0,
+        mouth: 0.75,
+        eyesClosed: true,
+      },
+      {
+        frameNumber: 1,
+        time: 0.1,
+        deltaSeconds: 0.1,
+        mouth: 0.25,
+        eyesClosed: false,
+      },
+    ]);
+  });
+
+  it('places the transparent browser frame using avatarLayout', async () => {
+    const source = await createFakeFrameSource([]);
+    const renderer = await createRenderer(createConfig(), source);
+
+    await renderer.render(0, 0, false);
+    const context = renderer.canvas.getContext('2d');
+    const background = context.getImageData(0, 0, 1, 1).data;
+    const avatarCenter = context.getImageData(5, 15, 1, 1).data;
+
+    expect([...background]).toEqual([0, 0, 0, 255]);
+    expect([...avatarCenter]).toEqual([255, 0, 0, 255]);
+  });
+
+  it('rejects non-sequential frame requests before calling the source', async () => {
+    const inputs: Inochi2DFrameInput[] = [];
+    const source = await createFakeFrameSource(inputs);
+    const renderer = await createRenderer(createConfig(), source);
+
+    await expect(renderer.render(1, 0, false)).rejects.toThrow(
+      /Frames must be rendered sequentially/,
+    );
+    expect(inputs).toEqual([]);
+  });
+});
+
+async function createFakeFrameSource(
+  inputs: Inochi2DFrameInput[],
+): Promise<Inochi2DFrameSource> {
+  const canvas = createCanvas(4, 4);
+  const context = canvas.getContext('2d');
+  context.fillStyle = '#ff0000';
+  context.fillRect(0, 0, 4, 4);
+  const image = await loadImage(canvas.toBuffer('image/png'));
+  return {
+    width: 4,
+    height: 4,
+    diagnostics,
+    async renderFrame(input) {
+      inputs.push(input);
+      return { image, elapsedMs: 2.5 };
+    },
+    async close() {},
+  };
+}
+
+function createConfig(): RenderConfig {
+  return {
+    width: 20,
+    height: 20,
+    fps: 10,
+    background: { color: '#000000' },
+    avatarLayout: { scale: 2, x: 0.25, y: 0.75 },
+    avatarFraming: {
+      scale: 0.65,
+      x: 0,
+      y: 1450,
+    },
+    avatarMotion: '/model/avatar.motion.json',
+    inochi2dRuntime: '/runtime',
+    motion: { intensity: 2 },
+    blinkSeed: 42,
+    avatar: '/model/avatar.inx',
+    audio: '/audio.wav',
+    output: '/video.mp4',
+    telop: '',
+    subtitles: [],
+    chapters: [],
+    duration: 1,
+  };
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/tests/script-gen.test.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/tests/script-gen.test.ts
@@ -1,0 +1,354 @@
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import type { Message, ToolChatCompletion } from '@aituber-onair/core';
+import type { AgentChatModuleLike } from '../src/script-gen/codex.js';
+import {
+  extractJsonPayload,
+  requestScriptViaCodex,
+} from '../src/script-gen/codex.js';
+import type { ChatServiceFactoryLike } from '../src/script-gen/chat.js';
+import {
+  loadChatServiceFactory,
+  requestScript,
+  resolveApiKey,
+} from '../src/script-gen/chat.js';
+import {
+  analysisPathForOutput,
+  normalizeScriptForOutput,
+  parseArgs,
+} from '../src/script-gen/cli.js';
+import { ingestSource } from '../src/script-gen/ingest.js';
+import { buildUserPrompt } from '../src/script-gen/prompt.js';
+import {
+  assertTokenProvenance,
+  parseAndValidateScript,
+  validateScript,
+} from '../src/script-gen/schema.js';
+import type { NewsdeskScript } from '../src/types.js';
+
+const testDirectory = path.dirname(new URL(import.meta.url).pathname);
+const projectRoot = path.resolve(testDirectory, '..');
+
+const validScript: NewsdeskScript = {
+  avatar: '/path/to/inochi2d/models/avatar.inx',
+  avatarMotion: '/path/to/inochi2d/models/avatar.motion.json',
+  inochi2dRuntime: '/path/to/inochi2d/runtime',
+  voice: {
+    engine: 'sine',
+    options: { frequency: 440, secondsPerChar: 0.01, minDuration: 0.2 },
+  },
+  leadIn: 0.1,
+  leadOut: 0.2,
+  defaultPauseAfter: 0.08,
+  background: { color: '#20242c' },
+  avatarLayout: { scale: 1, x: 0.5, y: 0.5 },
+  avatarFraming: { scale: 0.65, x: 0, y: 1450 },
+  motion: { intensity: 1 },
+  blinkSeed: 42,
+  lines: [
+    { text: 'ミコです。', chapter: 'chat 0.49.0', pauseAfter: 0.08 },
+    { text: 'JSON出力を改善しました。', pauseAfter: 0.08 },
+    { text: '2件の境界ケースを修正しました。', pauseAfter: 0.08 },
+  ],
+};
+
+const validResponse = {
+  analysis: {
+    docType: 'release-notes',
+    title: 'chat 0.49.0',
+    keyFacts: ['JSON output improved', '2 edge cases fixed'],
+  },
+  script: validScript,
+};
+
+function completion(textBlocks: string[]): ToolChatCompletion {
+  return {
+    blocks: textBlocks.map((text) => ({ type: 'text' as const, text })),
+    stop_reason: 'end',
+  };
+}
+
+describe('script generation CLI and source ingestion', () => {
+  it('parses one source and defaults to codex-sdk and script.json', () => {
+    expect(parseArgs(['notes.txt', '--focus', '料金', '--dry-run'])).toEqual({
+      source: 'notes.txt',
+      focus: '料金',
+      output: 'script.json',
+      provider: 'codex-sdk',
+      dryRun: true,
+      help: false,
+    });
+    expect(() => parseArgs(['a.txt', 'b.txt'])).toThrow(/second input source/);
+    expect(() => parseArgs(['--changelog', 'CHANGELOG.md'])).toThrow(
+      /Unknown argument/,
+    );
+  });
+
+  it('normalizes files and standard input to plain text', async () => {
+    const fileText = await ingestSource('tests/fixtures/CHANGELOG.md');
+    const stdinText = await ingestSource('-', {
+      input: Readable.from(['first\r\n', 'second\n']),
+    });
+
+    expect(fileText).toMatch(/^# Changelog/);
+    expect(stdinText).toBe('first\nsecond');
+  });
+
+  it('extracts article text from an HTML URL', async () => {
+    const html = `<!doctype html><html><head><title>News</title></head><body>
+      <nav>Navigation</nav><article><h1>大切なお知らせ</h1>
+      <p>料金を20円改定します。</p></article></body></html>`;
+    const fetchImpl = (async () =>
+      new Response(html, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })) as typeof fetch;
+
+    const source = await ingestSource('https://example.com/news', {
+      fetchImpl,
+    });
+
+    expect(source).toMatch(/大切なお知らせ/);
+    expect(source).toMatch(/料金を20円改定/);
+    expect(source).not.toMatch(/Navigation/);
+  });
+
+  it('builds an optional focus prompt without altering the source', () => {
+    const prompt = buildUserPrompt({
+      sourceText: '本文です。',
+      focus: '料金の話を中心に',
+    });
+
+    expect(prompt).toMatch(
+      /Center the script on this perspective:\n料金の話を中心に/,
+    );
+    expect(prompt).toMatch(/Source text:\n\n本文です。$/);
+    expect(buildUserPrompt({ sourceText: '本文', focus: null })).not.toMatch(
+      /perspective/,
+    );
+  });
+});
+
+describe('strict schema and provenance', () => {
+  it('validates the nested response and rejects unknown analysis fields', () => {
+    expect(parseAndValidateScript(JSON.stringify(validResponse))).toEqual(
+      validResponse,
+    );
+    expect(() => parseAndValidateScript('```json\n{}\n```')).toThrow(
+      /not valid JSON/,
+    );
+    expect(() =>
+      parseAndValidateScript(
+        JSON.stringify({
+          ...validResponse,
+          analysis: { ...validResponse.analysis, extra: true },
+        }),
+      ),
+    ).toThrow(/analysis\.extra is not allowed/);
+  });
+
+  it('accepts 3 to 12 lines and keeps the 35-character limit', () => {
+    expect(validateScript(validScript)).toEqual([]);
+    expect(
+      validateScript({
+        ...validScript,
+        lines: Array.from({ length: 12 }, () => ({ text: 'あ'.repeat(35) })),
+      }),
+    ).toEqual([]);
+    expect(
+      validateScript({
+        ...validScript,
+        lines: Array.from({ length: 13 }, () => ({ text: '有効な行です。' })),
+      }).join('\n'),
+    ).toMatch(/between 3 and 12/);
+    expect(
+      validateScript({
+        ...validScript,
+        unexpected: true,
+        lines: [...validScript.lines.slice(0, 2), { text: 'あ'.repeat(36) }],
+      }).join('\n'),
+    ).toMatch(/unexpected is not allowed|at most 35/);
+  });
+
+  it('validates optional avatar framing overrides', () => {
+    expect(
+      validateScript({ ...validScript, avatarFraming: undefined }),
+    ).toEqual([]);
+    expect(
+      validateScript({
+        ...validScript,
+        avatarFraming: {
+          scale: 0,
+          x: 10_001,
+          extra: true,
+        },
+      }).join('\n'),
+    ).toMatch(
+      /scale must be at least 0.01|x must be at most 10000|extra is not allowed/,
+    );
+  });
+
+  it('requires valid model, motion, and runtime paths', () => {
+    expect(validateScript({ ...validScript, avatarMotion: undefined })).toEqual(
+      [],
+    );
+    expect(
+      validateScript({
+        ...validScript,
+        avatar: '/path/to/avatar.json',
+        avatarMotion: '/path/to/avatar.motion.bin',
+        inochi2dRuntime: '',
+      }).join('\n'),
+    ).toMatch(
+      /avatar must point to an .inx|avatarMotion must point to a JSON|inochi2dRuntime must be a non-empty string/,
+    );
+  });
+
+  it('checks displayed numeric tokens against source plus focus', () => {
+    const script: NewsdeskScript = {
+      ...validScript,
+      telop: '2026年のお知らせ',
+      lines: [
+        { text: 'ミコです。', chapter: 'chat 0.49.0' },
+        { text: '2件を修正しました。', reading: 'にけんを修正しました。' },
+        { text: '料金は300円です。' },
+      ],
+    };
+    const source = 'chat 0.49.0 は2026年に2件を修正しました。';
+
+    expect(() =>
+      assertTokenProvenance(script, source, '料金は300円'),
+    ).not.toThrow();
+    expect(() => assertTokenProvenance(script, source)).toThrow(/300/);
+  });
+
+  it('canonicalizes leading zeroes only for pure-integer provenance tokens', () => {
+    const script: NewsdeskScript = {
+      ...validScript,
+      lines: [
+        { text: '7月25日です。' },
+        { text: '数字なし' },
+        { text: '数字なし' },
+      ],
+    };
+
+    expect(() =>
+      assertTokenProvenance(script, '公開日は2026-07-25です。'),
+    ).not.toThrow();
+    expect(() =>
+      assertTokenProvenance(
+        {
+          ...script,
+          lines: [{ text: '8月25日です。' }, ...script.lines.slice(1)],
+        },
+        '公開日は2026-7-25です。',
+      ),
+    ).toThrow(/8/);
+  });
+});
+
+describe('Core chat providers', () => {
+  it('requests a script through a ChatServiceFactory-compatible fake', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const factory: ChatServiceFactoryLike = {
+      createChatService(provider, options) {
+        calls.push({ provider, options });
+        return {
+          async chatOnce(
+            messages: Message[],
+            stream: boolean,
+            _onPartialResponse: (text: string) => void,
+            maxTokens?: number,
+          ) {
+            calls.push({ messages, stream, maxTokens });
+            return completion(['{"analysis":', '{},"script":{}}']);
+          },
+        };
+      },
+    };
+
+    const result = await requestScript({
+      provider: 'openai',
+      apiKey: 'test-secret',
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      factory,
+    });
+
+    expect(result).toBe('{"analysis":{},"script":{}}');
+    expect(calls[0]).toEqual({
+      provider: 'openai',
+      options: {
+        apiKey: 'test-secret',
+        responseFormat: { type: 'json_object' },
+      },
+    });
+    expect(calls[1]?.stream).toBe(false);
+    expect(calls[1]?.maxTokens).toBe(2_000);
+  });
+
+  it('uses the codex-sdk Core agent provider without an API key', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const agentModule: AgentChatModuleLike = {
+      createAgentChatService(provider, options) {
+        calls.push({ provider, options });
+        return {
+          async chatOnce(messages, stream) {
+            calls.push({ messages, stream });
+            return completion(['```json\n{"a":1}\n```']);
+          },
+        };
+      },
+    };
+
+    const raw = await requestScriptViaCodex({
+      systemPrompt: 'System rules.',
+      userPrompt: 'User input.',
+      agentModule,
+    });
+
+    expect(raw).toBe('{"a":1}');
+    expect(calls[0]).toEqual({
+      provider: 'codex-sdk',
+      options: { skipGitRepoCheck: true },
+    });
+    expect(calls[1]?.stream).toBe(false);
+  });
+
+  it('unwraps optional JSON fences', () => {
+    expect(extractJsonPayload('  {"a":1}  ')).toBe('{"a":1}');
+    expect(extractJsonPayload('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it('resolves keys only for API providers and loads Core factory', () => {
+    expect(resolveApiKey('openai', { OPENAI_API_KEY: 'openai-key' })).toBe(
+      'openai-key',
+    );
+    expect(resolveApiKey('claude', { ANTHROPIC_API_KEY: 'claude-key' })).toBe(
+      'claude-key',
+    );
+    expect(resolveApiKey('gemini', { GEMINI_API_KEY: 'gemini-key' })).toBe(
+      'gemini-key',
+    );
+    expect(() => resolveApiKey('openai', {})).toThrow(
+      /OPENAI_API_KEY is required/,
+    );
+    expect(loadChatServiceFactory().getAvailableProviders?.()).toEqual(
+      expect.arrayContaining(['openai', 'claude', 'gemini']),
+    );
+  });
+
+  it('normalizes generated scripts to license-safe local placeholders', () => {
+    const outputPath = path.join(projectRoot, 'samples', 'news.json');
+    const normalized = normalizeScriptForOutput(validScript, outputPath);
+    expect(normalized.avatar).toBe('/path/to/inochi2d/models/avatar.inx');
+    expect(normalized.avatarMotion).toBe(
+      '/path/to/inochi2d/models/avatar.motion.json',
+    );
+    expect(normalized.inochi2dRuntime).toBe('/path/to/inochi2d/runtime');
+    expect(analysisPathForOutput(outputPath)).toBe(
+      path.join(projectRoot, 'samples', 'news.analysis.json'),
+    );
+    expect(analysisPathForOutput('/tmp/news')).toBe('/tmp/news.analysis.json');
+  });
+});

--- a/packages/core/examples/node-inochi2d-newsdesk/tsconfig.dev.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/tsconfig.dev.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests", "vitest.config.ts", "vitest.e2e.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/tsconfig.json
+++ b/packages/core/examples/node-inochi2d-newsdesk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/core/examples/node-inochi2d-newsdesk/vitest.config.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['./tests/**/*.test.ts'],
+    exclude: ['./tests/e2e/**/*.test.ts'],
+  },
+});

--- a/packages/core/examples/node-inochi2d-newsdesk/vitest.e2e.config.ts
+++ b/packages/core/examples/node-inochi2d-newsdesk/vitest.e2e.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['./tests/e2e/**/*.test.ts'],
+    testTimeout: 180_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

Sixth `node-<format>-newsdesk` example: `packages/core/examples/node-inochi2d-newsdesk`. Same pipeline as #319–#324, with the avatar rendered by `react-inochi2d-app`'s **unmodified WASM Inochi2D runtime bridge** inside the headless-Chromium harness.

- The bridge runs its own rAF loop on `performance.now()` / `Math.random()`, so the harness installs a **seeded virtual clock** before the bridge loads (patched `requestAnimationFrame`/`cancelAnimationFrame`, `performance.now`, `Date.now`, mulberry32 `Math.random` seeded from `blinkSeed`) and advances exactly one frame interval per output frame, asserting the bridge queues exactly one next callback. Deterministic without forking the bridge — two consecutive renders produce **byte-identical MP4s** on the same machine (md5 asserted in e2e).
- Mouth via the React example's candidate list (`Mouth:: Shape` vec2 first, `setParameterVector`), blink via `setEyeBlinkValue`, looping `original_idle_calm_breath` idle; `motion.intensity` maps to animation weight.
- Runtime, Aka `.inx`, and motion JSON referenced from `react-inochi2d-app` by relative path — nothing copied. Aka is CC BY 4.0; the attribution and modification notes are reproduced in README en/ja. The small dark patches near the ears also appear in the React example's screenshot — model/runtime artifacts, not a harness regression.
- vitest unit (24/24) + always-on e2e, `docs/examples*.md` entries. Other examples untouched (read-only asset reuse).

## Verification

- Example: fmt / lint / typecheck / test (24/24) / build / test:e2e (1/1, real Chromium + Aka) pass; root fmt → lint → test → build pass.
- Rendered `samples/hello-sine.json` and the AivisSpeech sample; inspected frames: lip-sync, deterministic blink, idle breath, bust-up framing, overlays. ~220 ms/frame with SwiftShader.
- Real end-to-end with the default `codex-sdk` provider: `script-gen tests/fixtures/CHANGELOG.md --focus 0.49.0` → `gen` → MP4.
- public-release-check (diff): no findings; no binaries or local paths in tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
