### PR TITLE
fix(core-examples): drop machine-specific e2e model default in node-live2d-newsdesk

### DIFF
--- a/packages/core/examples/node-live2d-newsdesk/README.ja.md
+++ b/packages/core/examples/node-live2d-newsdesk/README.ja.md
@@ -43,7 +43,7 @@ Cubism Core とモデルにはそれぞれのライセンスがあるため、�
 隣接する React 例の `public/scripts/live2dcubismcore.min.js` も gitignore 済みで、
 明示的なパスを指定すれば利用できます。
 
-Hiyori は Live2D のサンプルキャラクターです。Hiyori を使った動画を公開する場合は
+Live2D 公式のサンプルモデルを利用する場合、そのモデルで作った動画の公開時は
 [無償提供マテリアルの使用許諾契約書](https://www.live2d.com/eula/live2d-free-material-license-agreement.html)
 と
 [Live2D Cubism サンプルデータ利用条件](https://www.live2d.com/eula/live2d-sample-model-terms.html)
@@ -141,6 +141,7 @@ npm run test:e2e
 ```
 
 単体テストは偽フレームソースを使うため、プロプライエタリファイルは不要です。E2E は
-`LIVE2D_CORE_PATH` と `LIVE2D_MODEL_PATH` を読みます。既定では隣接 React 例の
-Core と、現在ユーザーの Documents 内の Hiyori を探し、どちらかがなければ理由を
-表示して skip します。ファイルをダウンロードしたり同梱したりはしません。
+`LIVE2D_CORE_PATH` と `LIVE2D_MODEL_PATH` を読みます。Core の既定は隣接 React 例の
+gitignore 済みドロップで、モデルパスに既定はありません。`LIVE2D_MODEL_PATH` が
+未設定、またはどちらかのファイルがなければ、理由を表示して skip します。
+ファイルをダウンロードしたり同梱したりはしません。

--- a/packages/core/examples/node-live2d-newsdesk/README.md
+++ b/packages/core/examples/node-live2d-newsdesk/README.md
@@ -45,8 +45,8 @@ local drop inside this example, `models/` and
 `public/scripts/live2dcubismcore.min.js` is also gitignored and can be used by
 an explicit path.
 
-Hiyori is a Live2D sample character. Publishing a video made with Hiyori must
-follow both the
+If you use one of Live2D's official sample models, publishing a video made
+with it must follow both the
 [Free Material License Agreement](https://www.live2d.com/eula/live2d-free-material-license-agreement_en.html)
 and the
 [Terms of Use for Live2D Cubism Sample Data](https://www.live2d.com/eula/live2d-sample-model-terms_en.html),
@@ -151,7 +151,7 @@ npm run test:e2e
 ```
 
 The unit suite uses a fake frame source and requires no proprietary files. The
-E2E suite reads `LIVE2D_CORE_PATH` and `LIVE2D_MODEL_PATH`. Its local defaults
-target the sibling React example's Core drop and a Hiyori model in the current
-user's Documents directory. If either file is absent, the E2E test skips with
-a clear reason instead of downloading or bundling the asset.
+E2E suite reads `LIVE2D_CORE_PATH` and `LIVE2D_MODEL_PATH`. The Core path
+defaults to the sibling React example's gitignored drop; the model path has no
+default. If `LIVE2D_MODEL_PATH` is unset or either file is absent, the E2E
+test skips with a clear reason instead of downloading or bundling the asset.

--- a/packages/core/examples/node-live2d-newsdesk/tests/e2e/gen.test.ts
+++ b/packages/core/examples/node-live2d-newsdesk/tests/e2e/gen.test.ts
@@ -2,7 +2,6 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import { createCanvas, loadImage } from '@napi-rs/canvas';
 
@@ -27,19 +26,12 @@ const cubismCorePath =
     projectRoot,
     '../react-live2d-app/public/scripts/live2dcubismcore.min.js',
   );
-const live2DModelPath =
-  process.env.LIVE2D_MODEL_PATH ||
-  path.join(
-    os.homedir(),
-    'Documents',
-    'live2d_models',
-    'hiyori_pro_jp',
-    'runtime',
-    'hiyori_pro_t11.model3.json',
-  );
+const live2DModelPath = process.env.LIVE2D_MODEL_PATH || '';
 const missingAssets = [
   !existsSync(cubismCorePath) ? 'LIVE2D_CORE_PATH' : null,
-  !existsSync(live2DModelPath) ? 'LIVE2D_MODEL_PATH' : null,
+  live2DModelPath === '' || !existsSync(live2DModelPath)
+    ? 'LIVE2D_MODEL_PATH'
+    : null,
 ].filter((value): value is string => value !== null);
 
 interface CommandResult {


### PR DESCRIPTION
## Summary

The Live2D e2e test shipped with a development-machine convention as its default: `LIVE2D_MODEL_PATH` fell back to a Hiyori sample model under the current user's `Documents` directory, and the READMEs described that default. That is internal dev-environment detail and should not appear in the published example.

- `tests/e2e/gen.test.ts`: no model-path default at all — the e2e runs only when `LIVE2D_MODEL_PATH` points at an existing `.model3.json`, and skips with a clear reason otherwise. (`LIVE2D_CORE_PATH` keeps its repo-relative gitignored default.)
- README en/ja: e2e docs updated; the license note now states the general rule (Live2D's official sample models are governed by the Free Material License Agreement and the Sample Data terms) instead of naming a specific model.
- No references to a specific model or a home-directory layout remain in tracked files.

Security note: the removed text exposed no credentials, usernames, or infrastructure — only a filesystem convention on a dev machine (the path was built via `os.homedir()` at runtime). It remains in git history of earlier merges, which is acceptable for non-secret information; no history rewrite is proposed.

## Verification

- Example: fmt / lint / test (24/24) pass; e2e **skips** when `LIVE2D_MODEL_PATH` is unset and **passes** (1/1) with real local assets.
- Root: fmt → lint → test → build pass.
- public-release-check (diff): no findings; `git grep -i hiyori` in the example returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
