### PR TITLE
feat(core-examples): add Anime2.5DRig motion mode to node-psd-newsdesk

### DIFF
--- a/docs/examples.ja.md
+++ b/docs/examples.ja.md
@@ -201,7 +201,8 @@ npm run dev
   4状態 PNGTuber ニュース動画を作る Node.js パイプライン。
 - [`packages/core/examples/node-psd-newsdesk`](../packages/core/examples/node-psd-newsdesk):
   ソーステキストから Core のチャット・音声を通して、チャプター付き縦型
-  静的 PSDTool アバターニュース動画を作る Node.js パイプライン。
+  PSD アバターニュース動画を作る Node.js パイプライン。静的 PSDTool と
+  ヘッドレス Chromium の Anime2.5DRig motion の両モードに対応。
 - [`packages/core/examples/node-vrm-newsdesk`](../packages/core/examples/node-vrm-newsdesk):
   ヘッドレス Chromium で VRM を描画し、Core のチャット・音声を通して
   チャプター付き縦型アバターニュース動画を作る Node.js パイプライン。

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -201,7 +201,8 @@ npm run dev
   vertical four-state PNGTuber news video.
 - [`packages/core/examples/node-psd-newsdesk`](../packages/core/examples/node-psd-newsdesk):
   Node.js pipeline from source text through Core chat and voice to a chaptered
-  vertical static PSDTool avatar news video.
+  vertical PSD avatar news video, with static PSDTool and headless-Chromium
+  Anime2.5DRig motion modes.
 - [`packages/core/examples/node-vrm-newsdesk`](../packages/core/examples/node-vrm-newsdesk):
   Node.js pipeline that drives a headless-Chromium VRM renderer and produces a
   chaptered vertical avatar news video with Core chat and voice.

--- a/packages/core/examples/node-psd-newsdesk/README.ja.md
+++ b/packages/core/examples/node-psd-newsdesk/README.ja.md
@@ -5,15 +5,16 @@
 この AITuber OnAir Core サンプルは、ソーステキストをチャプター付きの日本語
 ニュース動画へ変換します。Core のチャットプロバイダーでレビュー可能な JSON
 台本を生成し、Core の `VoiceEngineAdapter` またはローカルテスト音源で音声を
-作り、音声 RMS と決定論的なまばたきに合わせて静的 PSDTool 形式の `.psd`
-レイヤーを合成し、チャプターラベルと字幕入りの縦型 H.264/AAC MP4 を出力します。
+作り、静的 PSDTool 合成または Anime2.5DRig WebGL motion を選択して、
+チャプターラベルと字幕入りの縦型 H.264/AAC MP4 を出力します。
 
 ```text
 ファイル、標準入力、URL
   -> Core chat / Core Agent SDK
   -> script.json + analysis.json（確認）
   -> Core voice / sine / macOS say
-  -> 静的 PSDTool レイヤー + 2値 RMS 口パク + 決定論的なまばたき
+  -> 自動判定 -> Anime2.5DRig motion または静的 PSDTool fallback
+  -> 音声口パク + 決定論的な motion / まばたき
   -> ffmpeg -> 1080x1920 MP4（確認）
 ```
 
@@ -24,6 +25,7 @@
 
 - Node.js 22 以降と npm
 - `PATH` 上の `ffmpeg` と `ffprobe`
+- `auto` 判定と motion mode 用に Playwright からインストールした Chromium
 - 既定の `codex-sdk` 用の ChatGPT サインイン、または API プロバイダー用の
   API キー
 - 任意: 同梱の「まお」サンプルを使う場合は
@@ -36,6 +38,7 @@
 
 ```sh
 npm install
+npx playwright install chromium
 npm run build
 ```
 
@@ -96,6 +99,19 @@ npm run gen -- \
   --output work/hello-newsdesk.mp4
 ```
 
+motion sample は、隣接する React example の procedural な motion 対応 PSD を
+コピーせずに参照します。
+
+```sh
+npm run gen -- \
+  --script samples/hello-sine-motion.json \
+  --output work/hello-sine-motion.mp4
+
+npm run gen -- \
+  --script samples/hello-newsdesk-motion.json \
+  --output work/hello-newsdesk-motion.mp4
+```
+
 追加モード:
 
 ```sh
@@ -114,6 +130,15 @@ npm run gen -- --script samples/hello-sine.json --frame 45 --png work/frame45.pn
 配置、固定のまばたき seed、3〜12行のナレーションを指定します。各行には字幕、
 発音調整用の `reading`、チャプターラベル、後続 pause を設定できます。完全な
 定義は [`script.json` フォーマット](./docs/script-format.md)を参照してください。
+
+## PSD モード
+
+描画モードは2つとも第一級です。既定の `avatarMode: "auto"` は最初に
+Anime2.5DRig rigger を実行し、正規化された `face` part があれば motion mode、
+対象外なら静的 PSDTool mode に fallback します。`avatarMode: "static"` は
+Chromium を起動せず、既存の pure Node Canvas 2D renderer を使います。
+`avatarMode: "motion"` は利用可能な rig を必須とし、対象外 PSD では rigger の
+診断文をそのまま表示して停止します。
 
 ## 静的 PSDTool モード
 
@@ -154,10 +179,8 @@ Node レンダラーは `react-psd-app` の静的 PSDTool 経路を再現しま�
 停止します。正規化 RMS が `0.45` 以上なら `mouthOpen`、未満なら
 `mouthClosed` を表示します。
 
-モーションモードは明示的な非目標です。Anime2.5DRig モーションモードには WebGL
-メッシュレンダラーが必要なため移植していません。このサンプルではモーションモード用
-PSD も静的モードで描画され、口・目ロールだけを切り替えます。小さな呼吸上下動と
-ロールは動画フレーム専用の変換で、`motion.intensity` の `0` で無効化できます。
+小さな呼吸上下動とロールは動画フレーム専用の変換で、
+`motion.intensity` の `0` で無効化できます。
 
 静的モードの制限は `react-psd-app` と同じです。PSB は非対応、既知の正常入力は
 通常ピクセルレイヤーを持つ8-bit RGB PSD です。通常以外のブレンドモードは通常の
@@ -172,10 +195,37 @@ React PNGTuber サンプルから決定的に再生成するには `npm run gene
 部分だけを持ちます。この切り抜きにより、キャンバス全体を覆う一方のロールが他方を
 隠すことなく、口と目のグループを独立して切り替えられます。
 
+## Anime2.5DRig motion mode
+
+motion mode は headless Chromium を使い、次の sibling source を read-only で
+bundle します。
+
+- `react-psd-app/src/vendor/anime25drig/rigger.js`
+- `react-psd-app/src/lib/rig/anime25Rig.ts`
+- `react-psd-app/src/lib/rig/anime25Renderer.ts`
+
+harness は renderer bundle より先に seeded virtual clock を導入し、
+`requestAnimationFrame`、`cancelAnimationFrame`、`performance.now`、
+`Date.now`、`Math.random` を置き換えます。各出力フレームでは renderer が公開する
+audio `mouthOpen` 入力を設定し、仮想時刻を進め、現在の rAF callback を正確に1回
+flush し、次の callback が1件だけ queue されたことを確認します。idle sway、呼吸、
+random motion、mesh physics は有効なまま再現可能になります。
+`motion.intensity` は renderer へ渡され、motion 側では `0` から `2` です。
+
+sibling renderer は目の開閉を直接設定する API を公開していません。そのため
+motion mode では Node の `eyesClosed` schedule を使わず、内蔵 blink automation を
+維持します。時刻と乱数を `blinkSeed` から固定するため、まばたきも決定論的です。
+static mode は従来どおり Node schedule で目を直接切り替えます。
+
+motion sample は `../../react-psd-app/public/avatar/sample.psd` を参照します。
+この PSD は React example が procedural に生成した配布可能な素材で、この package
+にはコピーしません。
+
 ## 検証
 
 ```sh
 npm install
+npx playwright install chromium
 npm run fmt
 npm run lint
 npm run typecheck
@@ -184,11 +234,23 @@ npm run build
 npm run test:e2e
 ```
 
-E2E テストは `dist/gen.cjs` から実際に動画を生成し、ffprobe で H.264/AAC、
-1080x1920 PNG を確認します。同じ sine 音声を `--render-only` で再生成した
-MP4 の MD5 が一致することも検証します。
+常時 E2E は `dist/gen.cjs` から static / motion の両方を描画し、ffprobe で
+H.264/AAC、1080x1920 PNG、motion の口・idle pixel 差分を確認します。motion は
+同じ入力を連続2回描画して timings JSON と MP4 MD5 も比較します。
 
 ## 素材利用条件とクレジット
+
+Anime2.5DRig 互換 auto-rigging と renderer のクレジットは次のとおりです。
+
+- Project: [Anime2.5DRig](https://github.com/852wa/Anime2.5DRig)
+- Author: 852wa (hakoniwa)
+- Copyright: Copyright (c) 2026 hakoniwa
+- License: MIT License
+- Upstream commit: `d48825867acd081de22b0e7b5585bb562288796d`
+
+この example は vendored sibling rigger と renderer を read-only で import し、
+コピーしません。sibling の `public/avatar/sample.psd` は procedural に生成された
+license-clean な素材です。
 
 同梱のミコ由来 PSD アバターの著作権表記は © Yuki Shindo (AITuber OnAir) です。
 このアバターはリポジトリの MIT License 対象外です。作品・コンテンツの一部

--- a/packages/core/examples/node-psd-newsdesk/README.md
+++ b/packages/core/examples/node-psd-newsdesk/README.md
@@ -5,16 +5,16 @@
 This AITuber OnAir Core example turns source text into a chaptered Japanese
 news video. It generates a reviewed JSON script with a Core chat provider,
 synthesizes narration through Core's `VoiceEngineAdapter` or a local test
-engine, composites a static PSDTool-style `.psd` layer tree while switching
-mouth and eye roles from audio RMS and deterministic blinks, and writes a
-vertical H.264/AAC MP4 with chapter labels and subtitles.
+engine, selects either static PSDTool compositing or Anime2.5DRig WebGL motion,
+and writes a vertical H.264/AAC MP4 with chapter labels and subtitles.
 
 ```text
 file, stdin, or URL
   -> Core chat / Core Agent SDK
   -> script.json + analysis.json (review)
   -> Core voice / sine / macOS say
-  -> static PSDTool layers + binary RMS lip sync + deterministic blink
+  -> auto detection -> Anime2.5DRig motion or static PSDTool fallback
+  -> audio lip sync + deterministic motion/blink
   -> ffmpeg -> 1080x1920 MP4 (review)
 ```
 
@@ -26,6 +26,7 @@ X, YouTube, or another service.
 
 - Node.js 22 or later and npm
 - `ffmpeg` and `ffprobe` on `PATH`
+- Chromium installed through Playwright for `auto` detection and motion mode
 - A ChatGPT sign-in for the default `codex-sdk` provider, or an API key for an
   API provider
 - Optional: AivisSpeech at `http://127.0.0.1:10101` for the bundled Mao sample
@@ -37,6 +38,7 @@ macOS-only smoke-test option and is not intended for published narration.
 
 ```sh
 npm install
+npx playwright install chromium
 npm run build
 ```
 
@@ -97,6 +99,19 @@ npm run gen -- \
   --output work/hello-newsdesk.mp4
 ```
 
+Motion samples reference the procedural, motion-capable PSD from the sibling
+React example without copying it:
+
+```sh
+npm run gen -- \
+  --script samples/hello-sine-motion.json \
+  --output work/hello-sine-motion.mp4
+
+npm run gen -- \
+  --script samples/hello-newsdesk-motion.json \
+  --output work/hello-newsdesk-motion.mp4
+```
+
 Additional generation modes:
 
 ```sh
@@ -116,6 +131,15 @@ overrides, voice engine/options, background, avatar layout, deterministic blink
 seed, and 3–12 narration lines. Each line may set subtitle text, a
 pronunciation-only `reading`, a chapter label, and its following pause. See the
 complete [`script.json` format](./docs/script-format.md).
+
+## PSD modes
+
+There are two first-class render modes. `avatarMode: "auto"` is the default:
+the Anime2.5DRig rigger runs first, and a normalized `face` part selects motion
+mode. Ineligible PSDs fall back to static PSDTool mode. `avatarMode: "static"`
+skips Chromium and keeps the existing pure-Node Canvas 2D renderer.
+`avatarMode: "motion"` requires a usable rig and stops with the rigger's exact
+diagnostic when the PSD is ineligible.
 
 ## Static PSDTool mode
 
@@ -156,11 +180,8 @@ If detection and overrides cannot resolve every role, generation stops and
 prints the layer tree. Normalized RMS at or above `0.45` shows `mouthOpen`;
 lower values show `mouthClosed`.
 
-Motion mode is an explicit non-goal. Anime2.5DRig motion mode requires a WebGL
-mesh renderer and is not ported here. Motion-mode PSDs render in static mode in
-this example; only mouth/eye role layers switch. The small deterministic breath
-bob and roll are video-frame transforms controlled by `motion.intensity`, and
-`0` disables them.
+The small deterministic breath bob and roll are video-frame transforms
+controlled by `motion.intensity`, and `0` disables them.
 
 Static-mode limitations match `react-psd-app`: PSB is unsupported; the
 known-good input is an 8-bit RGB PSD with normal pixel layers; non-normal blend
@@ -176,10 +197,39 @@ the mouth and eye role layers contain only padded feature-difference regions.
 Those cropped roles let the mouth and eye groups switch independently instead
 of one full-canvas role covering the other.
 
+## Anime2.5DRig motion mode
+
+Motion mode uses headless Chromium and bundles these sibling sources read-only:
+
+- `react-psd-app/src/vendor/anime25drig/rigger.js`
+- `react-psd-app/src/lib/rig/anime25Rig.ts`
+- `react-psd-app/src/lib/rig/anime25Renderer.ts`
+
+The harness installs its seeded virtual clock before the renderer bundle loads.
+It replaces `requestAnimationFrame`, `cancelAnimationFrame`,
+`performance.now`, `Date.now`, and `Math.random`. For each output frame it
+sets the renderer's documented audio `mouthOpen` input, advances virtual time,
+flushes exactly one current rAF callback, and requires one next callback to be
+queued. Idle sway, breathing, random motion, and mesh physics therefore remain
+active but reproducible. `motion.intensity` is passed to the renderer, whose
+motion range is `0` through `2`.
+
+The sibling renderer exposes no direct eye-open input. Motion mode therefore
+keeps its built-in blink automation instead of using the Node `eyesClosed`
+schedule; blink timing is deterministic because both time and randomness are
+patched from `blinkSeed`. Static mode continues to use the Node schedule
+directly.
+
+The motion samples reference
+`../../react-psd-app/public/avatar/sample.psd`. That PSD is procedurally
+generated by the React example and is safe to ship; this package does not copy
+it.
+
 ## Verification
 
 ```sh
 npm install
+npx playwright install chromium
 npm run fmt
 npm run lint
 npm run typecheck
@@ -188,11 +238,24 @@ npm run build
 npm run test:e2e
 ```
 
-The end-to-end test renders through the bundled `dist/gen.cjs`, checks the
-H.264/AAC streams with ffprobe, verifies a 1080x1920 PNG, and confirms that a
-`--render-only` pass has the same MD5 as the initial deterministic sine render.
+The always-on end-to-end suite renders both modes through `dist/gen.cjs`, checks
+H.264/AAC streams with ffprobe, verifies 1080x1920 PNG frames, and checks motion
+mouth/idle pixel differences. Two consecutive motion renders compare timings
+JSON and MP4 MD5.
 
 ## Asset terms and attribution
+
+Anime2.5DRig-compatible auto-rigging and rendering carry this attribution:
+
+- Project: [Anime2.5DRig](https://github.com/852wa/Anime2.5DRig)
+- Author: 852wa (hakoniwa)
+- Copyright: Copyright (c) 2026 hakoniwa
+- License: MIT License
+- Upstream commit: `d48825867acd081de22b0e7b5585bb562288796d`
+
+This example imports the vendored sibling rigger and renderer read-only and
+does not copy them. The sibling `public/avatar/sample.psd` is procedurally
+generated and license-clean.
 
 The bundled Miko-derived PSD avatar is © Yuki Shindo (AITuber OnAir) and is not covered by
 the repository's MIT License. It may be redistributed as an integral part of a

--- a/packages/core/examples/node-psd-newsdesk/docs/script-format.md
+++ b/packages/core/examples/node-psd-newsdesk/docs/script-format.md
@@ -6,6 +6,7 @@ are resolved relative to the script file.
 ```json
 {
   "avatar": "../assets/sample-static.psd",
+  "avatarMode": "static",
   "voice": {
     "engine": "sine",
     "options": {
@@ -34,6 +35,9 @@ are resolved relative to the script file.
 ## Top-level fields
 
 - `avatar`: `.psd` path.
+- `avatarMode` (optional): `auto` (default), `static`, or `motion`. `auto`
+  selects motion only when the Anime2.5DRig rigger produces a normalized
+  `face` part, then falls back to static PSDTool compositing.
 - `avatarRoles` (optional): exact pixel-layer paths overriding automatic
   `mouthOpen`, `mouthClosed`, `eyesOpen`, and `eyesClosed` detection.
 - `output` (optional): MP4 path. The CLI `--output` takes precedence.
@@ -45,9 +49,10 @@ are resolved relative to the script file.
 - `background.color` and optional `background.image`: canvas background.
 - `telop` (optional): title shown only while no line chapter is active.
 - `avatarLayout`: avatar `scale` and fractional `x`/`y` anchors.
-- `motion.intensity`: multiplier clamped from 0 through 3 for the subtle,
-  deterministic breath bob and roll. This idle motion is a video-only addition;
-  `0` disables it.
+- `motion.intensity`: motion multiplier. Static mode clamps it from 0 through 3
+  for the video-only breath bob and roll. Motion mode passes it to the sibling
+  renderer, which clamps it from 0 through 2 for idle sway, breathing, random
+  motion, and physics.
 - `blinkSeed`: deterministic blink schedule seed.
 - `lines`: ordered narration and subtitle entries.
 
@@ -69,19 +74,38 @@ Normalized audio RMS values at or above `0.45` select the open-mouth role;
 lower values select the closed-mouth role. The threshold gives the bundled sine
 fixture clear open/closed alternation while remaining a simple binary lip-sync.
 
-## Static PSD behavior
+## PSD modes
+
+The general rule is motion detection first, static fallback second. With the
+default `auto`, the vendored Anime2.5DRig rigger must produce a normalized
+`face` part for motion mode. `static` skips Chromium and keeps the pure-Node
+Canvas 2D path. `motion` requires a usable rig and fails with the rigger's
+diagnostic when the PSD is ineligible.
+
+### Static PSDTool behavior
 
 Leading `!` forces a node visible. Leading `*` creates a sibling radio item;
 initial visibility keeps only the first visible radio item. The suffixes
 `:flipx`, `:flipy`, and `:flipxy` are parsed and removed from display paths, but
 the pixels are not flipped.
 
-This Node example always uses static Canvas 2D compositing. Anime2.5DRig motion
-mode is a WebGL feature and is not ported; motion-mode PSDs still render
-statically with only resolved mouth and eye role layers switching. PSB,
-non-normal blend rendering, masks, clipping masks, adjustment/effect rendering,
-PSDTool metadata, and visual flip variants are unsupported. Use an 8-bit RGB
-PSD with normal pixel layers.
+PSB, non-normal blend rendering, masks, clipping masks, adjustment/effect
+rendering, PSDTool metadata, and visual flip variants are unsupported. Use an
+8-bit RGB PSD with normal pixel layers.
+
+### Anime2.5DRig motion behavior
+
+Motion mode bundles the sibling rigger and WebGL mesh renderer read-only into a
+headless-Chromium harness. Before those modules load, the harness replaces
+`requestAnimationFrame`, `cancelAnimationFrame`, `performance.now`, `Date.now`,
+and `Math.random` with a virtual clock seeded by `blinkSeed`. Each video frame
+sets audio-derived `mouthOpen`, advances time, flushes exactly one current rAF
+callback, and requires the renderer to queue exactly one next callback.
+
+The renderer has no direct eye-open input, so the external `eyesClosed`
+schedule is intentionally unused in motion mode. Its built-in blink automation
+stays enabled and becomes deterministic through the seeded virtual clock. Idle
+sway, breathing, random motion, and physics also remain enabled.
 
 ## Line fields
 

--- a/packages/core/examples/node-psd-newsdesk/harness/index.html
+++ b/packages/core/examples/node-psd-newsdesk/harness/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PSD Motion Newsdesk Render Harness</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+      }
+
+      canvas {
+        display: block;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="avatar"></canvas>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/packages/core/examples/node-psd-newsdesk/harness/main.ts
+++ b/packages/core/examples/node-psd-newsdesk/harness/main.ts
@@ -1,0 +1,178 @@
+import { installBrowserVirtualClock, VirtualClock } from './virtualClock.js';
+
+interface MotionRuntimeDetection {
+  usable: boolean;
+  reason: string;
+  summary: {
+    canvasWidth: number;
+    canvasHeight: number;
+    layerCount: number;
+    anchorCount: number;
+    strandCount: number;
+    partsFound: string[];
+    missingRequiredParts: string[];
+    warnings: string[];
+    preprocessed: { noisy: number; layers: number };
+  } | null;
+}
+
+interface MotionRuntimeAvatar {
+  setMouthOpen(value: number): void;
+  setIntensity(value: number): void;
+  setMotionEnabled(value: boolean): void;
+  dispose(): void;
+}
+
+interface MotionRuntimeModule {
+  loadMotionRuntime(
+    canvas: HTMLCanvasElement,
+    psdBuffer: ArrayBuffer,
+  ): Promise<{
+    detection: MotionRuntimeDetection;
+    avatar: MotionRuntimeAvatar | null;
+  }>;
+}
+
+interface HarnessLoadOptions {
+  runtimeUrl: string;
+  avatarUrl: string;
+  blinkSeed: number;
+  motionIntensity: number;
+}
+
+interface HarnessFrameOptions {
+  time: number;
+  deltaSeconds: number;
+  mouth: number;
+  eyesClosed: boolean;
+}
+
+interface VirtualFrameDiagnostics {
+  timeMs: number;
+  callbacksPerFrame: number;
+  pendingCallbacks: number;
+}
+
+export interface HarnessLoadResult {
+  detection: MotionRuntimeDetection;
+  canvasSize: { width: number; height: number } | null;
+  virtualClock: {
+    seed: number;
+    timeMs: number;
+    callbacksPerFrame: number;
+    pendingCallbacks: number;
+  };
+  eyeInput: 'internal-seeded-automation';
+}
+
+interface HarnessState {
+  avatar: MotionRuntimeAvatar;
+  seed: number;
+  lastCallbacksPerFrame: number;
+}
+
+declare global {
+  interface Window {
+    load(options: HarnessLoadOptions): Promise<HarnessLoadResult>;
+    renderFrame(options: HarnessFrameOptions): VirtualFrameDiagnostics;
+  }
+}
+
+const virtualClock = new VirtualClock();
+virtualClock.reset(0);
+installBrowserVirtualClock(virtualClock);
+
+let state: HarnessState | null = null;
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+async function load(options: HarnessLoadOptions): Promise<HarnessLoadResult> {
+  state?.avatar.dispose();
+  state = null;
+  virtualClock.reset(options.blinkSeed);
+
+  const response = await fetch(options.avatarUrl);
+  if (!response.ok) {
+    throw new Error(`Could not load PSD avatar: HTTP ${response.status}.`);
+  }
+  const canvas = document.querySelector<HTMLCanvasElement>('#avatar');
+  if (!canvas) throw new Error('Harness canvas was not found.');
+  const runtime = (await import(
+    /* @vite-ignore */ options.runtimeUrl
+  )) as MotionRuntimeModule;
+  const loaded = await runtime.loadMotionRuntime(
+    canvas,
+    await response.arrayBuffer(),
+  );
+  const detection: MotionRuntimeDetection = {
+    usable: loaded.detection.usable,
+    reason: loaded.detection.reason,
+    summary: loaded.detection.summary,
+  };
+  if (!loaded.avatar || !loaded.detection.usable) {
+    return {
+      detection,
+      canvasSize: null,
+      virtualClock: {
+        seed: options.blinkSeed,
+        timeMs: virtualClock.now(),
+        callbacksPerFrame: 0,
+        pendingCallbacks: virtualClock.pendingAnimationFrames(),
+      },
+      eyeInput: 'internal-seeded-automation',
+    };
+  }
+
+  loaded.avatar.setMotionEnabled(true);
+  loaded.avatar.setIntensity(options.motionIntensity);
+  state = {
+    avatar: loaded.avatar,
+    seed: options.blinkSeed,
+    lastCallbacksPerFrame: 0,
+  };
+  renderFrame({ time: 0, deltaSeconds: 0, mouth: 0, eyesClosed: false });
+  return {
+    detection,
+    canvasSize: { width: canvas.width, height: canvas.height },
+    virtualClock: {
+      seed: options.blinkSeed,
+      timeMs: virtualClock.now(),
+      callbacksPerFrame: state.lastCallbacksPerFrame,
+      pendingCallbacks: virtualClock.pendingAnimationFrames(),
+    },
+    eyeInput: 'internal-seeded-automation',
+  };
+}
+
+function renderFrame(options: HarnessFrameOptions): VirtualFrameDiagnostics {
+  if (!state) throw new Error('Call window.load before window.renderFrame.');
+  state.avatar.setMouthOpen(clamp01(options.mouth));
+  // The sibling renderer exposes no direct eye-open setter. Its blink
+  // automation remains enabled and is deterministic under the patched clock.
+  void options.eyesClosed;
+  virtualClock.advance(options.deltaSeconds);
+  const expectedTimeMs = options.time * 1000;
+  if (Math.abs(virtualClock.now() - expectedTimeMs) > 0.001) {
+    throw new Error(
+      `Virtual time mismatch: expected ${expectedTimeMs}, got ${virtualClock.now()}.`,
+    );
+  }
+  const callbacks = virtualClock.flushAnimationFrame();
+  const pending = virtualClock.pendingAnimationFrames();
+  if (callbacks !== 1 || pending !== 1) {
+    throw new Error(
+      `Anime2.5DRig renderer must render exactly once per virtual frame (flushed ${callbacks}, pending ${pending}).`,
+    );
+  }
+  state.lastCallbacksPerFrame = callbacks;
+  return {
+    timeMs: virtualClock.now(),
+    callbacksPerFrame: callbacks,
+    pendingCallbacks: pending,
+  };
+}
+
+window.load = load;
+window.renderFrame = renderFrame;

--- a/packages/core/examples/node-psd-newsdesk/harness/motionRuntime.ts
+++ b/packages/core/examples/node-psd-newsdesk/harness/motionRuntime.ts
@@ -1,0 +1,36 @@
+import {
+  createAnime25RigAvatar,
+  type Anime25RigAvatar,
+} from '../../react-psd-app/src/lib/rig/anime25Renderer.js';
+import {
+  detectAnime25RigFromBuffer,
+  type Anime25RigDetection,
+  type Anime25Rigger,
+} from '../../react-psd-app/src/lib/rig/anime25Rig.js';
+// @ts-expect-error The vendored MIT UMD module intentionally has no types.
+import vendoredRigger from '../../react-psd-app/src/vendor/anime25drig/rigger.js';
+
+const riggerModule = vendoredRigger as Anime25Rigger & {
+  default?: Anime25Rigger;
+};
+globalThis.Rigger = riggerModule.default ?? riggerModule;
+
+export interface MotionRuntimeLoadResult {
+  detection: Anime25RigDetection;
+  avatar: Anime25RigAvatar | null;
+}
+
+/** Detect and, when eligible, mount the sibling Anime2.5DRig renderer. */
+export async function loadMotionRuntime(
+  canvas: HTMLCanvasElement,
+  psdBuffer: ArrayBuffer,
+): Promise<MotionRuntimeLoadResult> {
+  const detection = await detectAnime25RigFromBuffer(psdBuffer);
+  if (!detection.usable || !detection.rig) {
+    return { detection, avatar: null };
+  }
+  return {
+    detection,
+    avatar: createAnime25RigAvatar(canvas, detection.rig),
+  };
+}

--- a/packages/core/examples/node-psd-newsdesk/harness/virtualClock.ts
+++ b/packages/core/examples/node-psd-newsdesk/harness/virtualClock.ts
@@ -1,0 +1,93 @@
+export type VirtualAnimationFrameCallback = (timestamp: number) => void;
+
+/** Deterministic mulberry32 random-number generator. */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+/**
+ * Browser-style virtual clock whose queued animation callbacks run only when
+ * the caller advances and flushes a frame.
+ */
+export class VirtualClock {
+  private timestampMs = 0;
+  private nextAnimationFrameId = 1;
+  private animationFrames = new Map<number, VirtualAnimationFrameCallback>();
+  private nextRandom = createSeededRandom(0);
+
+  /** Reset time, queued callbacks, callback IDs, and the seeded RNG. */
+  reset(seed: number, timestampMs = 0): void {
+    this.timestampMs = timestampMs;
+    this.nextAnimationFrameId = 1;
+    this.animationFrames.clear();
+    this.nextRandom = createSeededRandom(seed);
+  }
+
+  /** Current virtual time in milliseconds. */
+  now(): number {
+    return this.timestampMs;
+  }
+
+  /** Advance virtual time without executing animation callbacks. */
+  advance(deltaSeconds: number): void {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds < 0) {
+      throw new Error('Virtual clock deltaSeconds must be non-negative.');
+    }
+    this.timestampMs += deltaSeconds * 1000;
+  }
+
+  /** Queue a callback in browser requestAnimationFrame insertion order. */
+  requestAnimationFrame(callback: VirtualAnimationFrameCallback): number {
+    const id = this.nextAnimationFrameId;
+    this.nextAnimationFrameId += 1;
+    this.animationFrames.set(id, callback);
+    return id;
+  }
+
+  /** Cancel one queued callback. */
+  cancelAnimationFrame(id: number): void {
+    this.animationFrames.delete(id);
+  }
+
+  /** Number of callbacks waiting for the next virtual frame. */
+  pendingAnimationFrames(): number {
+    return this.animationFrames.size;
+  }
+
+  /**
+   * Flush all callbacks that were queued at the start of this frame. Callbacks
+   * scheduled during the flush remain queued for the next virtual timestamp,
+   * matching browser rAF semantics.
+   */
+  flushAnimationFrame(): number {
+    const callbacks = [...this.animationFrames.values()];
+    this.animationFrames.clear();
+    for (const callback of callbacks) callback(this.timestampMs);
+    return callbacks.length;
+  }
+
+  /** Return the next deterministic random value in the range [0, 1). */
+  random(): number {
+    return this.nextRandom();
+  }
+}
+
+/** Install one virtual clock into the browser before importing the bridge. */
+export function installBrowserVirtualClock(clock: VirtualClock): void {
+  window.requestAnimationFrame = (callback) =>
+    clock.requestAnimationFrame(callback);
+  window.cancelAnimationFrame = (id) => clock.cancelAnimationFrame(id);
+  Object.defineProperty(window.performance, 'now', {
+    configurable: true,
+    value: () => clock.now(),
+  });
+  Date.now = () => Math.floor(clock.now());
+  Math.random = () => clock.random();
+}

--- a/packages/core/examples/node-psd-newsdesk/package-lock.json
+++ b/packages/core/examples/node-psd-newsdesk/package-lock.json
@@ -13,7 +13,8 @@
         "@napi-rs/canvas": "^1.0.3",
         "@openai/codex-sdk": "^0.146.0",
         "@webtoon/psd": "^0.4.0",
-        "linkedom": "^0.18.13"
+        "linkedom": "^0.18.13",
+        "playwright": "^1.55.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -2374,6 +2375,50 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",

--- a/packages/core/examples/node-psd-newsdesk/package.json
+++ b/packages/core/examples/node-psd-newsdesk/package.json
@@ -25,7 +25,8 @@
     "@napi-rs/canvas": "^1.0.3",
     "@openai/codex-sdk": "^0.146.0",
     "@webtoon/psd": "^0.4.0",
-    "linkedom": "^0.18.13"
+    "linkedom": "^0.18.13",
+    "playwright": "^1.55.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/packages/core/examples/node-psd-newsdesk/prompts/newsdesk.md
+++ b/packages/core/examples/node-psd-newsdesk/prompts/newsdesk.md
@@ -19,6 +19,7 @@ Analyze the document before writing. Return this exact outer structure:
   },
   "script": {
     "avatar": "...",
+    "avatarMode": "static",
     "voice": { "engine": "...", "options": {} },
     "background": { "color": "..." },
     "avatarLayout": { "scale": 1, "x": 0, "y": 0 },
@@ -68,6 +69,7 @@ The `script` object must follow this schema example:
 ```json
 {
   "avatar": "../assets/sample-static.psd",
+  "avatarMode": "static",
   "voice": {
     "engine": "sine",
     "options": {

--- a/packages/core/examples/node-psd-newsdesk/samples/hello-newsdesk-motion.json
+++ b/packages/core/examples/node-psd-newsdesk/samples/hello-newsdesk-motion.json
@@ -1,6 +1,6 @@
 {
-  "avatar": "../assets/sample-static.psd",
-  "avatarMode": "static",
+  "avatar": "../../react-psd-app/public/avatar/sample.psd",
+  "avatarMode": "auto",
   "voice": {
     "engine": "aituber-voice",
     "options": {
@@ -15,9 +15,9 @@
     "color": "#20242c"
   },
   "avatarLayout": {
-    "scale": 1,
+    "scale": 1.18,
     "x": 0.5,
-    "y": 0.51
+    "y": 0.52
   },
   "motion": {
     "intensity": 1
@@ -35,7 +35,7 @@
       "pauseAfter": 0.03
     },
     {
-      "text": "新しいリリースを私がお知らせします。",
+      "text": "メッシュの動きと口パクを確認します。",
       "pauseAfter": 0.03
     }
   ]

--- a/packages/core/examples/node-psd-newsdesk/samples/hello-sine-motion.json
+++ b/packages/core/examples/node-psd-newsdesk/samples/hello-sine-motion.json
@@ -1,6 +1,6 @@
 {
-  "avatar": "../assets/sample-static.psd",
-  "avatarMode": "static",
+  "avatar": "../../react-psd-app/public/avatar/sample.psd",
+  "avatarMode": "auto",
   "voice": {
     "engine": "sine",
     "options": {
@@ -16,9 +16,9 @@
     "color": "#20242c"
   },
   "avatarLayout": {
-    "scale": 1,
+    "scale": 1.18,
     "x": 0.5,
-    "y": 0.51
+    "y": 0.52
   },
   "motion": {
     "intensity": 1
@@ -36,7 +36,7 @@
       "pauseAfter": 0.08
     },
     {
-      "text": "新しいリリースを私がお知らせします。",
+      "text": "メッシュの動きと口パクを確認します。",
       "pauseAfter": 0.08
     }
   ]

--- a/packages/core/examples/node-psd-newsdesk/scripts/build.mjs
+++ b/packages/core/examples/node-psd-newsdesk/scripts/build.mjs
@@ -1,11 +1,30 @@
-import { mkdir } from 'node:fs/promises';
+import { copyFile, mkdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { build } from 'esbuild';
 
 const root = resolve(process.cwd());
 const distDir = resolve(root, 'dist');
+const harnessDistDir = resolve(distDir, 'harness');
+const anime25RiggerPlugin = {
+  name: 'anime25drig-umd-global',
+  setup(buildContext) {
+    buildContext.onLoad(
+      { filter: /anime25drig\/rigger\.js$/ },
+      async (args) => {
+        const source = await readFile(args.path, 'utf8');
+        return {
+          contents: `var module = undefined;\n${source}\nexport default globalThis.Rigger;\n`,
+          loader: 'js',
+        };
+      },
+    );
+  },
+};
 
-await mkdir(distDir, { recursive: true });
+await Promise.all([
+  mkdir(distDir, { recursive: true }),
+  mkdir(harnessDistDir, { recursive: true }),
+]);
 
 // Bundle the Core integration like the coding-agent example. Native, DOM-heavy,
 // and runtime-loaded agent SDK dependencies remain external.
@@ -27,6 +46,38 @@ await build({
     'linkedom',
     '@mozilla/readability',
     '@openai/codex-sdk',
+    'playwright',
     '@webtoon/psd',
   ],
 });
+
+await Promise.all([
+  build({
+    entryPoints: [resolve(root, 'harness/main.ts')],
+    outfile: resolve(harnessDistDir, 'main.js'),
+    bundle: true,
+    platform: 'browser',
+    format: 'esm',
+    target: 'chrome120',
+    sourcemap: true,
+    logLevel: 'info',
+  }),
+  build({
+    entryPoints: [resolve(root, 'harness/motionRuntime.ts')],
+    outfile: resolve(harnessDistDir, 'motion-runtime.js'),
+    bundle: true,
+    platform: 'browser',
+    format: 'esm',
+    target: 'chrome120',
+    alias: {
+      'ag-psd': resolve(root, 'node_modules/ag-psd'),
+    },
+    plugins: [anime25RiggerPlugin],
+    sourcemap: true,
+    logLevel: 'info',
+  }),
+  copyFile(
+    resolve(root, 'harness/index.html'),
+    resolve(harnessDistDir, 'index.html'),
+  ),
+]);

--- a/packages/core/examples/node-psd-newsdesk/src/gen/avatarMode.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/gen/avatarMode.ts
@@ -1,0 +1,17 @@
+import type { AvatarMode, ResolvedAvatarMode } from '../types.js';
+
+export interface MotionModeDetection {
+  usable: boolean;
+  reason: string;
+}
+
+/** Resolve the requested mode from one Anime2.5DRig rigger diagnostic. */
+export function selectAvatarMode(
+  requested: AvatarMode,
+  detection: MotionModeDetection,
+): ResolvedAvatarMode {
+  if (requested === 'static') return 'static';
+  if (detection.usable) return 'motion';
+  if (requested === 'motion') throw new Error(detection.reason);
+  return 'static';
+}

--- a/packages/core/examples/node-psd-newsdesk/src/gen/cli.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/gen/cli.ts
@@ -6,6 +6,7 @@ import { defaultAvatarPath, resolveFrom } from '../paths.js';
 import type {
   NewsdeskScript,
   RenderConfig,
+  ResolvedAvatarMode,
   ScriptLine,
   ScriptVoice,
   TimedText,
@@ -17,6 +18,7 @@ import {
   writeSilenceWav,
 } from './audio.js';
 import { createBlinkSchedule } from './blink.js';
+import { selectAvatarMode } from './avatarMode.js';
 import * as aituberVoiceEngine from './engines/aituberVoice.js';
 import * as sayEngine from './engines/say.js';
 import * as sineEngine from './engines/sine.js';
@@ -24,10 +26,16 @@ import type { SynthesisResult, VoiceEngine } from './engines/types.js';
 import { assertFfmpeg, encodeMp4, writeFrame } from './ffmpeg.js';
 import { loadPsdAvatar } from './psdBinding.js';
 import {
+  createPsdMotionCandidate,
+  type PsdMotionAvatarDiagnostics,
+} from './psdMotionAvatar.js';
+import {
   type AvatarStateKey,
+  createMotionRenderer,
   createRenderer,
   type MouthState,
   type MotionDiagnostics,
+  type NewsdeskRenderer,
   resolveMouthState,
 } from './renderer.js';
 
@@ -87,6 +95,14 @@ interface RenderSummary {
   frames?: number;
   totalFrames?: number;
   duration?: number;
+  avatarMode: ResolvedAvatarMode;
+  blinkControl: 'node-schedule' | 'internal-seeded-automation';
+  avatarDiagnostics?: PsdMotionAvatarDiagnostics;
+  renderPerformance?: {
+    measuredFrames: number;
+    totalMs: number;
+    averageMsPerFrame: number;
+  };
   mouthFrames: Record<MouthState, number>;
   stateFrames: Record<AvatarStateKey, number>;
   blinkFrames?: number;
@@ -313,14 +329,35 @@ async function render(
   config: RenderConfig,
   args: GenArgs,
 ): Promise<RenderSummary> {
-  const [audio, avatar] = await Promise.all([
-    decodeWav(config.audio),
-    loadPsdAvatar(config.avatar, config.avatarRoles),
-  ]);
+  const audio = await decodeWav(config.audio);
+  const requestedMode = config.avatarMode ?? 'auto';
+  let resolvedMode: ResolvedAvatarMode;
+  let renderer: NewsdeskRenderer;
+  if (requestedMode === 'static') {
+    resolvedMode = 'static';
+    const avatar = await loadPsdAvatar(config.avatar, config.avatarRoles);
+    renderer = await createRenderer(config, avatar);
+  } else {
+    const candidate = await createPsdMotionCandidate(config);
+    resolvedMode = selectAvatarMode(requestedMode, candidate.detection);
+    if (resolvedMode === 'motion') {
+      if (!candidate.source) {
+        throw new Error(candidate.detection.reason);
+      }
+      try {
+        renderer = await createMotionRenderer(config, candidate.source);
+      } catch (error) {
+        await candidate.source.close();
+        throw error;
+      }
+    } else {
+      const avatar = await loadPsdAvatar(config.avatar, config.avatarRoles);
+      renderer = await createRenderer(config, avatar);
+    }
+  }
   const totalFrames = Math.max(1, Math.ceil(config.duration * config.fps));
   const mouthValues = createMouthValues(audio, config.fps, totalFrames);
   const blink = createBlinkSchedule(totalFrames, config.fps, config.blinkSeed);
-  const renderer = await createRenderer(config, avatar);
   const targetFrame =
     args.png && args.frame !== null
       ? Math.max(0, Math.min(totalFrames - 1, Math.floor(args.frame)))
@@ -336,6 +373,8 @@ async function render(
     mouth_open_eyes_closed: 0,
   };
   const samples: RenderSummary['motionSamples'] = [];
+  let measuredFrames = 0;
+  let totalRenderMs = 0;
   const poseBounds: Record<'x' | 'y' | 'rotation', PoseRange> = {
     x: { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY },
     y: { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY },
@@ -351,14 +390,16 @@ async function render(
     totalFrames - 1,
   ]);
 
-  const renderOne = (frame: number): void => {
+  const renderOne = async (frame: number): Promise<void> => {
     const mouthState = resolveMouthState(mouthValues[frame]);
     mouthFrames[mouthState] += 1;
-    const diagnostics = renderer.render(
-      frame,
-      mouthValues[frame],
-      Boolean(blink[frame]),
+    const diagnostics = await Promise.resolve(
+      renderer.render(frame, mouthValues[frame], Boolean(blink[frame])),
     );
+    if (diagnostics.frameElapsedMs !== undefined) {
+      measuredFrames += 1;
+      totalRenderMs += diagnostics.frameElapsedMs;
+    }
     stateFrames[diagnostics.stateKey] += 1;
     for (const key of ['x', 'y', 'rotation'] as const) {
       poseBounds[key].min = Math.min(
@@ -374,7 +415,7 @@ async function render(
       samples.push({
         frame,
         time: frame / config.fps,
-        eyesClosed: Boolean(blink[frame]),
+        eyesClosed: resolvedMode === 'static' ? Boolean(blink[frame]) : false,
         ...diagnostics,
       });
     }
@@ -388,38 +429,74 @@ async function render(
       ]),
     );
 
+  const renderPerformance = (): RenderSummary['renderPerformance'] =>
+    measuredFrames > 0
+      ? {
+          measuredFrames,
+          totalMs: totalRenderMs,
+          averageMsPerFrame: totalRenderMs / measuredFrames,
+        }
+      : undefined;
+
   if (args.png && targetFrame !== null) {
-    for (let frame = 0; frame <= targetFrame; frame += 1) renderOne(frame);
-    const pngPath = path.resolve(args.png);
-    await mkdir(path.dirname(pngPath), { recursive: true });
-    await writeFile(pngPath, renderer.canvas.toBuffer('image/png'));
-    return {
-      png: pngPath,
-      frame: targetFrame,
-      totalFrames,
-      mouthFrames,
-      stateFrames,
-      poseAmplitude: poseAmplitude(),
-      motionSamples: samples,
-    };
+    try {
+      for (let frame = 0; frame <= targetFrame; frame += 1) {
+        await renderOne(frame);
+      }
+      const pngPath = path.resolve(args.png);
+      await mkdir(path.dirname(pngPath), { recursive: true });
+      await writeFile(pngPath, renderer.canvas.toBuffer('image/png'));
+      return {
+        png: pngPath,
+        frame: targetFrame,
+        totalFrames,
+        avatarMode: resolvedMode,
+        blinkControl:
+          resolvedMode === 'motion'
+            ? 'internal-seeded-automation'
+            : 'node-schedule',
+        avatarDiagnostics: renderer.avatarDiagnostics,
+        renderPerformance: renderPerformance(),
+        mouthFrames,
+        stateFrames,
+        poseAmplitude: poseAmplitude(),
+        motionSamples: samples,
+      };
+    } finally {
+      await renderer.close();
+    }
   }
 
-  await encodeMp4({
-    config,
-    writeFrames: async (stdin: Writable) => {
-      for (let frame = 0; frame < totalFrames; frame += 1) {
-        renderOne(frame);
-        await writeFrame(stdin, renderer.rgba());
-      }
-    },
-  });
+  try {
+    await encodeMp4({
+      config,
+      writeFrames: async (stdin: Writable) => {
+        for (let frame = 0; frame < totalFrames; frame += 1) {
+          await renderOne(frame);
+          await writeFrame(stdin, renderer.rgba());
+        }
+      },
+    });
+  } finally {
+    await renderer.close();
+  }
   return {
     output: config.output,
     frames: totalFrames,
     duration: totalFrames / config.fps,
+    avatarMode: resolvedMode,
+    blinkControl:
+      resolvedMode === 'motion'
+        ? 'internal-seeded-automation'
+        : 'node-schedule',
+    avatarDiagnostics: renderer.avatarDiagnostics,
+    renderPerformance: renderPerformance(),
     mouthFrames,
     stateFrames,
-    blinkFrames: blink.reduce((sum, value) => sum + value, 0),
+    blinkFrames:
+      resolvedMode === 'static'
+        ? blink.reduce((sum, value) => sum + value, 0)
+        : undefined,
     poseAmplitude: poseAmplitude(),
     motionSamples: samples,
   };
@@ -494,6 +571,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       avatar: script.avatar
         ? resolveFrom(scriptPath, script.avatar)
         : defaultAvatarPath(),
+      avatarMode: script.avatarMode ?? 'auto',
       avatarRoles: script.avatarRoles,
       audio: paths.wavPath,
       output: paths.outputPath,

--- a/packages/core/examples/node-psd-newsdesk/src/gen/psdMotionAvatar.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/gen/psdMotionAvatar.ts
@@ -1,0 +1,405 @@
+import { createReadStream } from 'node:fs';
+import { realpath, stat } from 'node:fs/promises';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import type { AddressInfo } from 'node:net';
+import { type Image, loadImage } from '@napi-rs/canvas';
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from 'playwright';
+import { resolveProjectRoot } from '../paths.js';
+import type { RenderConfig } from '../types.js';
+import type { MotionModeDetection } from './avatarMode.js';
+
+const SWIFTSHADER_ARGS = [
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+];
+
+export interface PsdMotionRigSummary {
+  canvasWidth: number;
+  canvasHeight: number;
+  layerCount: number;
+  anchorCount: number;
+  strandCount: number;
+  partsFound: string[];
+  missingRequiredParts: string[];
+  warnings: string[];
+  preprocessed: { noisy: number; layers: number };
+}
+
+export interface PsdMotionAvatarDiagnostics {
+  runtime: 'anime25drig-webgl';
+  detection: MotionModeDetection & { summary: PsdMotionRigSummary | null };
+  canvasSize: { width: number; height: number };
+  eyeInput: 'internal-seeded-automation';
+  motionIntensity: number;
+  virtualClock: {
+    seed: number;
+    timeMs: number;
+    callbacksPerFrame: number;
+    pendingCallbacks: number;
+  };
+  launchMode: 'swiftshader' | 'default-gl';
+  captureMode: 'playwright-element-png';
+}
+
+export interface PsdMotionFrameInput {
+  frameNumber: number;
+  time: number;
+  deltaSeconds: number;
+  mouth: number;
+  eyesClosed: boolean;
+}
+
+export interface PsdMotionAvatarFrame {
+  image: Image;
+  elapsedMs: number;
+}
+
+export interface PsdMotionFrameSource {
+  width: number;
+  height: number;
+  diagnostics: PsdMotionAvatarDiagnostics;
+  renderFrame(input: PsdMotionFrameInput): Promise<PsdMotionAvatarFrame>;
+  close(): Promise<void>;
+}
+
+export interface PsdMotionCandidate {
+  detection: MotionModeDetection & { summary: PsdMotionRigSummary | null };
+  source: PsdMotionFrameSource | null;
+}
+
+interface HarnessServer {
+  server: Server;
+  origin: string;
+}
+
+interface HarnessLoadResult {
+  detection: MotionModeDetection & { summary: PsdMotionRigSummary | null };
+  canvasSize: { width: number; height: number } | null;
+  virtualClock: PsdMotionAvatarDiagnostics['virtualClock'];
+  eyeInput: PsdMotionAvatarDiagnostics['eyeInput'];
+}
+
+interface BrowserSession {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  loaded: HarnessLoadResult;
+  launchMode: PsdMotionAvatarDiagnostics['launchMode'];
+}
+
+function contentType(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (lower.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (lower.endsWith('.psd')) return 'application/octet-stream';
+  return 'application/octet-stream';
+}
+
+async function sendFile(
+  response: ServerResponse,
+  filePath: string,
+): Promise<void> {
+  try {
+    const metadata = await stat(filePath);
+    if (!metadata.isFile()) {
+      response.writeHead(404);
+      response.end('File unavailable.');
+      return;
+    }
+    response.writeHead(200, {
+      'Content-Type': contentType(filePath),
+      'Content-Length': metadata.size,
+      'Cache-Control': 'no-store',
+    });
+    createReadStream(filePath).pipe(response);
+  } catch (error) {
+    response.writeHead(
+      (error as NodeJS.ErrnoException).code === 'ENOENT' ? 404 : 500,
+    );
+    response.end('File unavailable.');
+  }
+}
+
+/** Resolve one URL beneath a read-only root without traversal or escapes. */
+export function resolveLocalAssetPath(
+  rootDirectory: string,
+  routePrefix: string,
+  requestPath: string,
+): string | null {
+  if (!requestPath.startsWith(routePrefix)) return null;
+  let relative: string;
+  try {
+    relative = decodeURIComponent(requestPath.slice(routePrefix.length));
+  } catch {
+    return null;
+  }
+  const normalized = relative.replaceAll('\\', '/');
+  const segments = normalized.split('/');
+  if (
+    normalized === '' ||
+    path.isAbsolute(normalized) ||
+    segments.some(
+      (segment) => segment === '' || segment === '.' || segment === '..',
+    )
+  ) {
+    return null;
+  }
+  const root = path.resolve(rootDirectory);
+  const candidate = path.resolve(root, ...segments);
+  return candidate.startsWith(`${root}${path.sep}`) ? candidate : null;
+}
+
+async function sendRootedFile(
+  response: ServerResponse,
+  rootDirectory: string,
+  routePrefix: string,
+  requestPath: string,
+): Promise<void> {
+  const candidate = resolveLocalAssetPath(
+    rootDirectory,
+    routePrefix,
+    requestPath,
+  );
+  if (!candidate) {
+    response.writeHead(403);
+    response.end('Invalid local asset path.');
+    return;
+  }
+  try {
+    const [rootRealPath, candidateRealPath] = await Promise.all([
+      realpath(rootDirectory),
+      realpath(candidate),
+    ]);
+    if (!candidateRealPath.startsWith(`${rootRealPath}${path.sep}`)) {
+      response.writeHead(403);
+      response.end('Local asset escapes its root.');
+      return;
+    }
+    await sendFile(response, candidateRealPath);
+  } catch (error) {
+    response.writeHead(
+      (error as NodeJS.ErrnoException).code === 'ENOENT' ? 404 : 500,
+    );
+    response.end('Local asset unavailable.');
+  }
+}
+
+async function startHarnessServer(
+  config: RenderConfig,
+): Promise<HarnessServer> {
+  const harnessDirectory = path.join(resolveProjectRoot(), 'dist', 'harness');
+  const avatarRoot = path.dirname(config.avatar);
+  const server = createServer((request, response) => {
+    const url = new URL(request.url || '/', 'http://127.0.0.1');
+    if (request.method !== 'GET') {
+      response.writeHead(405);
+      response.end('Method not allowed.');
+      return;
+    }
+    if (url.pathname === '/' || url.pathname === '/harness/index.html') {
+      void sendFile(response, path.join(harnessDirectory, 'index.html'));
+    } else if (url.pathname.startsWith('/harness/')) {
+      void sendRootedFile(
+        response,
+        harnessDirectory,
+        '/harness/',
+        url.pathname,
+      );
+    } else if (url.pathname.startsWith('/avatar/')) {
+      void sendRootedFile(response, avatarRoot, '/avatar/', url.pathname);
+    } else {
+      response.writeHead(404);
+      response.end('Not found.');
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    server.close();
+    throw new Error('The PSD motion harness did not expose an address.');
+  }
+  return { server, origin: `http://127.0.0.1:${address.port}` };
+}
+
+async function stopServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function launchSession(
+  origin: string,
+  config: RenderConfig,
+  launchMode: PsdMotionAvatarDiagnostics['launchMode'],
+): Promise<BrowserSession> {
+  const browser = await chromium.launch({
+    headless: true,
+    args: launchMode === 'swiftshader' ? SWIFTSHADER_ARGS : [],
+  });
+  const context = await browser.newContext({
+    viewport: { width: config.width, height: config.height },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  try {
+    await page.goto(`${origin}/harness/index.html`, { waitUntil: 'load' });
+    await page.waitForFunction(
+      () =>
+        typeof (window as unknown as { load?: unknown }).load === 'function',
+    );
+    const loaded = await page.evaluate(
+      async (options) => {
+        const harnessWindow = window as unknown as {
+          load(value: typeof options): Promise<HarnessLoadResult>;
+        };
+        return harnessWindow.load(options);
+      },
+      {
+        runtimeUrl: '/harness/motion-runtime.js',
+        avatarUrl: `/avatar/${encodeURIComponent(path.basename(config.avatar))}`,
+        blinkSeed: config.blinkSeed,
+        motionIntensity: config.motion.intensity,
+      },
+    );
+    if (loaded.canvasSize) {
+      await page.setViewportSize(loaded.canvasSize);
+    }
+    return { browser, context, page, loaded, launchMode };
+  } catch (error) {
+    await browser.close();
+    throw error;
+  }
+}
+
+function isMissingBrowser(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Executable doesn't exist|playwright install/i.test(message);
+}
+
+async function connectBrowser(
+  origin: string,
+  config: RenderConfig,
+): Promise<BrowserSession> {
+  try {
+    return await launchSession(origin, config, 'swiftshader');
+  } catch (error) {
+    if (isMissingBrowser(error)) throw error;
+    console.error(
+      `SwiftShader PSD motion harness failed; retrying default GL: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return launchSession(origin, config, 'default-gl');
+  }
+}
+
+async function requirePsd(filePath: string): Promise<void> {
+  if (!filePath.toLowerCase().endsWith('.psd')) {
+    throw new Error('PSD avatar must point to a .psd file.');
+  }
+  try {
+    const metadata = await stat(filePath);
+    if (!metadata.isFile()) throw new Error('not a file');
+  } catch (error) {
+    throw new Error(`PSD avatar file was not found: ${filePath}`, {
+      cause: error,
+    });
+  }
+}
+
+/** Enforce the sequential frame-source contract used by video encoding. */
+export function assertSequentialMotionFrame(
+  expected: number,
+  received: number,
+): void {
+  if (received !== expected) {
+    throw new Error(
+      `PSD motion frames must be sequential (expected ${expected}, got ${received}).`,
+    );
+  }
+}
+
+/** Detect motion eligibility and keep a browser source only when usable. */
+export async function createPsdMotionCandidate(
+  config: RenderConfig,
+): Promise<PsdMotionCandidate> {
+  await requirePsd(config.avatar);
+  const harness = await startHarnessServer(config);
+  let session: BrowserSession;
+  try {
+    session = await connectBrowser(harness.origin, config);
+  } catch (error) {
+    await stopServer(harness.server);
+    throw error;
+  }
+  const { detection, canvasSize } = session.loaded;
+  if (!detection.usable || !canvasSize) {
+    await session.browser.close();
+    await stopServer(harness.server);
+    return { detection, source: null };
+  }
+
+  const diagnostics: PsdMotionAvatarDiagnostics = {
+    runtime: 'anime25drig-webgl',
+    detection,
+    canvasSize,
+    eyeInput: session.loaded.eyeInput,
+    motionIntensity: config.motion.intensity,
+    virtualClock: session.loaded.virtualClock,
+    launchMode: session.launchMode,
+    captureMode: 'playwright-element-png',
+  };
+  let nextFrame = 0;
+  let closed = false;
+  const source: PsdMotionFrameSource = {
+    width: canvasSize.width,
+    height: canvasSize.height,
+    diagnostics,
+    async renderFrame(input) {
+      assertSequentialMotionFrame(nextFrame, input.frameNumber);
+      const startedAt = performance.now();
+      const virtualFrame = await session.page.evaluate((options) => {
+        const harnessWindow = window as unknown as {
+          renderFrame(value: typeof options): {
+            timeMs: number;
+            callbacksPerFrame: number;
+            pendingCallbacks: number;
+          };
+        };
+        return harnessWindow.renderFrame(options);
+      }, input);
+      diagnostics.virtualClock = {
+        seed: config.blinkSeed,
+        ...virtualFrame,
+      };
+      const png = await session.page.locator('#avatar').screenshot({
+        type: 'png',
+        omitBackground: true,
+      });
+      const image = await loadImage(png);
+      nextFrame += 1;
+      return { image, elapsedMs: performance.now() - startedAt };
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      await session.browser.close();
+      await stopServer(harness.server);
+    },
+  };
+  return { detection, source };
+}

--- a/packages/core/examples/node-psd-newsdesk/src/gen/renderer.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/gen/renderer.ts
@@ -8,6 +8,10 @@ import {
 import type { RenderConfig, ScriptAvatarLayout } from '../types.js';
 import type { PsdAvatar } from './psdBinding.js';
 import type { PsdModel } from './psdModel.js';
+import type {
+  PsdMotionAvatarDiagnostics,
+  PsdMotionFrameSource,
+} from './psdMotionAvatar.js';
 import { getVisibleLayerIds } from './psdVisibility.js';
 
 /** A normalized RMS value at or above this level uses an open-mouth image. */
@@ -32,16 +36,20 @@ export interface MotionDiagnostics {
   pose: Pose;
   stateKey: AvatarStateKey;
   mouthState: MouthState;
+  frameElapsedMs?: number;
 }
 
 export interface NewsdeskRenderer {
   canvas: Canvas;
+  avatarMode: 'static' | 'motion';
+  avatarDiagnostics?: PsdMotionAvatarDiagnostics;
   render(
     frameNumber: number,
     mouthValue: number,
     eyesClosed: boolean,
-  ): MotionDiagnostics;
+  ): MotionDiagnostics | Promise<MotionDiagnostics>;
   rgba(): Buffer;
+  close(): Promise<void>;
 }
 
 interface TextBoxOptions {
@@ -75,6 +83,7 @@ export async function createRenderer(
 
   return {
     canvas,
+    avatarMode: 'static',
     render(frameNumber, mouthValue, eyesClosed) {
       if (frameNumber !== nextFrame) {
         throw new Error(
@@ -111,6 +120,72 @@ export async function createRenderer(
         imageData.data.byteOffset,
         imageData.data.byteLength,
       );
+    },
+    async close() {},
+  };
+}
+
+/** Create a compositor backed by the sibling Anime2.5DRig WebGL renderer. */
+export async function createMotionRenderer(
+  config: RenderConfig,
+  frameSource: PsdMotionFrameSource,
+): Promise<NewsdeskRenderer> {
+  const canvas = createCanvas(config.width, config.height);
+  const context = canvas.getContext('2d');
+  const backgroundImage = config.background.image
+    ? await loadImage(config.background.image)
+    : null;
+  const modelSize = { width: frameSource.width, height: frameSource.height };
+  const zeroPose: Pose = { x: 0, y: 0, rotation: 0, scale: 1 };
+  let nextFrame = 0;
+
+  return {
+    canvas,
+    avatarMode: 'motion',
+    avatarDiagnostics: frameSource.diagnostics,
+    async render(frameNumber, mouthValue, eyesClosed) {
+      if (frameNumber !== nextFrame) {
+        throw new Error(
+          `Frames must be rendered sequentially (expected ${nextFrame}, ` +
+            `got ${frameNumber}).`,
+        );
+      }
+      const frame = await frameSource.renderFrame({
+        frameNumber,
+        time: frameNumber / config.fps,
+        deltaSeconds: frameNumber === 0 ? 0 : 1 / config.fps,
+        mouth: mouthValue,
+        eyesClosed,
+      });
+      drawBackground(context, canvas, config.background, backgroundImage);
+      drawAvatar(
+        context,
+        canvas,
+        modelSize,
+        frame.image,
+        config.avatarLayout,
+        zeroPose,
+      );
+      drawTextOverlays(context, canvas, config, frameNumber / config.fps);
+      nextFrame += 1;
+      const mouthState = resolveMouthState(mouthValue);
+      return {
+        pose: zeroPose,
+        stateKey: resolveAvatarStateKey(mouthState, false),
+        mouthState,
+        frameElapsedMs: frame.elapsedMs,
+      };
+    },
+    rgba() {
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      return Buffer.from(
+        imageData.data.buffer,
+        imageData.data.byteOffset,
+        imageData.data.byteLength,
+      );
+    },
+    async close() {
+      await frameSource.close();
     },
   };
 }
@@ -184,8 +259,8 @@ function drawBackground(
 function drawAvatar(
   context: SKRSContext2D,
   canvas: Canvas,
-  model: PsdModel,
-  avatarCanvas: Canvas,
+  model: Pick<PsdModel, 'width' | 'height'>,
+  avatarCanvas: Canvas | Image,
   layout: ScriptAvatarLayout,
   pose: Pose,
 ): void {
@@ -205,7 +280,10 @@ function drawAvatar(
   context.restore();
 }
 
-function calculateBaseScale(canvas: Canvas, model: PsdModel): number {
+function calculateBaseScale(
+  canvas: Canvas,
+  model: Pick<PsdModel, 'width' | 'height'>,
+): number {
   return Math.min(
     (canvas.width * 0.96) / model.width,
     (canvas.height * 0.9) / model.height,

--- a/packages/core/examples/node-psd-newsdesk/src/script-gen/schema.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/script-gen/schema.ts
@@ -2,6 +2,7 @@ import type { NewsdeskScript, ScriptLine } from '../types.js';
 
 const TOP_LEVEL_FIELDS = new Set([
   'avatar',
+  'avatarMode',
   'avatarRoles',
   'output',
   'voice',
@@ -236,6 +237,12 @@ export function validateScript(script: unknown): string[] {
 
   addUnknownFieldErrors(script, TOP_LEVEL_FIELDS, 'script', errors);
   requireString(script.avatar, 'script.avatar', errors);
+  if (
+    script.avatarMode !== undefined &&
+    !['auto', 'static', 'motion'].includes(String(script.avatarMode))
+  ) {
+    errors.push('script.avatarMode must be "auto", "static", or "motion".');
+  }
   if (script.avatarRoles !== undefined) {
     validateAvatarRoles(script.avatarRoles, errors);
   }

--- a/packages/core/examples/node-psd-newsdesk/src/types.ts
+++ b/packages/core/examples/node-psd-newsdesk/src/types.ts
@@ -6,6 +6,8 @@
  */
 
 export type VoiceEngineName = 'sine' | 'say' | 'aituber-voice';
+export type AvatarMode = 'auto' | 'static' | 'motion';
+export type ResolvedAvatarMode = Exclude<AvatarMode, 'auto'>;
 
 export interface ScriptVoice {
   engine: VoiceEngineName;
@@ -60,6 +62,8 @@ export interface ScriptLine {
 export interface NewsdeskScript {
   /** PSD avatar path, relative to the script file. */
   avatar?: string;
+  /** Select Anime2.5DRig motion detection or the static PSDTool path. */
+  avatarMode?: AvatarMode;
   /** Optional exact layer paths that override automatic role detection. */
   avatarRoles?: ScriptAvatarRoles;
   /** MP4 path, relative to the script file. `--output` takes precedence. */
@@ -97,6 +101,7 @@ export interface RenderConfig {
   blinkSeed: number;
   /** Absolute PSD avatar path. */
   avatar: string;
+  avatarMode: AvatarMode;
   avatarRoles?: ScriptAvatarRoles;
   /** Absolute path of the combined narration WAV. */
   audio: string;

--- a/packages/core/examples/node-psd-newsdesk/tests/e2e/gen.test.ts
+++ b/packages/core/examples/node-psd-newsdesk/tests/e2e/gen.test.ts
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { readFile, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { loadImage } from '@napi-rs/canvas';
+import { createCanvas, loadImage } from '@napi-rs/canvas';
 
 const testDirectory = path.dirname(new URL(import.meta.url).pathname);
 const projectRoot = path.resolve(testDirectory, '..', '..');
@@ -15,6 +16,15 @@ const scriptPath = path.join(
 );
 const outputPath = path.join(workDirectory, 'hello.mp4');
 const pngPath = path.join(workDirectory, 'frame.png');
+const motionWorkDirectory = path.join(projectRoot, 'work', 'test-motion-e2e');
+const motionScriptPath = path.join(
+  projectRoot,
+  'tests',
+  'fixtures',
+  'hello-sine-motion.json',
+);
+const motionOutputPath = path.join(motionWorkDirectory, 'motion.mp4');
+const motionTimingsPath = path.join(motionWorkDirectory, 'motion.timings.json');
 
 interface CommandResult {
   stdout: string;
@@ -50,6 +60,45 @@ async function md5(filePath: string): Promise<string> {
   return createHash('md5')
     .update(await readFile(filePath))
     .digest('hex');
+}
+
+async function changedPixelsInRegion(
+  firstPath: string,
+  secondPath: string,
+  region: { x: number; y: number; width: number; height: number },
+): Promise<number> {
+  const [first, second] = await Promise.all([
+    loadImage(firstPath),
+    loadImage(secondPath),
+  ]);
+  const canvas = createCanvas(first.width, first.height);
+  const context = canvas.getContext('2d');
+  context.drawImage(first, 0, 0);
+  const firstPixels = context.getImageData(
+    region.x,
+    region.y,
+    region.width,
+    region.height,
+  ).data;
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(second, 0, 0);
+  const secondPixels = context.getImageData(
+    region.x,
+    region.y,
+    region.width,
+    region.height,
+  ).data;
+  let changed = 0;
+  for (let index = 0; index < firstPixels.length; index += 4) {
+    const difference = Math.max(
+      Math.abs(firstPixels[index] - secondPixels[index]),
+      Math.abs(firstPixels[index + 1] - secondPixels[index + 1]),
+      Math.abs(firstPixels[index + 2] - secondPixels[index + 2]),
+      Math.abs(firstPixels[index + 3] - secondPixels[index + 3]),
+    );
+    if (difference >= 12) changed += 1;
+  }
+  return changed;
 }
 
 it('creates deterministic vertical H.264/AAC video and a PNG frame', async () => {
@@ -123,4 +172,147 @@ it('creates deterministic vertical H.264/AAC video and a PNG frame', async () =>
   const png = await loadImage(pngPath);
   expect(png.width).toBe(1080);
   expect(png.height).toBe(1920);
+});
+
+it('auto-selects deterministic Anime2.5DRig motion with lip sync and idle movement', async () => {
+  expect(
+    existsSync(
+      path.resolve(projectRoot, '../react-psd-app/public/avatar/sample.psd'),
+    ),
+  ).toBe(true);
+  await rm(motionWorkDirectory, { recursive: true, force: true });
+
+  const first = await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    motionScriptPath,
+    '--output',
+    motionOutputPath,
+  ]);
+  const firstTimings = await readFile(motionTimingsPath, 'utf8');
+  const firstHash = await md5(motionOutputPath);
+  const firstSummary = JSON.parse(first.stdout).render as {
+    frames: number;
+    avatarMode: string;
+    blinkControl: string;
+    mouthFrames: { closed: number; open: number };
+    renderPerformance: { averageMsPerFrame: number };
+    avatarDiagnostics: {
+      runtime: string;
+      eyeInput: string;
+      canvasSize: { width: number; height: number };
+      detection: { usable: boolean; summary: { strandCount: number } };
+      virtualClock: {
+        seed: number;
+        timeMs: number;
+        callbacksPerFrame: number;
+        pendingCallbacks: number;
+      };
+    };
+  };
+
+  await run(process.execPath, [
+    'dist/gen.cjs',
+    '--script',
+    motionScriptPath,
+    '--output',
+    motionOutputPath,
+  ]);
+  expect(await readFile(motionTimingsPath, 'utf8')).toBe(firstTimings);
+  expect(await md5(motionOutputPath)).toBe(firstHash);
+
+  expect(firstSummary.avatarMode).toBe('motion');
+  expect(firstSummary.blinkControl).toBe('internal-seeded-automation');
+  expect(firstSummary.mouthFrames.closed).toBeGreaterThan(0);
+  expect(firstSummary.mouthFrames.open).toBeGreaterThan(0);
+  expect(firstSummary.renderPerformance.averageMsPerFrame).toBeGreaterThan(0);
+  expect(firstSummary.avatarDiagnostics).toMatchObject({
+    runtime: 'anime25drig-webgl',
+    eyeInput: 'internal-seeded-automation',
+    canvasSize: { width: 1024, height: 1536 },
+    detection: { usable: true },
+    virtualClock: {
+      seed: 42,
+      callbacksPerFrame: 1,
+      pendingCallbacks: 1,
+    },
+  });
+  expect(
+    firstSummary.avatarDiagnostics.detection.summary.strandCount,
+  ).toBeGreaterThan(0);
+  expect(firstSummary.avatarDiagnostics.virtualClock.timeMs).toBeCloseTo(
+    ((firstSummary.frames - 1) / 30) * 1000,
+    5,
+  );
+
+  const probe = await run('ffprobe', [
+    '-v',
+    'error',
+    '-count_frames',
+    '-show_entries',
+    'stream=codec_type,codec_name,width,height,pix_fmt,r_frame_rate,nb_read_frames',
+    '-of',
+    'json',
+    motionOutputPath,
+  ]);
+  const streams = JSON.parse(probe.stdout).streams as Array<
+    Record<string, string | number>
+  >;
+  expect(streams.find((stream) => stream.codec_type === 'video')).toMatchObject(
+    {
+      codec_name: 'h264',
+      width: 1080,
+      height: 1920,
+      pix_fmt: 'yuv420p',
+      r_frame_rate: '30/1',
+      nb_read_frames: String(firstSummary.frames),
+    },
+  );
+  expect(
+    streams.find((stream) => stream.codec_type === 'audio')?.codec_name,
+  ).toBe('aac');
+
+  const framePaths = {
+    closed: path.join(motionWorkDirectory, 'closed.png'),
+    open: path.join(motionWorkDirectory, 'open.png'),
+    distant: path.join(motionWorkDirectory, 'distant.png'),
+  };
+  for (const [name, frame] of [
+    ['closed', 0],
+    ['open', 3],
+    ['distant', 75],
+  ] as const) {
+    await run(process.execPath, [
+      'dist/gen.cjs',
+      '--script',
+      motionScriptPath,
+      '--output',
+      path.join(motionWorkDirectory, `${name}-source.mp4`),
+      '--frame',
+      String(frame),
+      '--png',
+      framePaths[name],
+    ]);
+    const image = await loadImage(framePaths[name]);
+    expect({ width: image.width, height: image.height }).toEqual({
+      width: 1080,
+      height: 1920,
+    });
+  }
+  expect(
+    await changedPixelsInRegion(framePaths.closed, framePaths.open, {
+      x: 420,
+      y: 720,
+      width: 240,
+      height: 260,
+    }),
+  ).toBeGreaterThan(250);
+  expect(
+    await changedPixelsInRegion(framePaths.open, framePaths.distant, {
+      x: 200,
+      y: 320,
+      width: 680,
+      height: 360,
+    }),
+  ).toBeGreaterThan(250);
 });

--- a/packages/core/examples/node-psd-newsdesk/tests/fixtures/hello-sine-motion.json
+++ b/packages/core/examples/node-psd-newsdesk/tests/fixtures/hello-sine-motion.json
@@ -1,11 +1,12 @@
 {
-  "avatar": "../assets/sample-static.psd",
-  "avatarMode": "static",
+  "avatar": "../../../react-psd-app/public/avatar/sample.psd",
+  "avatarMode": "auto",
   "voice": {
-    "engine": "aituber-voice",
+    "engine": "sine",
     "options": {
-      "engineType": "aivisSpeech",
-      "speaker": "888753760"
+      "frequency": 440,
+      "secondsPerChar": 0.02,
+      "minDuration": 0.18
     }
   },
   "leadIn": 0.05,
@@ -15,9 +16,9 @@
     "color": "#20242c"
   },
   "avatarLayout": {
-    "scale": 1,
+    "scale": 1.18,
     "x": 0.5,
-    "y": 0.51
+    "y": 0.52
   },
   "motion": {
     "intensity": 1
@@ -30,12 +31,12 @@
       "pauseAfter": 0.03
     },
     {
-      "text": "ここは AITuber OnAir のニュースデスク。",
-      "chapter": "ニュースデスクとは",
+      "text": "メッシュで動きます。",
+      "chapter": "モーション",
       "pauseAfter": 0.03
     },
     {
-      "text": "新しいリリースを私がお知らせします。",
+      "text": "口パクも確認します。",
       "pauseAfter": 0.03
     }
   ]

--- a/packages/core/examples/node-psd-newsdesk/tests/fixtures/hello-sine.json
+++ b/packages/core/examples/node-psd-newsdesk/tests/fixtures/hello-sine.json
@@ -1,5 +1,6 @@
 {
   "avatar": "../../assets/sample-static.psd",
+  "avatarMode": "static",
   "voice": {
     "engine": "sine",
     "options": {

--- a/packages/core/examples/node-psd-newsdesk/tests/gen-unit.test.ts
+++ b/packages/core/examples/node-psd-newsdesk/tests/gen-unit.test.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createMouthValues } from '../src/gen/audio.js';
+import { selectAvatarMode } from '../src/gen/avatarMode.js';
 import { createBlinkSchedule } from '../src/gen/blink.js';
+import {
+  assertSequentialMotionFrame,
+  resolveLocalAssetPath,
+} from '../src/gen/psdMotionAvatar.js';
 import {
   autoDetectRoleBindings,
   loadPsdAvatar,
@@ -23,6 +28,7 @@ import {
   resolveIdlePose,
   resolveMouthState,
 } from '../src/gen/renderer.js';
+import { createSeededRandom, VirtualClock } from '../harness/virtualClock.js';
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const samplePsd = path.resolve(testDirectory, '../assets/sample-static.psd');
@@ -65,6 +71,65 @@ describe('deterministic animation helpers', () => {
       scale: 1,
     });
     expect(resolveIdlePose(75, 30, 1).y).not.toBe(0);
+  });
+
+  it('reuses deterministic browser clock and RNG semantics', () => {
+    const firstRandom = createSeededRandom(42);
+    const secondRandom = createSeededRandom(42);
+    expect([firstRandom(), firstRandom(), firstRandom()]).toEqual([
+      secondRandom(),
+      secondRandom(),
+      secondRandom(),
+    ]);
+
+    const clock = new VirtualClock();
+    clock.reset(42);
+    const order: string[] = [];
+    clock.requestAnimationFrame(() => {
+      order.push('first');
+      clock.requestAnimationFrame(() => order.push('nested'));
+    });
+    clock.requestAnimationFrame(() => order.push('second'));
+    clock.advance(1 / 30);
+    expect(clock.flushAnimationFrame()).toBe(2);
+    expect(order).toEqual(['first', 'second']);
+    expect(clock.pendingAnimationFrames()).toBe(1);
+    expect(clock.flushAnimationFrame()).toBe(1);
+    expect(order).toEqual(['first', 'second', 'nested']);
+  });
+});
+
+describe('PSD avatar mode selection', () => {
+  const usable = { usable: true, reason: 'Anime2.5DRig parts detected.' };
+  const ineligible = { usable: false, reason: 'missing part: face' };
+
+  it('selects motion first for auto and falls back to static', () => {
+    expect(selectAvatarMode('auto', usable)).toBe('motion');
+    expect(selectAvatarMode('auto', ineligible)).toBe('static');
+  });
+
+  it('honors forced modes and preserves the rigger diagnostic', () => {
+    expect(selectAvatarMode('static', usable)).toBe('static');
+    expect(selectAvatarMode('motion', usable)).toBe('motion');
+    expect(() => selectAvatarMode('motion', ineligible)).toThrow(
+      'missing part: face',
+    );
+  });
+
+  it('enforces sequential motion frames and read-only route boundaries', () => {
+    expect(() => assertSequentialMotionFrame(4, 4)).not.toThrow();
+    expect(() => assertSequentialMotionFrame(4, 5)).toThrow(
+      /expected 4, got 5/,
+    );
+    expect(resolveLocalAssetPath('/models', '/avatar/', '/avatar/a.psd')).toBe(
+      path.resolve('/models/a.psd'),
+    );
+    expect(
+      resolveLocalAssetPath('/models', '/avatar/', '/avatar/../secret.psd'),
+    ).toBeNull();
+    expect(
+      resolveLocalAssetPath('/models', '/avatar/', '/avatar/%2e%2e/secret.psd'),
+    ).toBeNull();
   });
 });
 

--- a/packages/core/examples/node-psd-newsdesk/tests/script-gen.test.ts
+++ b/packages/core/examples/node-psd-newsdesk/tests/script-gen.test.ts
@@ -31,6 +31,7 @@ const projectRoot = path.resolve(testDirectory, '..');
 
 const validScript: NewsdeskScript = {
   avatar: '../../assets/sample-static.psd',
+  avatarMode: 'static',
   voice: {
     engine: 'sine',
     options: { frequency: 440, secondsPerChar: 0.01, minDuration: 0.2 },
@@ -183,6 +184,16 @@ describe('strict schema and provenance', () => {
         avatarRoles: { mouthOpen: '', unexpected: 'Layer' },
       }).join('\n'),
     ).toMatch(/mouthOpen must be a non-empty string|unexpected is not allowed/);
+  });
+
+  it('accepts only auto, static, or motion avatar modes', () => {
+    expect(validateScript({ ...validScript, avatarMode: 'auto' })).toEqual([]);
+    expect(validateScript({ ...validScript, avatarMode: 'motion' })).toEqual(
+      [],
+    );
+    expect(
+      validateScript({ ...validScript, avatarMode: 'animated' }).join('\n'),
+    ).toMatch(/avatarMode must be "auto", "static", or "motion"/);
   });
 
   it('checks displayed numeric tokens against source plus focus', () => {

--- a/packages/core/examples/node-psd-newsdesk/tsconfig.json
+++ b/packages/core/examples/node-psd-newsdesk/tsconfig.json
@@ -12,7 +12,11 @@
     "declaration": false,
     "sourceMap": true,
     "noEmit": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "ag-psd": ["node_modules/ag-psd"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

Completes the `node-<format>-newsdesk` series: `node-psd-newsdesk` gains react-psd-app's second rendering path, **Anime2.5DRig motion mode**, next to the existing static PSDTool mode.

- `avatarMode: auto | static | motion` mirrors the React app's decision flow: run the rigger first, use motion when a normalized `face` part is found, else fall back to the unchanged pure-Node static renderer; forcing `motion` on an ineligible PSD surfaces the rigger's diagnostic.
- Motion rendering uses the headless-Chromium harness with the **seeded virtual clock** from `node-inochi2d-newsdesk` (patched rAF / `performance.now` / `Date.now` / `Math.random` before the renderer loads; one flushed callback per frame, asserted). The sibling example's MIT rigger + WebGL renderer are bundled **read-only from source** — no copies, no React changes; Anime2.5DRig attribution reproduced in README en/ja.
- Per-frame audio input drives `mouthOpen` via the renderer's documented lip-sync path; the renderer has no direct eye input, so its internal blink automation runs deterministically under `blinkSeed` (documented in diagnostics + README).
- Motion samples/fixture reference react-psd-app's license-clean procedural `sample.psd` by relative path.
- Static regression: byte-identical MP4 to the pre-change baseline. Motion e2e renders twice and asserts identical timings JSON and MP4 md5 (byte-stable on this machine). ~93 ms/frame with SwiftShader.

## Verification

- Example: fmt / lint / typecheck / test (29/29) / build / test:e2e (2/2: static + motion) pass; root fmt → lint → test → build pass.
- Real renders inspected: sine + AivisSpeech motion videos (mouth open/closed, deterministic blink, mesh sway/breath, overlays) and the static regression render.
- Real end-to-end with the default `codex-sdk` provider: `script-gen tests/fixtures/CHANGELOG.md --focus 0.49.0` → motion `gen` → MP4.
- public-release-check (diff): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
