### PR TITLE
docs(skills): cover the Node newsdesk examples in core-propagation guidance

### DIFF
--- a/.claude/skills/sync-core-after-chat-upgrade/SKILL.md
+++ b/.claude/skills/sync-core-after-chat-upgrade/SKILL.md
@@ -59,6 +59,13 @@ Collect missing inputs before editing:
      requires defaults, model selectors, settings UI, or docs updates. These
      apps usually use free-form model input rather than fixed chat model lists,
      so code changes are only needed when behavior or defaults must change.
+   - The Node newsdesk examples (`packages/core/examples/node-purupuru-newsdesk`,
+     `node-pngtuber-newsdesk`, `node-psd-newsdesk`, `node-vrm-newsdesk`,
+     `node-live2d-newsdesk`, `node-inochi2d-newsdesk`) pass provider names and
+     options straight through to Core, so chat changes rarely need code edits.
+     Check `src/script-gen/chat.ts` provider handling and the README provider
+     notes only when providers are added, removed, or renamed, or when the
+     Core Agent SDK entry (`@aituber-onair/core/agent`) changes behavior.
 5. Update docs when `update_docs` is `true`:
    - `packages/core/README.md`
    - `packages/core/README_ja.md`
@@ -83,6 +90,12 @@ Collect missing inputs before editing:
      - `packages/core/examples/react-vrm-app/package-lock.json`
      - `packages/core/examples/react-live2d-app/package-lock.json`
      - `packages/core/examples/coding-agent/package-lock.json`
+     - `packages/core/examples/node-purupuru-newsdesk/package-lock.json`
+     - `packages/core/examples/node-pngtuber-newsdesk/package-lock.json`
+     - `packages/core/examples/node-psd-newsdesk/package-lock.json`
+     - `packages/core/examples/node-vrm-newsdesk/package-lock.json`
+     - `packages/core/examples/node-live2d-newsdesk/package-lock.json`
+     - `packages/core/examples/node-inochi2d-newsdesk/package-lock.json`
    - After updating, search all `packages/core/examples/*/package-lock.json`
      files for stale `@aituber-onair/core` versions or stale
      `@aituber-onair/chat` dependency ranges.
@@ -96,6 +109,9 @@ Collect missing inputs before editing:
      - `npm --prefix packages/core/examples/react-vrm-app run build`
      - `npm --prefix packages/core/examples/react-live2d-app run build`
      - `npm --prefix packages/core/examples/coding-agent run build`
+   - If any Node newsdesk example or its lockfile changed, run
+     `npm --prefix packages/core/examples/<example> run build` for each
+     changed one (all six share the same structure).
    - Starter/template smoke tests must install the published Chat dependency
      from npm while using the local Core release-candidate tarball. Do not
      inject a local Chat tarball: doing so can hide an unpublished or incorrect
@@ -118,6 +134,8 @@ npm --prefix packages/core/examples/react-pet-app run build
 npm --prefix packages/core/examples/react-vrm-app run build
 npm --prefix packages/core/examples/react-live2d-app run build
 npm --prefix packages/core/examples/coding-agent run build
+# For each changed Node newsdesk example (node-*-newsdesk):
+npm --prefix packages/core/examples/node-purupuru-newsdesk run build
 ```
 
 ## Acceptance Criteria

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,12 @@
   engine selector, persisted settings type/defaults, settings UI,
   `VoiceServiceOptions` wiring, README mention, lockfile metadata, and example
   build. Cloud voice providers that expose voice-list APIs should provide a
-  selectable voice list instead of requiring users to type opaque voice IDs.
+  selectable voice list instead of requiring users to type opaque voice IDs. The
+  Node newsdesk examples (`packages/core/examples/node-*-newsdesk`) pass
+  `VoiceServiceOptions` through unchanged and have no engine selector or
+  persisted settings, so for them a voice upgrade only needs the embedded-core
+  lockfile refresh, plus a README touch-up when a sample or doc names a
+  specific engine.
 - When requests match "wrap a TTS engine as OpenAI-compatible", "build an OpenAI-compatible speech server", "expose <provider> as `/v1/audio/speech`", or "set up a Colab TTS compatibility server", follow `skills/wrap-tts-as-openai-compatible/SKILL.md`.
 - For `wrap-tts-as-openai-compatible`, first classify the upstream TTS as direct Python API, CLI/file-output, or internal runtime plus save helper, then validate the wrapper from `@aituber-onair/voice` when applicable.
 - Prefer this skill for practical local TTS engines that cleanly support one-shot WAV generation. Do not force research-first or streaming-first systems into this workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,11 @@ Usage:
   the engine selector, persisted settings type/defaults, settings UI,
   `VoiceServiceOptions` wiring, README mention, lockfile metadata, and example
   build. If the provider has a voice-list API, surface it as a selectable list
-  so users do not have to type opaque voice IDs.
+  so users do not have to type opaque voice IDs. The Node newsdesk examples
+  (`packages/core/examples/node-*-newsdesk`) pass `VoiceServiceOptions`
+  through unchanged and have no engine selector or persisted settings, so for
+  them a voice upgrade only needs the embedded-core lockfile refresh, plus a
+  README touch-up when a sample or doc names a specific engine.
 - Invoke explicitly with `$wrap-tts-as-openai-compatible`, or use prompts like
   "wrap a TTS engine as OpenAI-compatible", "build an OpenAI-compatible speech
   server", or "set up a Colab TTS compatibility server".

--- a/skills/sync-core-after-chat-upgrade/SKILL.md
+++ b/skills/sync-core-after-chat-upgrade/SKILL.md
@@ -59,6 +59,13 @@ Collect missing inputs before editing:
      requires defaults, model selectors, settings UI, or docs updates. These
      apps usually use free-form model input rather than fixed chat model lists,
      so code changes are only needed when behavior or defaults must change.
+   - The Node newsdesk examples (`packages/core/examples/node-purupuru-newsdesk`,
+     `node-pngtuber-newsdesk`, `node-psd-newsdesk`, `node-vrm-newsdesk`,
+     `node-live2d-newsdesk`, `node-inochi2d-newsdesk`) pass provider names and
+     options straight through to Core, so chat changes rarely need code edits.
+     Check `src/script-gen/chat.ts` provider handling and the README provider
+     notes only when providers are added, removed, or renamed, or when the
+     Core Agent SDK entry (`@aituber-onair/core/agent`) changes behavior.
 5. Update docs when `update_docs` is `true`:
    - `packages/core/README.md`
    - `packages/core/README_ja.md`
@@ -83,6 +90,12 @@ Collect missing inputs before editing:
      - `packages/core/examples/react-vrm-app/package-lock.json`
      - `packages/core/examples/react-live2d-app/package-lock.json`
      - `packages/core/examples/coding-agent/package-lock.json`
+     - `packages/core/examples/node-purupuru-newsdesk/package-lock.json`
+     - `packages/core/examples/node-pngtuber-newsdesk/package-lock.json`
+     - `packages/core/examples/node-psd-newsdesk/package-lock.json`
+     - `packages/core/examples/node-vrm-newsdesk/package-lock.json`
+     - `packages/core/examples/node-live2d-newsdesk/package-lock.json`
+     - `packages/core/examples/node-inochi2d-newsdesk/package-lock.json`
    - After updating, search all `packages/core/examples/*/package-lock.json`
      files for stale `@aituber-onair/core` versions or stale
      `@aituber-onair/chat` dependency ranges.
@@ -96,6 +109,9 @@ Collect missing inputs before editing:
      - `npm --prefix packages/core/examples/react-vrm-app run build`
      - `npm --prefix packages/core/examples/react-live2d-app run build`
      - `npm --prefix packages/core/examples/coding-agent run build`
+   - If any Node newsdesk example or its lockfile changed, run
+     `npm --prefix packages/core/examples/<example> run build` for each
+     changed one (all six share the same structure).
    - Starter/template smoke tests must install the published Chat dependency
      from npm while using the local Core release-candidate tarball. Do not
      inject a local Chat tarball: doing so can hide an unpublished or incorrect
@@ -118,6 +134,8 @@ npm --prefix packages/core/examples/react-pet-app run build
 npm --prefix packages/core/examples/react-vrm-app run build
 npm --prefix packages/core/examples/react-live2d-app run build
 npm --prefix packages/core/examples/coding-agent run build
+# For each changed Node newsdesk example (node-*-newsdesk):
+npm --prefix packages/core/examples/node-purupuru-newsdesk run build
 ```
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

Follow-up to the `node-<format>-newsdesk` series (#319–#328): the six new examples embed local core workspace metadata in their `package-lock.json` (verified: `../..` entry carries core's version and chat/voice ranges), so core/chat/voice version bumps would leave them stale — but the propagation guidance didn't know they exist.

- `skills/sync-core-after-chat-upgrade/SKILL.md` (+ `.claude` mirror, kept byte-identical): add the six lockfiles to the refresh list, a step-4 note that these examples pass provider names/options straight through to Core (code edits only when providers change or `@aituber-onair/core/agent` behavior changes), and per-changed-example build verification.
- `CLAUDE.md` / `AGENTS.md` voice-propagation rule: general rule stated for the group — the Node newsdesk examples pass `VoiceServiceOptions` through unchanged with no engine selector or persisted settings, so a voice upgrade needs only the embedded-core lockfile refresh plus README touch-ups when a specific engine is named.

`add-chat-model` needs no change: the Node examples hardcode no model lists (provider defaults are used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
