### PR TITLE
feat(agent): prepare @aituber-onair/agent 0.0.1 alpha release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           npm -w @aituber-onair/voice run build
           npm -w @aituber-onair/core run build
           npm -w @aituber-onair/comment-intelligence run build
+          npm -w @aituber-onair/agent run build
 
       - name: Run tests
         run: npm run test --workspaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AITuber OnAir is a TypeScript monorepo that provides a comprehensive toolkit for creating AI-powered virtual streamers (AITubers). The project consists of seven main packages:
+AITuber OnAir is a TypeScript monorepo that provides a comprehensive toolkit for creating AI-powered virtual streamers (AITubers). The project consists of eight main packages:
 
 - **`@aituber-onair/core`** - Core library for AI-driven virtual streaming applications with memory management and event-driven architecture
 - **`@aituber-onair/chat`** - Chat and LLM API integration library supporting multiple AI providers (OpenAI, Claude, Gemini) with unified interface
+- **`@aituber-onair/agent`** - Embeddable AI-character agent runtime with host-controlled tools, policies, approvals, hooks, events, and Chat/Codex backends
 - **`@aituber-onair/voice`** - Independent voice synthesis library supporting multiple TTS engines (VOICEVOX, VoicePeak, OpenAI TTS, MiniMax, etc.)
 - **`@aituber-onair/manneri`** - Conversation pattern detection library that identifies repetitive dialogue and provides topic diversification prompts
 - **`@aituber-onair/bushitsu-client`** - WebSocket client library for chat functionality with React hooks support, auto-reconnection, rate limiting, and mention support
@@ -210,6 +211,8 @@ packages/
 │   └── examples/   # Usage examples for core functionality
 ├── chat/           # ChatService interface, provider implementations, MCP support
 │   └── examples/   # Chat service usage examples
+├── agent/          # Embeddable AI-character Agent runtime and backends
+│   └── examples/   # Product-integrated Agent usage examples
 ├── voice/          # VoiceService, TTS engines, emotion parsing, audio playback
 │   └── examples/   # Voice synthesis examples
 ├── manneri/        # ManneriDetector, analyzers, prompt generation

--- a/README.md
+++ b/README.md
@@ -334,6 +334,19 @@ Filters live comments before they reach an AI character: selects one comment to 
 npm install @aituber-onair/comment-intelligence
 ```
 
+### [@aituber-onair/agent](./packages/agent/README.md)
+
+<p align="center">
+  <img src="./packages/agent/images/aituber-onair-agent.png" alt="AITuber OnAir Agent logo" width="360" />
+</p>
+
+Embeddable runtime for giving an AI character a job inside your product:
+host-controlled tools, policies, approvals, hooks, and events, with Chat and Codex app-server backends.
+
+```bash
+npm install @aituber-onair/agent
+```
+
 ### [@aituber-onair/bushitsu-client](./packages/bushitsu-client/README.md)
 
 <p align="center">
@@ -376,6 +389,7 @@ aituber-onair/
     ├── manneri/          # Conversation pattern detection
     ├── noise/            # Post-generation response rewriting
     ├── comment-intelligence/ # Live comment filtering and context building
+    ├── agent/            # Embeddable AI-character agent runtime
     ├── bushitsu-client/  # WebSocket chat client + React hooks
     └── kizuna/           # Viewer relationship / bond system
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -317,6 +317,19 @@ npm install @aituber-onair/noise
 npm install @aituber-onair/comment-intelligence
 ```
 
+### [@aituber-onair/agent](./packages/agent/README.ja.md)
+
+<p align="center">
+  <img src="./packages/agent/images/aituber-onair-agent.png" alt="AITuber OnAir Agent ロゴ" width="360" />
+</p>
+
+プロダクトの中でAIキャラクターに仕事を与える組み込み型ランタイム。
+ホスト管理のTool、policy、approval、hook、eventと、Chat／Codex app-serverバックエンドを提供します。
+
+```bash
+npm install @aituber-onair/agent
+```
+
 ### [@aituber-onair/bushitsu-client](./packages/bushitsu-client/README_ja.md)
 
 <p align="center">
@@ -359,6 +372,7 @@ aituber-onair/
     ├── manneri/          # 会話パターン検出
     ├── noise/            # 生成後の返答書き換え
     ├── comment-intelligence/ # ライブコメントのフィルタリングと文脈生成
+    ├── agent/            # 組み込み型AIキャラクターAgentランタイム
     ├── bushitsu-client/  # WebSocket チャットクライアント + React hooks
     └── kizuna/           # 視聴者との関係性 / 絆システム
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -7135,7 +7135,7 @@
         },
         "packages/agent": {
             "name": "@aituber-onair/agent",
-            "version": "0.0.0",
+            "version": "0.0.1",
             "license": "MIT",
             "devDependencies": {
                 "@aituber-onair/chat": "^0.52.0",

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -8,6 +8,8 @@
   terminating an otherwise healthy transport.
 - Lets `run()` and `runStream()` answer approval requests through a guarded
   host callback, with actionable timeout guidance for unattended `run()` calls.
+- Guarantees that error details embedded in Agent events contain only JSON
+  values, converting or dropping unsupported runtime values.
 
 ### Added
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,15 +1,9 @@
 # @aituber-onair/agent
 
-## Unreleased
+## 0.0.1
 
-### Fixed
-
-- Ignores late Codex app-server responses for timed-out requests without
-  terminating an otherwise healthy transport.
-- Lets `run()` and `runStream()` answer approval requests through a guarded
-  host callback, with actionable timeout guidance for unattended `run()` calls.
-- Guarantees that error details embedded in Agent events contain only JSON
-  values, converting or dropping unsupported runtime values.
+This package is an alpha release. Its public API may change before a stable
+release.
 
 ### Added
 
@@ -22,14 +16,17 @@
 - Adds a Node.js Codex app-server backend for Codex CLI 0.136.0 or later,
   verified against 0.145.0, with streamed Turns, resume support, approvals,
   safe artifacts, and compatibility checks without an exact version pin.
-- Adds a live-stream operations staff example backed by a real Codex app-server,
-  server-side comment preprocessing, validated generated artifacts, and an
-  HTTP/SSE dashboard client.
-
-### Changed
-
-- Renames backend feature-flag fields and Chat backend options from
-  `capabilities` to `backendCapabilities` to distinguish them from
+- Adds guarded `onApprovalRequest` handling for `run()` and `runStream()`, with
+  actionable timeout guidance for unattended `run()` calls.
+- Defines backend feature-flag fields and Chat backend options under
+  `backendCapabilities` rather than `capabilities` to distinguish them from
   host-granted capability descriptors.
-- Adds phase-specific hook value typing and comprehensive JSDoc for the public
-  API surface.
+- Adds phase-specific hook value typing and comprehensive public API JSDoc.
+- Adds JSON-safe error details in Agent events, converting or dropping
+  unsupported runtime values.
+- Adds timeout-safe Codex transport behavior that ignores late responses for
+  timed-out requests without terminating an otherwise healthy transport.
+- Adds `codex-workspace-server`, `stream-operations-staff`, and
+  `channel-strategy-staff` examples covering restricted workspaces, live-stream
+  operations, Chat-backed strategy work, validated artifacts, and HTTP/SSE
+  dashboard integration.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -31,3 +31,5 @@
 - Renames backend feature-flag fields and Chat backend options from
   `capabilities` to `backendCapabilities` to distinguish them from
   host-granted capability descriptors.
+- Adds phase-specific hook value typing and comprehensive JSDoc for the public
+  API surface.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Ignores late Codex app-server responses for timed-out requests without
+  terminating an otherwise healthy transport.
+
 ### Added
 
 - Adds an embeddable Agent and Session runtime with host-controlled Tools,

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Ignores late Codex app-server responses for timed-out requests without
   terminating an otherwise healthy transport.
+- Lets `run()` and `runStream()` answer approval requests through a guarded
+  host callback, with actionable timeout guidance for unattended `run()` calls.
 
 ### Added
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -23,3 +23,9 @@
 - Adds a live-stream operations staff example backed by a real Codex app-server,
   server-side comment preprocessing, validated generated artifacts, and an
   HTTP/SSE dashboard client.
+
+### Changed
+
+- Renames backend feature-flag fields and Chat backend options from
+  `capabilities` to `backendCapabilities` to distinguish them from
+  host-granted capability descriptors.

--- a/packages/agent/README.ja.md
+++ b/packages/agent/README.ja.md
@@ -199,17 +199,17 @@ const result = await publicSession.run(
 ```
 
 組み込みChat provider名を指定した場合は、`ChatServiceFactory`のcapability metadataを
-fallbackとして使います。独自providerでは`capabilities`を明示してください。Tool非対応の
-providerへは空のTool一覧を渡します。現在の`codex-sdk` Chat providerはtext-onlyで、
-streaming deltaではなく完了後の全文を返します。
+fallbackとして使います。独自providerでは`backendCapabilities`を明示してください。
+Tool非対応のproviderへは空のTool一覧を渡します。現在の`codex-sdk` Chat providerは
+text-onlyで、streaming deltaではなく完了後の全文を返します。
 
 会話履歴とTool履歴はSessionごとに保持します。1 Turnで利用できるprovider Tool roundは
 既定で6回です。必要に応じて`maxToolRounds`へ別の正の整数を指定できます。
 `AbortSignal`とAgentのtimeoutはAgent Turnを停止し、遅れて届いた結果を無視します。
 汎用の`ChatService` interfaceは、すでに実行中のprovider requestがnetwork transport層でも
 cancelされることまでは保証しません。同じ理由で、組み込みprovider metadataから導出した
-capabilityは`interruption: false`と`sessionResume: false`を宣言します。ChatService
-バックエンドのTurnは`AbortSignal`またはtimeoutで停止してください。
+`backendCapabilities`は`interruption: false`と`sessionResume: false`を宣言します。
+ChatServiceバックエンドのTurnは`AbortSignal`またはtimeoutで停止してください。
 `agent.resumeSession(...)`が必要な場合は、Codex app-serverバックエンドのように
 `sessionResume`を宣言するバックエンドを使用します。
 

--- a/packages/agent/README.ja.md
+++ b/packages/agent/README.ja.md
@@ -7,9 +7,17 @@
 JavaScript／TypeScriptプロダクトの中で、AIキャラクターに仕事を与えるための
 組み込み型ランタイムです。
 
-> **Status: 未リリースの開発版。** 本パッケージはAITuber OnAirモノレポ内で
-> 実装・テスト済みですが、npmへはまだ公開されていません（`version 0.0.0`、
-> `private`）。このREADMEは現在の実装を説明しています。
+> このパッケージはα版です。安定版になるまでに公開APIが変更される可能性が
+> あります。
+
+```bash
+npm install @aituber-onair/agent @aituber-onair/chat
+```
+
+`@aituber-onair/chat`は、`@aituber-onair/agent/chat` entry pointを使う場合のみ
+必要なoptional peer dependencyです。Codex app-server entry pointにはローカルに
+インストールされたCodex CLIが必要です。詳しくは
+[Codex app-serverとの統合](#codex-app-serverとの統合)を参照してください。
 
 ## このパッケージについて
 

--- a/packages/agent/README.ja.md
+++ b/packages/agent/README.ja.md
@@ -165,7 +165,7 @@ export function createStreamStaff(apiKey: string) {
     tools: [analyzeComments],
     policy: {
       defaultDecision: 'deny',
-      allowTools: ['comments.analyze'],
+      requireApproval: { tools: ['comments.analyze'] },
     },
   });
 }
@@ -183,13 +183,19 @@ const publicSession = await agent.startSession({
   allowedTools: ['comments.analyze'],
 });
 
-const result = await publicSession.run({
-  instruction: '返信する価値がある場合だけ応答してください。',
-  input: {
-    kind: 'viewer-comment',
-    data: { text: viewerComment },
+const result = await publicSession.run(
+  {
+    instruction: '返信する価値がある場合だけ応答してください。',
+    input: {
+      kind: 'viewer-comment',
+      data: { text: viewerComment },
+    },
   },
-});
+  {
+    onApprovalRequest: async (request, { signal }) =>
+      (await showApprovalDialog(request, { signal })) ? 'allow-once' : 'deny',
+  }
+);
 ```
 
 組み込みChat provider名を指定した場合は、`ChatServiceFactory`のcapability metadataを
@@ -215,11 +221,16 @@ capabilityは`interruption: false`と`sessionResume: false`を宣言します。
 - Tool入力schemaは、`type`、`properties`、`required`、`items`、`enum`、
   `description`、boolean値の`additionalProperties`に対応します。未対応のkeywordは
   無視せず、Agent作成時に拒否します。
-- 承認要求は`session.resolveApproval(requestId, decision)`の応答を
-  `limits.approvalTimeoutMs`（既定30秒）まで待ち、timeout、abort、Session終了時は
-  拒否として扱います。人間の運営者が承認へ応答する場合は、`createAgent`で上限を
-  引き上げてください。`limits.maxToolCallsPerTurn`（既定8回）は1 Turnあたりの
-  ランタイムTool実行数を制限します。
+- `session.run(...)`では、`options.onApprovalRequest`から承認へ応答します。
+  `session.runStream(...)`では、同じcallbackを使うか、eventを読みながら
+  `session.resolveApproval(requestId, decision)`を呼び出します。承認timerはstreamの
+  consumerがeventを読む時点ではなく、`approval.requested`が発行された時点で開始し、
+  `limits.approvalTimeoutMs`（既定30秒）まで待ちます。timeout、abort、Session終了時は
+  拒否として扱います。callbackがthrowするか不正なdecisionを返した場合も拒否し、
+  callbackのbugをTurnの失敗理由へ変えず、errorを`approval.resolved`へ記録します。
+  人間の運営者が承認へ応答する場合は、`createAgent`で上限を引き上げてください。
+- `limits.maxToolCallsPerTurn`（既定8回）は1 TurnあたりのランタイムTool実行数を
+  制限します。
 - `sensitiveFields`には、ドット区切りのobject pathを指定できます。一致する入力値は
   Tool eventと承認eventでは秘匿化します。ホストのhandlerには、承認時と同じ入力値を
   固定した変更不可のsnapshotを渡します。

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -208,21 +208,21 @@ const result = await publicSession.run(
 ```
 
 Built-in Chat provider names use `ChatServiceFactory` capability metadata as a
-fallback. Supply `capabilities` explicitly for a custom provider. Providers
-without Tool support receive an empty Tool list; for example, the current
-`codex-sdk` Chat provider is text-only and returns completed text rather than
-streaming deltas.
+fallback. Supply `backendCapabilities` explicitly for a custom provider.
+Providers without Tool support receive an empty Tool list; for example, the
+current `codex-sdk` Chat provider is text-only and returns completed text rather
+than streaming deltas.
 
 The backend keeps conversation and Tool history inside each Session and limits
 one Turn to six provider Tool rounds by default. Set `maxToolRounds` to another
 positive integer when needed. `AbortSignal` and Agent timeouts stop the Agent
 Turn and ignore late results. The generic `ChatService` interface does not
 guarantee that an already-running provider request is cancelled at the network
-transport layer. For the same reason, capabilities derived from built-in
-provider metadata declare `interruption: false` and `sessionResume: false`:
-cancel ChatService backend Turns with `AbortSignal` or timeouts, and use a
-backend that declares `sessionResume`, such as the Codex app-server backend,
-when `agent.resumeSession(...)` is required.
+transport layer. For the same reason, `backendCapabilities` derived from
+built-in provider metadata declare `interruption: false` and
+`sessionResume: false`: cancel ChatService backend Turns with `AbortSignal` or
+timeouts, and use a backend that declares `sessionResume`, such as the Codex
+app-server backend, when `agent.resumeSession(...)` is required.
 
 ## Tool execution rules
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -7,10 +7,17 @@
 An embeddable runtime for giving an AI character a job inside a JavaScript or
 TypeScript product.
 
-> **Status: unreleased development version.** This package is implemented and
-> tested inside the AITuber OnAir monorepo but is not published to npm yet
-> (`version 0.0.0`, `private`). The documented API describes the current
-> implementation.
+> This package is an alpha release. Its public API may change before a stable
+> release.
+
+```bash
+npm install @aituber-onair/agent @aituber-onair/chat
+```
+
+`@aituber-onair/chat` is an optional peer dependency needed only for the
+`@aituber-onair/agent/chat` entry point. The Codex app-server entry point needs
+a locally installed Codex CLI; see
+[Codex app-server integration](#codex-app-server-integration).
 
 ## What this package is
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -173,7 +173,7 @@ export function createStreamStaff(apiKey: string) {
     tools: [analyzeComments],
     policy: {
       defaultDecision: 'deny',
-      allowTools: ['comments.analyze'],
+      requireApproval: { tools: ['comments.analyze'] },
     },
   });
 }
@@ -192,13 +192,19 @@ const publicSession = await agent.startSession({
   allowedTools: ['comments.analyze'],
 });
 
-const result = await publicSession.run({
-  instruction: 'Respond only when a reply is useful.',
-  input: {
-    kind: 'viewer-comment',
-    data: { text: viewerComment },
+const result = await publicSession.run(
+  {
+    instruction: 'Respond only when a reply is useful.',
+    input: {
+      kind: 'viewer-comment',
+      data: { text: viewerComment },
+    },
   },
-});
+  {
+    onApprovalRequest: async (request, { signal }) =>
+      (await showApprovalDialog(request, { signal })) ? 'allow-once' : 'deny',
+  }
+);
 ```
 
 Built-in Chat provider names use `ChatServiceFactory` capability metadata as a
@@ -226,11 +232,18 @@ when `agent.resumeSession(...)` is required.
 - Tool input schemas support `type`, `properties`, `required`, `items`, `enum`,
   `description`, and boolean `additionalProperties`. Unsupported keywords are
   rejected when the Agent is created instead of being silently ignored.
-- Approval requests wait for `session.resolveApproval(requestId, decision)`
-  up to `limits.approvalTimeoutMs` (default 30 seconds) and are denied on
-  timeout, abort, or Session close. Raise the limit in `createAgent` when a
-  human operator answers approvals. `limits.maxToolCallsPerTurn` (default 8)
-  bounds runtime Tool executions per Turn.
+- With `session.run(...)`, answer approvals through
+  `options.onApprovalRequest`. With `session.runStream(...)`, either use the
+  same callback or call `session.resolveApproval(requestId, decision)` while
+  consuming events. The approval timer starts when `approval.requested` is
+  emitted, not when a stream consumer reads it, and waits up to
+  `limits.approvalTimeoutMs` (default 30 seconds). Timeout, abort, and Session
+  close deny the request. A callback that throws or returns an invalid decision
+  also denies the request and records its error on `approval.resolved` without
+  turning the callback bug into the Turn's failure reason. Raise the limit in
+  `createAgent` when a human operator answers approvals.
+- `limits.maxToolCallsPerTurn` (default 8) bounds runtime Tool executions per
+  Turn.
 - `sensitiveFields` accepts dot-separated object paths. Matching input values
   are redacted in Tool and approval events, while the original validated values
   are copied into the immutable snapshot passed to the host handler. Approval

--- a/packages/agent/examples/channel-strategy-staff/server/controller.ts
+++ b/packages/agent/examples/channel-strategy-staff/server/controller.ts
@@ -146,7 +146,7 @@ export async function createChannelStrategyController(
         phase: 'draft-response',
         onError: 'fail-turn',
         run: ({ value, turnId }) => {
-          if (typeof value === 'string') rawByTurn.set(turnId, value);
+          rawByTurn.set(turnId, value);
           return value;
         },
       },
@@ -160,9 +160,8 @@ export async function createChannelStrategyController(
             throw new Error('Codex completed without a text response.');
           }
           const proposal = parseAndValidateProposal(raw, evidenceSnapshot);
-          const result = value as AgentRunResult;
           return attachProposalArtifact(
-            result,
+            value,
             proposal,
             agentId,
             sessionId,

--- a/packages/agent/examples/channel-strategy-staff/server/stubCodexBackend.ts
+++ b/packages/agent/examples/channel-strategy-staff/server/stubCodexBackend.ts
@@ -118,7 +118,7 @@ export function createStubCodexBackend(
 
   return {
     name: 'stub-codex-app-server',
-    capabilities: STUB_CODEX_CAPABILITIES,
+    backendCapabilities: STUB_CODEX_CAPABILITIES,
     startedSessionIds,
     resumedSessionIds,
     receivedInputs,

--- a/packages/agent/examples/codex-workspace-server/tests/server.test.ts
+++ b/packages/agent/examples/codex-workspace-server/tests/server.test.ts
@@ -73,7 +73,7 @@ function createMockBackend(
 ): AgentBackend {
   return {
     name: 'mock-backend',
-    capabilities: {
+    backendCapabilities: {
       text: true,
       streaming: true,
       tools: false,

--- a/packages/agent/examples/stream-operations-staff/tests/controller.test.ts
+++ b/packages/agent/examples/stream-operations-staff/tests/controller.test.ts
@@ -35,7 +35,7 @@ class MockBackendSession implements AgentBackendSession {
 
 class MockBackend implements AgentBackend {
   readonly name = 'mock-codex';
-  readonly capabilities = Object.freeze({
+  readonly backendCapabilities = Object.freeze({
     text: true,
     streaming: true,
     tools: false,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aituber-onair/agent",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
   "description": "Embeddable runtime for giving AI characters jobs inside JavaScript and TypeScript products",
   "type": "module",
   "main": "dist/cjs/index.js",
@@ -38,7 +37,8 @@
     "test:coverage": "vitest run --coverage",
     "fmt": "biome format . --write",
     "fmt:check": "biome format .",
-    "lint": "biome lint ."
+    "lint": "biome lint .",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "aituber",
@@ -53,6 +53,9 @@
     "type": "git",
     "url": "https://github.com/shinshin86/aituber-onair.git",
     "directory": "packages/agent"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "peerDependencies": {
     "@aituber-onair/chat": "^0.52.0"

--- a/packages/agent/src/backends/chat/ChatServiceBackend.ts
+++ b/packages/agent/src/backends/chat/ChatServiceBackend.ts
@@ -32,6 +32,7 @@ import type {
   JsonValue,
 } from '../../types.js';
 import { AsyncEventQueue } from '../../core/AsyncEventQueue.js';
+import { sanitizeJsonRecord } from '../../internal/eventError.js';
 import {
   buildChatSessionMessages,
   buildChatTurnMessages,
@@ -750,16 +751,13 @@ function toToolResultBlock(result: AgentBackendToolResult): ToolResultBlock {
 }
 
 function toSerializableEventError(error: AgentEventError): JsonValue {
+  const details = sanitizeJsonRecord(error.details);
   return {
     name: error.name,
     code: error.code,
     message: error.message,
-    ...(error.details ? { details: sanitizeJsonValue(error.details) } : {}),
+    ...(details ? { details } : {}),
   };
-}
-
-function sanitizeJsonValue(value: unknown): JsonValue {
-  return JSON.parse(serializeChatData(value, 'Agent Tool error details'));
 }
 
 function toAgentUsage(

--- a/packages/agent/src/backends/chat/ChatServiceBackend.ts
+++ b/packages/agent/src/backends/chat/ChatServiceBackend.ts
@@ -78,7 +78,7 @@ interface ActiveChatTurn {
 class ChatServiceBackendRuntime implements ChatServiceBackend {
   readonly kind = 'chat' as const;
   readonly name: string;
-  readonly capabilities: Readonly<ChatServiceBackendCapabilities>;
+  readonly backendCapabilities: Readonly<ChatServiceBackendCapabilities>;
 
   private readonly provider?: string;
   private readonly createChatService: ChatServiceBackendOptions['createChatService'];
@@ -95,9 +95,9 @@ class ChatServiceBackendRuntime implements ChatServiceBackend {
     this.provider = options.provider;
     this.createChatService = options.createChatService;
     this.maxToolRounds = options.maxToolRounds ?? DEFAULT_MAX_TOOL_ROUNDS;
-    this.capabilities = Object.freeze(
-      options.capabilities
-        ? { ...options.capabilities }
+    this.backendCapabilities = Object.freeze(
+      options.backendCapabilities
+        ? { ...options.backendCapabilities }
         : resolveProviderCapabilities(options.provider as string)
     );
     this.name = this.provider
@@ -113,7 +113,7 @@ class ChatServiceBackendRuntime implements ChatServiceBackend {
         'ChatService backend does not support Session resume.'
       );
     }
-    if (!this.capabilities.tools && input.tools.length > 0) {
+    if (!this.backendCapabilities.tools && input.tools.length > 0) {
       throw new AgentBackendProtocolError(
         'ChatService backend received Tools while Tool support is disabled.'
       );
@@ -121,7 +121,7 @@ class ChatServiceBackendRuntime implements ChatServiceBackend {
 
     const toolRegistry = createProviderToolRegistry(input.tools);
     const factoryInput: ChatServiceFactoryInput = {
-      tools: this.capabilities.tools ? toolRegistry.definitions : [],
+      tools: this.backendCapabilities.tools ? toolRegistry.definitions : [],
       session: Object.freeze({
         agentId: input.agentId,
         sessionId: input.sessionId,
@@ -150,7 +150,7 @@ class ChatServiceBackendRuntime implements ChatServiceBackend {
     return new ChatServiceBackendSession({
       input,
       chatService,
-      capabilities: this.capabilities,
+      backendCapabilities: this.backendCapabilities,
       toolRegistry,
       maxToolRounds: this.maxToolRounds,
     });
@@ -160,7 +160,7 @@ class ChatServiceBackendRuntime implements ChatServiceBackend {
 interface ChatServiceBackendSessionOptions {
   readonly input: AgentBackendSessionInput;
   readonly chatService: ChatService;
-  readonly capabilities: Readonly<ChatServiceBackendCapabilities>;
+  readonly backendCapabilities: Readonly<ChatServiceBackendCapabilities>;
   readonly toolRegistry: ProviderToolRegistry;
   readonly maxToolRounds: number;
 }
@@ -170,7 +170,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
 
   private readonly inputTrust: AgentBackendSessionInput['inputTrust'];
   private readonly chatService: ChatService;
-  private readonly capabilities: Readonly<ChatServiceBackendCapabilities>;
+  private readonly backendCapabilities: Readonly<ChatServiceBackendCapabilities>;
   private readonly toolRegistry: ProviderToolRegistry;
   private readonly maxToolRounds: number;
   private history: Message[];
@@ -182,7 +182,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
     this.id = options.input.sessionId;
     this.inputTrust = options.input.inputTrust;
     this.chatService = options.chatService;
-    this.capabilities = options.capabilities;
+    this.backendCapabilities = options.backendCapabilities;
     this.toolRegistry = options.toolRegistry;
     this.maxToolRounds = options.maxToolRounds;
     this.history = buildChatSessionMessages(options.input);
@@ -310,7 +310,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
         return;
       }
 
-      if (!this.capabilities.tools) {
+      if (!this.backendCapabilities.tools) {
         throw new AgentBackendProtocolError(
           'ChatService requested a Tool while Tool support is disabled.'
         );
@@ -358,7 +358,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
     }
     let callbackError: AgentBackendProtocolError | undefined;
     let acceptDeltas = true;
-    const onPartialResponse = this.capabilities.streaming
+    const onPartialResponse = this.backendCapabilities.streaming
       ? (text: string) => {
           if (!acceptDeltas || turn.controller.signal.aborted) return;
           if (typeof text !== 'string') {
@@ -375,7 +375,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
       const completion = await raceWithAbort(
         this.chatService.chatOnce(
           messages,
-          this.capabilities.streaming,
+          this.backendCapabilities.streaming,
           onPartialResponse
         ),
         turn.controller.signal
@@ -499,30 +499,30 @@ function validateOptions(options: ChatServiceBackendOptions): string[] {
   ) {
     issues.push('provider must be a non-empty string');
   }
-  if (!options.capabilities && !options.provider) {
-    issues.push('capabilities or provider must be supplied');
+  if (!options.backendCapabilities && !options.provider) {
+    issues.push('backendCapabilities or provider must be supplied');
   }
-  if (options.capabilities) {
-    validateCapabilities(options.capabilities, issues);
+  if (options.backendCapabilities) {
+    validateCapabilities(options.backendCapabilities, issues);
     const providerCapabilities = options.provider
       ? getChatBackendProviderCapabilities(options.provider)
       : undefined;
     if (
       providerCapabilities &&
-      options.capabilities.tools &&
+      options.backendCapabilities.tools &&
       !providerCapabilities.tools
     ) {
       issues.push(
-        `capabilities.tools cannot enable Tools for provider "${options.provider}"`
+        `backendCapabilities.tools cannot enable Tools for provider "${options.provider}"`
       );
     }
     if (
       providerCapabilities &&
-      options.capabilities.streaming &&
+      options.backendCapabilities.streaming &&
       !providerCapabilities.streaming
     ) {
       issues.push(
-        `capabilities.streaming cannot enable streaming for provider "${options.provider}"`
+        `backendCapabilities.streaming cannot enable streaming for provider "${options.provider}"`
       );
     }
   }
@@ -536,61 +536,62 @@ function validateOptions(options: ChatServiceBackendOptions): string[] {
 }
 
 function validateCapabilities(
-  capabilities: ChatServiceBackendCapabilities,
+  backendCapabilities: ChatServiceBackendCapabilities,
   issues: string[]
 ): void {
   if (
-    typeof capabilities !== 'object' ||
-    capabilities === null ||
-    Array.isArray(capabilities)
+    typeof backendCapabilities !== 'object' ||
+    backendCapabilities === null ||
+    Array.isArray(backendCapabilities)
   ) {
-    issues.push('capabilities must be an object');
+    issues.push('backendCapabilities must be an object');
     return;
   }
-  for (const key of Object.keys(capabilities)) {
+  for (const key of Object.keys(backendCapabilities)) {
     if (!CAPABILITY_KEYS.has(key)) {
-      issues.push(`capabilities contains unsupported option "${key}"`);
+      issues.push(`backendCapabilities contains unsupported option "${key}"`);
     }
   }
   for (const key of CAPABILITY_KEYS) {
     if (
-      typeof capabilities[key as keyof ChatServiceBackendCapabilities] !==
-      'boolean'
+      typeof backendCapabilities[
+        key as keyof ChatServiceBackendCapabilities
+      ] !== 'boolean'
     ) {
-      issues.push(`capabilities.${key} must be a boolean`);
+      issues.push(`backendCapabilities.${key} must be a boolean`);
     }
   }
-  if (capabilities.text !== true) {
-    issues.push('capabilities.text must be true');
+  if (backendCapabilities.text !== true) {
+    issues.push('backendCapabilities.text must be true');
   }
-  if (capabilities.sessionResume !== false) {
-    issues.push('capabilities.sessionResume must be false');
+  if (backendCapabilities.sessionResume !== false) {
+    issues.push('backendCapabilities.sessionResume must be false');
   }
-  if (capabilities.approvals !== false) {
-    issues.push('capabilities.approvals must be false');
+  if (backendCapabilities.approvals !== false) {
+    issues.push('backendCapabilities.approvals must be false');
   }
 }
 
 function resolveProviderCapabilities(
   provider: string
 ): ChatServiceBackendCapabilities {
-  const capabilities = getChatBackendProviderCapabilities(provider);
-  if (!capabilities) {
+  const providerCapabilities = getChatBackendProviderCapabilities(provider);
+  if (!providerCapabilities) {
     throw new AgentConfigurationError(
       'ChatService backend provider capabilities were not found.',
       [
-        `Provider "${provider}" is not registered; supply explicit capabilities for custom providers`,
+        `Provider "${provider}" is not registered; supply explicit backendCapabilities for custom providers`,
       ]
     );
   }
   return {
     text: true,
-    streaming: capabilities.streaming,
-    tools: capabilities.tools,
+    streaming: providerCapabilities.streaming,
+    tools: providerCapabilities.tools,
     interruption: false,
     sessionResume: false,
     approvals: false,
-    detailedEvents: capabilities.tools,
+    detailedEvents: providerCapabilities.tools,
   };
 }
 

--- a/packages/agent/src/backends/chat/ChatServiceBackend.ts
+++ b/packages/agent/src/backends/chat/ChatServiceBackend.ts
@@ -476,6 +476,7 @@ class ChatServiceBackendSession implements AgentBackendSession {
   }
 }
 
+/** Creates a backend that owns one ChatService instance and history per Session. */
 export function createChatServiceBackend(
   options: ChatServiceBackendOptions
 ): ChatServiceBackend {

--- a/packages/agent/src/backends/chat/types.ts
+++ b/packages/agent/src/backends/chat/types.ts
@@ -5,6 +5,7 @@ import type {
   AgentBackendSessionDescriptor,
 } from '../../types.js';
 
+/** ChatService-specific backend flags; resume and backend approvals are unsupported. */
 export interface ChatServiceBackendCapabilities
   extends AgentBackendCapabilities {
   readonly text: true;
@@ -12,6 +13,7 @@ export interface ChatServiceBackendCapabilities
   readonly approvals: false;
 }
 
+/** Visible Tool definitions and immutable Session identity passed to the service factory. */
 export interface ChatServiceFactoryInput {
   /** Provider-safe definitions visible to this Session only. */
   readonly tools: ToolDefinition[];
@@ -26,6 +28,10 @@ interface ChatServiceBackendBaseOptions {
   readonly maxToolRounds?: number;
 }
 
+/**
+ * ChatService factory, optional provider identity, backend feature flags, and
+ * Tool-loop bound. Custom providers must declare `backendCapabilities`.
+ */
 export type ChatServiceBackendOptions = ChatServiceBackendBaseOptions &
   (
     | {
@@ -39,6 +45,7 @@ export type ChatServiceBackendOptions = ChatServiceBackendBaseOptions &
       }
   );
 
+/** Agent backend backed by `@aituber-onair/chat` with Session-scoped history. */
 export interface ChatServiceBackend extends AgentBackend {
   readonly kind: 'chat';
   readonly backendCapabilities: Readonly<ChatServiceBackendCapabilities>;

--- a/packages/agent/src/backends/chat/types.ts
+++ b/packages/agent/src/backends/chat/types.ts
@@ -31,15 +31,15 @@ export type ChatServiceBackendOptions = ChatServiceBackendBaseOptions &
     | {
         /** Used to verify the factory result and resolve fallback capabilities. */
         readonly provider: string;
-        readonly capabilities?: ChatServiceBackendCapabilities;
+        readonly backendCapabilities?: ChatServiceBackendCapabilities;
       }
     | {
         readonly provider?: string;
-        readonly capabilities: ChatServiceBackendCapabilities;
+        readonly backendCapabilities: ChatServiceBackendCapabilities;
       }
   );
 
 export interface ChatServiceBackend extends AgentBackend {
   readonly kind: 'chat';
-  readonly capabilities: Readonly<ChatServiceBackendCapabilities>;
+  readonly backendCapabilities: Readonly<ChatServiceBackendCapabilities>;
 }

--- a/packages/agent/src/backends/codex/CodexAppServerBackend.ts
+++ b/packages/agent/src/backends/codex/CodexAppServerBackend.ts
@@ -99,12 +99,14 @@ interface PendingCodexApproval {
   readonly resolve: (result: unknown) => void;
 }
 
+/** Creates a Codex app-server backend using the default process dependencies. */
 export function createCodexAppServerBackend(
   options: CodexAppServerBackendOptions
 ): CodexAppServerBackend {
   return createCodexAppServerBackendRuntime(options);
 }
 
+/** Internal dependency-injection variant used to test process integration. */
 export function createCodexAppServerBackendRuntime(
   options: CodexAppServerBackendOptions,
   dependencies: CodexAppServerClientDependencies = {}

--- a/packages/agent/src/backends/codex/CodexAppServerBackend.ts
+++ b/packages/agent/src/backends/codex/CodexAppServerBackend.ts
@@ -115,7 +115,7 @@ export function createCodexAppServerBackendRuntime(
 class CodexAppServerBackendRuntime implements CodexAppServerBackend {
   readonly kind = 'codex-app-server' as const;
   readonly name = 'codex-app-server';
-  readonly capabilities = CODEX_BACKEND_CAPABILITIES;
+  readonly backendCapabilities = CODEX_BACKEND_CAPABILITIES;
 
   private readonly options: CodexAppServerBackendOptions;
   private readonly dependencies: CodexAppServerClientDependencies;

--- a/packages/agent/src/backends/codex/client.ts
+++ b/packages/agent/src/backends/codex/client.ts
@@ -27,7 +27,9 @@ import {
   CodexAppServerTransport,
 } from './transport.js';
 
+/** Filesystem authority applied by Codex while executing a Thread. */
 export type CodexAppServerSandboxMode = 'read-only' | 'workspace-write';
+/** Codex-side policy controlling when command and file operations request approval. */
 export type CodexAppServerApprovalPolicy = 'untrusted' | 'on-request' | 'never';
 
 export interface CodexAppServerClientCompatibility {

--- a/packages/agent/src/backends/codex/protocol.ts
+++ b/packages/agent/src/backends/codex/protocol.ts
@@ -52,6 +52,7 @@ export interface CodexAppServerInitializeResponse {
   readonly platformOs: string;
 }
 
+/** Authentication mode and non-secret account metadata reported by Codex. */
 export type CodexAppServerAccount =
   | { readonly type: 'apiKey' }
   | {
@@ -64,11 +65,13 @@ export type CodexAppServerAccount =
       readonly usesCodexManagedCredentials: boolean;
     };
 
+/** Account discovery result, including whether Codex still requires sign-in. */
 export interface CodexAppServerAccountReadResult {
   readonly account: CodexAppServerAccount | null;
   readonly requiresOpenaiAuth: boolean;
 }
 
+/** Model metadata returned by the stable Codex model-list protocol. */
 export interface CodexAppServerModel {
   readonly id: string;
   readonly model: string;
@@ -82,6 +85,7 @@ export interface CodexAppServerModel {
   readonly [key: string]: unknown;
 }
 
+/** One cursor-paginated page of Codex models. */
 export interface CodexAppServerModelListResult {
   readonly data: readonly CodexAppServerModel[];
   readonly nextCursor: string | null;

--- a/packages/agent/src/backends/codex/transport.ts
+++ b/packages/agent/src/backends/codex/transport.ts
@@ -18,6 +18,7 @@ const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
 const MAX_DIAGNOSTIC_LENGTH = 8_192;
+const MAX_TIMED_OUT_REQUEST_IDS = 256;
 
 interface PendingRequest {
   readonly method: string;
@@ -64,6 +65,7 @@ export class CodexAppServerTransport {
   private readonly onDiagnostic?: (message: string) => void;
   private readonly onError?: (error: Error) => void;
   private readonly pendingRequests = new Map<number, PendingRequest>();
+  private readonly timedOutRequestIds = new Set<number>();
   private stdoutParts: Buffer[] = [];
   private stdoutBytes = 0;
   private stderrBuffer = '';
@@ -132,6 +134,7 @@ export class CodexAppServerTransport {
         const pending = this.pendingRequests.get(id);
         if (!pending) return;
         this.pendingRequests.delete(id);
+        this.recordTimedOutRequestId(id);
         pending.reject(
           new AgentTimeoutError(
             `Codex app-server request "${method}" timed out.`
@@ -370,6 +373,7 @@ export class CodexAppServerTransport {
     }
     const pending = this.pendingRequests.get(response.id);
     if (!pending) {
+      if (this.timedOutRequestIds.delete(response.id)) return;
       this.fail(
         new AgentBackendProtocolError(
           `Codex app-server returned unknown or duplicate response ID ${response.id}.`
@@ -518,6 +522,13 @@ export class CodexAppServerTransport {
       pending.reject(error);
     }
     this.pendingRequests.clear();
+  }
+
+  private recordTimedOutRequestId(id: number): void {
+    this.timedOutRequestIds.add(id);
+    if (this.timedOutRequestIds.size <= MAX_TIMED_OUT_REQUEST_IDS) return;
+    const oldestId = this.timedOutRequestIds.values().next().value;
+    if (oldestId !== undefined) this.timedOutRequestIds.delete(oldestId);
   }
 
   private createExitError(): AgentBackendProcessError {

--- a/packages/agent/src/backends/codex/types.ts
+++ b/packages/agent/src/backends/codex/types.ts
@@ -14,6 +14,7 @@ import type {
   CodexAppServerSandboxMode,
 } from './client.js';
 
+/** Fixed feature flags implemented by the Codex app-server backend. */
 export interface CodexAppServerBackendCapabilities
   extends AgentBackendCapabilities {
   readonly text: true;
@@ -25,6 +26,7 @@ export interface CodexAppServerBackendCapabilities
   readonly detailedEvents: true;
 }
 
+/** Minimum-version policy and optional custom acceptance rule for the Codex CLI. */
 export interface CodexAppServerCompatibility {
   /** Defaults to CODEX_APP_SERVER_MINIMUM_VERSION. */
   readonly minimumVersion?: string;
@@ -34,6 +36,7 @@ export interface CodexAppServerCompatibility {
   readonly accept?: (actual: string, verified: string) => boolean;
 }
 
+/** Working directory, protocol timeouts, Thread policy, model, and diagnostics. */
 export interface CodexAppServerCommonOptions {
   readonly workingDirectory: string;
   readonly compatibility?: CodexAppServerCompatibility;
@@ -48,6 +51,7 @@ export interface CodexAppServerCommonOptions {
   readonly onDiagnostic?: (message: string) => void;
 }
 
+/** Requires either an explicit executable path or deliberate PATH lookup opt-in. */
 export type CodexAppServerExecutableOptions =
   | {
       readonly codexPath: string;
@@ -58,20 +62,24 @@ export type CodexAppServerExecutableOptions =
       readonly allowPathLookup: true;
     };
 
+/** Complete configuration accepted by `createCodexAppServerBackend`. */
 export type CodexAppServerBackendOptions = CodexAppServerCommonOptions &
   CodexAppServerExecutableOptions;
 
+/** Pagination and visibility filters for Codex model discovery. */
 export interface CodexAppServerModelListOptions {
   readonly cursor?: string | null;
   readonly limit?: number | null;
   readonly includeHidden?: boolean | null;
 }
 
+/** Resumable Codex Thread Session with backend-specific Turn steering. */
 export interface CodexAppServerBackendSession extends AgentBackendSession {
   readonly id: string;
   steer(input: AgentRunInput): Promise<void>;
 }
 
+/** Node.js backend that manages Codex Threads, account reads, and model discovery. */
 export interface CodexAppServerBackend extends AgentBackend {
   readonly kind: 'codex-app-server';
   readonly backendCapabilities: Readonly<CodexAppServerBackendCapabilities>;

--- a/packages/agent/src/backends/codex/types.ts
+++ b/packages/agent/src/backends/codex/types.ts
@@ -74,7 +74,7 @@ export interface CodexAppServerBackendSession extends AgentBackendSession {
 
 export interface CodexAppServerBackend extends AgentBackend {
   readonly kind: 'codex-app-server';
-  readonly capabilities: Readonly<CodexAppServerBackendCapabilities>;
+  readonly backendCapabilities: Readonly<CodexAppServerBackendCapabilities>;
   startSession(
     input: AgentBackendSessionInput
   ): Promise<CodexAppServerBackendSession>;

--- a/packages/agent/src/bootstrap/bootstrapAgent.ts
+++ b/packages/agent/src/bootstrap/bootstrapAgent.ts
@@ -17,6 +17,7 @@ import type {
   AgentWorkspaceMetadata,
   JsonValue,
 } from '../types.js';
+import { createAgentEventError } from '../internal/eventError.js';
 
 const DEFAULT_BOOTSTRAP_VERSION = '1';
 
@@ -497,6 +498,27 @@ function validateWorkspaceMetadata(
   ) {
     issues.push('workspace metadata lastError is invalid');
   }
+  if (
+    value.lastError !== undefined &&
+    typeof value.lastError === 'object' &&
+    value.lastError !== null &&
+    value.lastError.details !== undefined
+  ) {
+    try {
+      const details = snapshotJsonValue(value.lastError.details);
+      if (
+        details === null ||
+        typeof details !== 'object' ||
+        Array.isArray(details)
+      ) {
+        throw new Error('must be a JSON object');
+      }
+    } catch {
+      issues.push(
+        'workspace metadata lastError.details must contain only JSON object values'
+      );
+    }
+  }
   if (issues.length > 0) {
     throw new AgentWorkspaceStateError(
       'The host returned invalid Agent workspace metadata.',
@@ -514,7 +536,9 @@ function createWorkspaceMetadata(
       ? Object.freeze({
           ...value.lastError,
           details: value.lastError.details
-            ? Object.freeze({ ...value.lastError.details })
+            ? (snapshotJsonValue(value.lastError.details) as Readonly<
+                Record<string, JsonValue>
+              >)
             : undefined,
         })
       : undefined,
@@ -574,12 +598,7 @@ function isIsoTimestamp(value: unknown): value is string {
 
 function toEventError(error: unknown): AgentEventError {
   if (error instanceof AgentError) {
-    return Object.freeze({
-      name: error.name,
-      code: error.code,
-      message: error.message,
-      details: error.details,
-    });
+    return Object.freeze(createAgentEventError(error));
   }
   return Object.freeze({
     name: error instanceof Error ? error.name : 'Error',

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -1,2 +1,4 @@
+/** Creates an Agent backend backed by one isolated ChatService per Session. */
 export { createChatServiceBackend } from './backends/chat/ChatServiceBackend.js';
+/** Public configuration and feature contracts for the ChatService backend. */
 export type * from './backends/chat/types.js';

--- a/packages/agent/src/codex-app-server.ts
+++ b/packages/agent/src/codex-app-server.ts
@@ -1,17 +1,22 @@
+/** Creates the Node.js Codex app-server backend over local JSONL stdio. */
 export { createCodexAppServerBackend } from './backends/codex/CodexAppServerBackend.js';
+/** Supported, minimum, and verified Codex app-server protocol versions. */
 export {
   CODEX_APP_SERVER_MINIMUM_VERSION,
   CODEX_APP_SERVER_PROTOCOL_GENERATION,
   CODEX_APP_SERVER_VERIFIED_VERSION,
 } from './backends/codex/protocol.js';
+/** Read-only Codex account and model discovery response contracts. */
 export type {
   CodexAppServerAccount,
   CodexAppServerAccountReadResult,
   CodexAppServerModel,
   CodexAppServerModelListResult,
 } from './backends/codex/protocol.js';
+/** Sandboxing and approval policy values forwarded to Codex Threads. */
 export type {
   CodexAppServerApprovalPolicy,
   CodexAppServerSandboxMode,
 } from './backends/codex/client.js';
+/** Public configuration, feature, Session, and backend contracts for Codex app-server. */
 export type * from './backends/codex/types.js';

--- a/packages/agent/src/core/AgentRuntime.ts
+++ b/packages/agent/src/core/AgentRuntime.ts
@@ -92,6 +92,7 @@ interface ResolvedSessionRequest {
   readonly limits: Required<AgentRuntimeLimits>;
 }
 
+/** Creates a managed Agent from a validated host definition and backend. */
 export function createAgent(options: AgentOptions): Agent {
   return new AgentRuntime(options);
 }

--- a/packages/agent/src/core/AgentRuntime.ts
+++ b/packages/agent/src/core/AgentRuntime.ts
@@ -99,7 +99,7 @@ export function createAgent(options: AgentOptions): Agent {
 class AgentRuntime implements Agent {
   readonly id: string;
   readonly brief: string;
-  readonly capabilities: Agent['capabilities'];
+  readonly backendCapabilities: Agent['backendCapabilities'];
 
   private readonly backend: AgentOptions['backend'];
   private readonly toolsById: ReadonlyMap<string, AgentToolSpec>;
@@ -127,15 +127,15 @@ class AgentRuntime implements Agent {
         'backend.startSession must be a function',
       ]);
     }
-    if (!options.backend.capabilities?.text) {
+    if (!options.backend.backendCapabilities?.text) {
       throw new AgentCapabilityError('text', options.backend.name);
     }
 
     this.id = options.id;
     this.brief = options.brief;
     this.backend = options.backend;
-    this.capabilities = snapshotBackendCapabilities(
-      options.backend.capabilities
+    this.backendCapabilities = snapshotBackendCapabilities(
+      options.backend.backendCapabilities
     );
     if (options.tools !== undefined && !Array.isArray(options.tools)) {
       throw new AgentConfigurationError('Agent Tool registration failed.', [
@@ -165,7 +165,7 @@ class AgentRuntime implements Agent {
     const operation = runAgentBootstrap(
       {
         agentId: this.id,
-        canResumeSession: this.capabilities.sessionResume,
+        canResumeSession: this.backendCapabilities.sessionResume,
         maxToolCallsPerTurn: this.limits.maxToolCallsPerTurn,
         validateSession: (sessionOptions) => {
           this.resolveSessionRequest(sessionOptions);
@@ -186,7 +186,7 @@ class AgentRuntime implements Agent {
   }
 
   resumeSession(options: AgentResumeSessionOptions): Promise<AgentSession> {
-    if (!this.capabilities.sessionResume) {
+    if (!this.backendCapabilities.sessionResume) {
       return Promise.reject(
         new AgentCapabilityError('sessionResume', this.backend.name)
       );
@@ -287,7 +287,7 @@ class AgentRuntime implements Agent {
         issues
       );
     }
-    if (visibleTools.length > 0 && !this.capabilities.tools) {
+    if (visibleTools.length > 0 && !this.backendCapabilities.tools) {
       throw new AgentCapabilityError('tools', this.backend.name);
     }
     return {
@@ -396,7 +396,7 @@ class AgentRuntime implements Agent {
         hooks: this.hooks,
         limits: sessionLimits,
         backendName: this.backend.name,
-        backendCapabilities: this.capabilities,
+        backendCapabilities: this.backendCapabilities,
         backendSession,
         lifecycle: backendSessionId
           ? { type: 'resumed', backendSessionId }

--- a/packages/agent/src/core/AgentSession.ts
+++ b/packages/agent/src/core/AgentSession.ts
@@ -21,6 +21,7 @@ import {
   sanitizeToolArguments,
   snapshotToolArguments,
 } from '../tools/sanitize.js';
+import { createAgentEventError } from '../internal/eventError.js';
 import { validateToolInput } from '../tools/schemaValidation.js';
 import type {
   AgentApprovalDecision,
@@ -1134,12 +1135,7 @@ export class AgentSessionRuntime implements AgentSession {
 }
 
 function toEventError(error: AgentError): AgentEventError {
-  return {
-    name: error.name,
-    code: error.code,
-    message: error.message,
-    details: error.details,
-  };
+  return createAgentEventError(error);
 }
 
 function describeError(error: unknown): string {

--- a/packages/agent/src/core/AgentSession.ts
+++ b/packages/agent/src/core/AgentSession.ts
@@ -33,6 +33,8 @@ import type {
   AgentEvent,
   AgentEventError,
   AgentHook,
+  AgentHookPhase,
+  AgentHookValueMap,
   AgentInputTrust,
   AgentPolicy,
   AgentRunInput,
@@ -432,11 +434,7 @@ export class AgentSessionRuntime implements AgentSession {
               usage: event.usage,
               backendMetadata: event.metadata,
             };
-            runResult = (await this.runHookPhase(
-              turn,
-              'output',
-              candidate
-            )) as AgentRunResult;
+            runResult = await this.runHookPhase(turn, 'output', candidate);
             assertRunResult(runResult, {
               agentId: this.agentId,
               sessionId: this.id,
@@ -990,11 +988,11 @@ export class AgentSessionRuntime implements AgentSession {
     pending.signal.removeEventListener('abort', pending.onAbort);
   }
 
-  private runHookPhase(
+  private runHookPhase<TPhase extends AgentHookPhase>(
     turn: ActiveTurn,
-    phase: Parameters<typeof runHooks>[1],
-    value: unknown
-  ): Promise<unknown> {
+    phase: TPhase,
+    value: AgentHookValueMap[TPhase]['input']
+  ): Promise<AgentHookValueMap[TPhase]['output']> {
     if (turn.controller.signal.aborted) {
       return Promise.reject(turn.controller.signal.reason);
     }

--- a/packages/agent/src/core/AgentSession.ts
+++ b/packages/agent/src/core/AgentSession.ts
@@ -61,6 +61,10 @@ interface ActiveTurn {
   readonly id: string;
   readonly queue: AsyncEventQueue<AgentEvent>;
   readonly controller: AbortController;
+  readonly invocation: 'run' | 'runStream';
+  readonly onApprovalRequest?: NonNullable<
+    AgentRunOptions['onApprovalRequest']
+  >;
   completion: Promise<void>;
   externalSignal?: AbortSignal;
   externalAbortListener?: () => void;
@@ -152,7 +156,7 @@ export class AgentSessionRuntime implements AgentSession {
     options?: AgentRunOptions
   ): Promise<AgentRunResult> {
     let result: AgentRunResult | undefined;
-    for await (const event of this.runStream(input, options)) {
+    for await (const event of this.startTurnStream(input, options, 'run')) {
       if (event.type === 'turn.completed') result = event.result;
     }
     if (!result) {
@@ -166,6 +170,14 @@ export class AgentSessionRuntime implements AgentSession {
   runStream(
     input: AgentRunInput,
     options?: AgentRunOptions
+  ): AsyncIterable<AgentEvent> {
+    return this.startTurnStream(input, options, 'runStream');
+  }
+
+  private startTurnStream(
+    input: AgentRunInput,
+    options: AgentRunOptions | undefined,
+    invocation: ActiveTurn['invocation']
   ): AsyncIterable<AgentEvent> {
     this.assertCanRun(input, options);
 
@@ -186,6 +198,8 @@ export class AgentSessionRuntime implements AgentSession {
       id: turnId,
       queue,
       controller,
+      invocation,
+      onApprovalRequest: options?.onApprovalRequest,
       completion: Promise.resolve(),
       toolCallCount: 0,
       toolCallIds: new Set(),
@@ -300,6 +314,12 @@ export class AgentSessionRuntime implements AgentSession {
     ) {
       issues.push('options.timeoutMs must be a positive finite number');
     }
+    if (
+      options?.onApprovalRequest !== undefined &&
+      typeof options.onApprovalRequest !== 'function'
+    ) {
+      issues.push('options.onApprovalRequest must be a function');
+    }
     if (issues.length > 0) {
       throw new AgentConfigurationError('Agent Run input is invalid.', issues);
     }
@@ -330,8 +350,10 @@ export class AgentSessionRuntime implements AgentSession {
 
       const preparedInput = await this.prepareRunInput(turn, input);
       const backendStream = this.backendSession.runStream(preparedInput, {
-        ...options,
         signal: turn.controller.signal,
+        ...(options?.timeoutMs !== undefined
+          ? { timeoutMs: options.timeoutMs }
+          : {}),
       });
       iterator = backendStream[Symbol.asyncIterator]();
 
@@ -856,7 +878,13 @@ export class AgentSessionRuntime implements AgentSession {
         rejectOnDeny,
       };
       pending.timeoutId = setTimeout(() => {
-        this.settleApproval(pending, 'deny', new AgentApprovalTimeoutError());
+        const error =
+          turn.invocation === 'run' && !turn.onApprovalRequest
+            ? new AgentApprovalTimeoutError(
+                'The approval request timed out. session.run() requires options.onApprovalRequest to answer approvals; otherwise use session.runStream() and call session.resolveApproval().'
+              )
+            : new AgentApprovalTimeoutError();
+        this.settleApproval(pending, 'deny', error);
       }, this.limits.approvalTimeoutMs);
       this.pendingApprovals.set(request.id, pending);
       turn.controller.signal.addEventListener('abort', onAbort, { once: true });
@@ -866,14 +894,55 @@ export class AgentSessionRuntime implements AgentSession {
         turnId: turn.id,
         request,
       });
+      if (turn.onApprovalRequest) {
+        void this.resolveApprovalFromHandler(
+          turn,
+          pending,
+          turn.onApprovalRequest
+        );
+      }
       if (turn.controller.signal.aborted) onAbort();
     });
+  }
+
+  private async resolveApprovalFromHandler(
+    turn: ActiveTurn,
+    pending: PendingApproval,
+    handler: NonNullable<AgentRunOptions['onApprovalRequest']>
+  ): Promise<void> {
+    let decision: AgentApprovalDecision = 'deny';
+    let handlerError: AgentConfigurationError | undefined;
+    try {
+      const candidate = await handler(pending.request, {
+        sessionId: this.id,
+        turnId: turn.id,
+        signal: turn.controller.signal,
+      });
+      if (candidate === 'allow-once' || candidate === 'deny') {
+        decision = candidate;
+      } else {
+        handlerError = new AgentConfigurationError(
+          'The approval request handler returned an invalid decision; the request was denied.',
+          ['onApprovalRequest must return "allow-once" or "deny"']
+        );
+      }
+    } catch (cause) {
+      handlerError = new AgentConfigurationError(
+        'The approval request handler failed; the request was denied.',
+        [`onApprovalRequest failed: ${describeError(cause)}`],
+        { cause }
+      );
+    }
+
+    if (!this.pendingApprovals.has(pending.request.id)) return;
+    this.settleApproval(pending, decision, undefined, handlerError);
   }
 
   private settleApproval(
     pending: PendingApproval,
     decision: AgentApprovalDecision,
-    error?: AgentError
+    error?: AgentError,
+    recordedError?: AgentError
   ): void {
     if (!this.pendingApprovals.has(pending.request.id)) return;
     this.removePendingApproval(pending);
@@ -883,6 +952,7 @@ export class AgentSessionRuntime implements AgentSession {
       turnId: pending.request.turnId,
       requestId: pending.request.id,
       decision,
+      ...(recordedError ? { error: toEventError(recordedError) } : {}),
     });
     if (error) pending.reject(error);
     else if (decision === 'deny' && pending.rejectOnDeny)
@@ -1072,6 +1142,10 @@ function toEventError(error: AgentError): AgentEventError {
     message: error.message,
     details: error.details,
   };
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function nextWithAbort<T>(

--- a/packages/agent/src/core/runHooks.ts
+++ b/packages/agent/src/core/runHooks.ts
@@ -1,29 +1,42 @@
 import { AgentHookError } from '../errors.js';
-import type { AgentHook, AgentHookPhase } from '../types.js';
+import type {
+  AgentHook,
+  AgentHookContext,
+  AgentHookPhase,
+  AgentHookValueMap,
+} from '../types.js';
 
-export async function runHooks(
+interface RuntimeAgentHook {
+  readonly id: string;
+  readonly phase: AgentHookPhase;
+  readonly onError: 'fail-turn' | 'skip';
+  run(context: AgentHookContext<unknown>): Promise<unknown> | unknown;
+}
+
+export async function runHooks<TPhase extends AgentHookPhase>(
   hooks: readonly AgentHook[],
-  phase: AgentHookPhase,
-  value: unknown,
+  phase: TPhase,
+  value: AgentHookValueMap[TPhase]['input'],
   context: {
     readonly agentId: string;
     readonly sessionId: string;
     readonly turnId: string;
     readonly signal: AbortSignal;
   }
-): Promise<unknown> {
-  let current = value;
+): Promise<AgentHookValueMap[TPhase]['output']> {
+  let current: unknown = value;
   for (const hook of hooks) {
     if (hook.phase !== phase) continue;
+    const runtimeHook = hook as RuntimeAgentHook;
     try {
-      current = await hook.run({ ...context, value: current });
+      current = await runtimeHook.run({ ...context, value: current });
     } catch (error) {
-      if (hook.onError === 'skip') continue;
+      if (runtimeHook.onError === 'skip') continue;
       throw new AgentHookError(
-        `Agent hook "${hook.id}" failed during "${phase}".`,
-        { cause: error, details: { hookId: hook.id, phase } }
+        `Agent hook "${runtimeHook.id}" failed during "${phase}".`,
+        { cause: error, details: { hookId: runtimeHook.id, phase } }
       );
     }
   }
-  return current;
+  return current as AgentHookValueMap[TPhase]['output'];
 }

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -1,11 +1,13 @@
 import type { AgentWorkspaceMetadata } from './types.js';
 
+/** Optional stable code, causal value, and diagnostic details for `AgentError`. */
 export interface AgentErrorOptions {
   readonly code?: string;
   readonly cause?: unknown;
   readonly details?: Readonly<Record<string, unknown>>;
 }
 
+/** Base class for typed runtime failures with stable codes and optional causes. */
 export class AgentError extends Error {
   readonly code: string;
   readonly cause?: unknown;
@@ -20,6 +22,7 @@ export class AgentError extends Error {
   }
 }
 
+/** Reports invalid host configuration or public API input with actionable issues. */
 export class AgentConfigurationError extends AgentError {
   readonly issues: readonly string[];
 
@@ -37,18 +40,21 @@ export class AgentConfigurationError extends AgentError {
   }
 }
 
+/** Raised when an operation targets a Session that has already closed. */
 export class AgentSessionClosedError extends AgentError {
   constructor(message = 'The Agent Session is closed.') {
     super(message, { code: 'AGENT_SESSION_CLOSED' });
   }
 }
 
+/** Raised when a second Turn is started before the current Turn finishes. */
 export class AgentTurnInProgressError extends AgentError {
   constructor(message = 'The Agent Session already has an active Turn.') {
     super(message, { code: 'AGENT_TURN_IN_PROGRESS' });
   }
 }
 
+/** Reports that the selected backend did not declare a required feature. */
 export class AgentCapabilityError extends AgentError {
   readonly capability: string;
 
@@ -66,24 +72,28 @@ export class AgentCapabilityError extends AgentError {
   }
 }
 
+/** Raised when host policy denies a Tool call or returns an invalid decision. */
 export class AgentPolicyDeniedError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_POLICY_DENIED' });
   }
 }
 
+/** Raised when a required host approval is explicitly denied. */
 export class AgentApprovalDeniedError extends AgentError {
   constructor(message = 'The requested operation was denied.') {
     super(message, { code: 'AGENT_APPROVAL_DENIED' });
   }
 }
 
+/** Raised when an approval request exceeds the configured response deadline. */
 export class AgentApprovalTimeoutError extends AgentError {
   constructor(message = 'The approval request timed out.') {
     super(message, { code: 'AGENT_APPROVAL_TIMEOUT' });
   }
 }
 
+/** Reports a backend Tool name or runtime Tool ID that is not registered. */
 export class AgentToolNotFoundError extends AgentError {
   readonly toolId: string;
 
@@ -96,24 +106,28 @@ export class AgentToolNotFoundError extends AgentError {
   }
 }
 
+/** Reports Tool arguments that fail the supported JSON Schema contract. */
 export class AgentToolValidationError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_TOOL_VALIDATION' });
   }
 }
 
+/** Wraps a host Tool handler failure or its Tool-specific timeout. */
 export class AgentToolExecutionError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_TOOL_EXECUTION' });
   }
 }
 
+/** Raised when one Turn exceeds its maximum number of accepted Tool calls. */
 export class AgentToolLoopLimitError extends AgentError {
   constructor(message = 'The Agent Tool loop limit was reached.') {
     super(message, { code: 'AGENT_TOOL_LOOP_LIMIT' });
   }
 }
 
+/** Raised when bootstrap is requested while another bootstrap operation is active. */
 export class AgentBootstrapInProgressError extends AgentError {
   constructor(
     message = 'The Agent already has an active bootstrap operation.'
@@ -122,6 +136,7 @@ export class AgentBootstrapInProgressError extends AgentError {
   }
 }
 
+/** Reports exhausted bootstrap attempts and carries the latest workspace metadata. */
 export class AgentBootstrapLimitError extends AgentError {
   readonly metadata: AgentWorkspaceMetadata;
 
@@ -138,6 +153,7 @@ export class AgentBootstrapLimitError extends AgentError {
   }
 }
 
+/** Wraps a failed bootstrap Turn and carries the metadata saved for recovery. */
 export class AgentBootstrapError extends AgentError {
   readonly metadata: AgentWorkspaceMetadata;
 
@@ -160,12 +176,14 @@ export class AgentBootstrapError extends AgentError {
   }
 }
 
+/** Reports invalid, conflicting, or stale host-owned workspace metadata. */
 export class AgentWorkspaceStateError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_WORKSPACE_STATE' });
   }
 }
 
+/** Identifies a JSON Schema keyword unsupported by Agent Tool validation. */
 export class AgentSchemaKeywordUnsupportedError extends AgentError {
   readonly keyword: string;
 
@@ -178,42 +196,49 @@ export class AgentSchemaKeywordUnsupportedError extends AgentError {
   }
 }
 
+/** Wraps a hook failure when that hook is configured to fail the Turn. */
 export class AgentHookError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_HOOK_ERROR' });
   }
 }
 
+/** Wraps an operational failure reported by or while invoking a backend. */
 export class AgentBackendError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_BACKEND_ERROR' });
   }
 }
 
+/** Reports malformed or out-of-order messages in a backend protocol. */
 export class AgentBackendProtocolError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_BACKEND_PROTOCOL' });
   }
 }
 
+/** Reports backend child-process startup, I/O, or unexpected exit failures. */
 export class AgentBackendProcessError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_BACKEND_PROCESS' });
   }
 }
 
+/** Reports an installed backend version outside the accepted compatibility range. */
 export class AgentBackendCompatibilityError extends AgentError {
   constructor(message: string, options: AgentErrorOptions = {}) {
     super(message, { ...options, code: 'AGENT_BACKEND_COMPATIBILITY' });
   }
 }
 
+/** Terminal Turn error used for caller, host, or backend interruption. */
 export class AgentInterruptedError extends AgentError {
   constructor(message = 'The Agent Turn was interrupted.') {
     super(message, { code: 'AGENT_INTERRUPTED' });
   }
 }
 
+/** Terminal Turn or backend request error used when an elapsed-time limit expires. */
 export class AgentTimeoutError extends AgentError {
   constructor(message = 'The Agent Turn timed out.') {
     super(message, { code: 'AGENT_TIMEOUT' });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,8 @@
+/** Creates a managed Agent from a host-owned definition and backend. */
 export { createAgent } from './core/AgentRuntime.js';
+/** Preserves generic Tool input/output inference while registering a structural Tool spec. */
 export { defineAgentTool } from './tools/defineAgentTool.js';
+/** Typed errors shared by the base runtime and optional backends. */
 export * from './errors.js';
+/** Public Agent, Session, Tool, policy, hook, event, and backend contracts. */
 export type * from './types.js';

--- a/packages/agent/src/internal/contracts.ts
+++ b/packages/agent/src/internal/contracts.ts
@@ -48,6 +48,6 @@ export function assertAgentDefinition(value: unknown): asserts value is {
  */
 export function snapshotBackendCapabilities<
   TCapabilities extends AgentBackendCapabilities,
->(capabilities: TCapabilities): Readonly<TCapabilities> {
-  return Object.freeze({ ...capabilities });
+>(backendCapabilities: TCapabilities): Readonly<TCapabilities> {
+  return Object.freeze({ ...backendCapabilities });
 }

--- a/packages/agent/src/internal/eventError.ts
+++ b/packages/agent/src/internal/eventError.ts
@@ -1,0 +1,95 @@
+import type { AgentError } from '../errors.js';
+import type { AgentEventError, JsonValue } from '../types.js';
+
+const OMIT_JSON_VALUE = Symbol('omit-json-value');
+
+export function createAgentEventError(error: AgentError): AgentEventError {
+  const details = sanitizeJsonRecord(error.details);
+  return {
+    name: error.name,
+    code: error.code,
+    message: error.message,
+    ...(details ? { details } : {}),
+  };
+}
+
+export function sanitizeJsonRecord(
+  value: Readonly<Record<string, unknown>> | undefined
+): Readonly<Record<string, JsonValue>> | undefined {
+  if (!value) return undefined;
+  const sanitized = sanitizeJsonValue(value, new Set());
+  if (
+    sanitized === OMIT_JSON_VALUE ||
+    sanitized === null ||
+    typeof sanitized !== 'object' ||
+    Array.isArray(sanitized)
+  ) {
+    return undefined;
+  }
+  const record = sanitized as Readonly<Record<string, JsonValue>>;
+  return Object.keys(record).length > 0 ? record : undefined;
+}
+
+function sanitizeJsonValue(
+  value: unknown,
+  ancestors: Set<object>
+): JsonValue | typeof OMIT_JSON_VALUE {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'bigint') return String(value);
+  if (
+    value === undefined ||
+    typeof value === 'function' ||
+    typeof value === 'symbol'
+  ) {
+    return OMIT_JSON_VALUE;
+  }
+  if (typeof value !== 'object' || ancestors.has(value)) {
+    return OMIT_JSON_VALUE;
+  }
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? value.toISOString() : OMIT_JSON_VALUE;
+  }
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message };
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => {
+        const sanitized = sanitizeJsonValue(item, ancestors);
+        return sanitized === OMIT_JSON_VALUE ? null : sanitized;
+      });
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return OMIT_JSON_VALUE;
+    }
+    const result: Record<string, JsonValue> = {};
+    for (const key of Object.keys(value)) {
+      let item: unknown;
+      try {
+        item = (value as Record<string, unknown>)[key];
+      } catch {
+        continue;
+      }
+      const sanitized = sanitizeJsonValue(item, ancestors);
+      if (sanitized !== OMIT_JSON_VALUE) result[key] = sanitized;
+    }
+    return result;
+  } catch {
+    return OMIT_JSON_VALUE;
+  } finally {
+    ancestors.delete(value);
+  }
+}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -279,7 +279,10 @@ type AgentHookDefinition<TPhase extends AgentHookPhase, TInput, TOutput> = {
 
 /**
  * Phase-discriminated host extension that may transform a pipeline value.
- * Explicit generic arguments preserve compatibility with legacy unknown hooks.
+ * By default, each phase uses its input and output types from
+ * `AgentHookValueMap`. An explicit `AgentHook<unknown>` is assignable after
+ * narrowing to `context`, `before-tool`, or `after-tool`, whose phase values are
+ * unknown. Hooks for other phases must use their phase-specific value types.
  */
 export type AgentHook<TInput = AgentHookInferredValue, TOutput = TInput> = {
   [TPhase in AgentHookPhase]: AgentHookDefinition<

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -188,6 +188,41 @@ export type AgentHookPhase =
   | 'output'
   | 'after-turn';
 
+type AgentAfterTurnHookValue =
+  | {
+      readonly status: 'completed';
+      readonly result: AgentRunResult;
+    }
+  | {
+      readonly status: 'interrupted' | 'failed';
+      readonly error: AgentEventError;
+    };
+
+export interface AgentHookValueMap {
+  readonly input: {
+    readonly input: AgentRunInput['input'];
+    readonly output: AgentRunInput['input'];
+  };
+  readonly context: {
+    readonly input: AgentRunInput['context'];
+    readonly output: AgentRunInput['context'];
+  };
+  readonly 'before-tool': { readonly input: unknown; readonly output: unknown };
+  readonly 'after-tool': { readonly input: unknown; readonly output: unknown };
+  readonly 'draft-response': {
+    readonly input: string;
+    readonly output: string;
+  };
+  readonly output: {
+    readonly input: AgentRunResult;
+    readonly output: AgentRunResult;
+  };
+  readonly 'after-turn': {
+    readonly input: AgentAfterTurnHookValue;
+    readonly output: AgentAfterTurnHookValue;
+  };
+}
+
 export interface AgentHookContext<TValue = unknown> {
   readonly agentId: string;
   readonly sessionId: string;
@@ -196,12 +231,25 @@ export interface AgentHookContext<TValue = unknown> {
   readonly signal: AbortSignal;
 }
 
-export interface AgentHook<TInput = unknown, TOutput = TInput> {
+declare const agentHookInferredValue: unique symbol;
+type AgentHookInferredValue = typeof agentHookInferredValue;
+
+type AgentHookDefinition<TPhase extends AgentHookPhase, TInput, TOutput> = {
   readonly id: string;
-  readonly phase: AgentHookPhase;
+  readonly phase: TPhase;
   readonly onError: 'fail-turn' | 'skip';
   run(context: AgentHookContext<TInput>): Promise<TOutput> | TOutput;
-}
+};
+
+export type AgentHook<TInput = AgentHookInferredValue, TOutput = TInput> = {
+  [TPhase in AgentHookPhase]: AgentHookDefinition<
+    TPhase,
+    [TInput] extends [AgentHookInferredValue]
+      ? AgentHookValueMap[TPhase]['input']
+      : TInput,
+    [TInput] extends [AgentHookInferredValue] ? unknown : TOutput
+  >;
+}[AgentHookPhase];
 
 export interface AgentBackendCapabilities {
   readonly text: boolean;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -287,7 +287,9 @@ export type AgentHook<TInput = AgentHookInferredValue, TOutput = TInput> = {
     [TInput] extends [AgentHookInferredValue]
       ? AgentHookValueMap[TPhase]['input']
       : TInput,
-    [TInput] extends [AgentHookInferredValue] ? unknown : TOutput
+    [TInput] extends [AgentHookInferredValue]
+      ? AgentHookValueMap[TPhase]['output']
+      : TOutput
   >;
 }[AgentHookPhase];
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,12 +1,20 @@
+/** A scalar value accepted by JSON without custom serialization. */
 export type JsonPrimitive = boolean | null | number | string;
 
+/** Recursively JSON-serializable data used by persisted and emitted contracts. */
 export type JsonValue =
   | JsonPrimitive
   | { readonly [key: string]: JsonValue }
   | readonly JsonValue[];
 
+/** Host classification of whether conversational input may contain adversarial data. */
 export type AgentInputTrust = 'trusted' | 'untrusted';
 
+/**
+ * Intended recipients of a Session: `operator` is operations staff, `owner` is
+ * the product owner, `private` is another non-public audience, and `public` is
+ * end-user facing. Only `public` is treated as public-facing.
+ */
 export type AgentAudience = 'operator' | 'owner' | 'private' | 'public';
 
 /**
@@ -19,6 +27,7 @@ export interface AgentConversationInput<TData = unknown> {
   readonly metadata?: Readonly<Record<string, JsonValue>>;
 }
 
+/** Host instruction plus separately labeled conversation data and context for one Turn. */
 export interface AgentRunInput<
   TInput extends AgentConversationInput = AgentConversationInput,
   TContext = unknown,
@@ -31,6 +40,7 @@ export interface AgentRunInput<
   readonly context?: TContext;
 }
 
+/** Cancellation, timeout, and automatic approval handling for one Turn. */
 export interface AgentRunOptions {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
@@ -48,12 +58,14 @@ export interface AgentRunOptions {
   ) => AgentApprovalDecision | Promise<AgentApprovalDecision>;
 }
 
+/** Stable provenance linking an Artifact to the Agent, Session, and Turn that created it. */
 export interface AgentArtifactSource {
   readonly agentId: string;
   readonly sessionId: string;
   readonly turnId: string;
 }
 
+/** Versioned JSON output emitted independently from the Agent's text response. */
 export interface AgentArtifact<TData extends JsonValue = JsonValue> {
   readonly id: string;
   readonly type: string;
@@ -64,12 +76,14 @@ export interface AgentArtifact<TData extends JsonValue = JsonValue> {
   readonly source: AgentArtifactSource;
 }
 
+/** Optional token accounting reported by a backend for one Turn. */
 export interface AgentUsage {
   readonly inputTokens?: number;
   readonly outputTokens?: number;
   readonly totalTokens?: number;
 }
 
+/** Validated terminal output returned by `AgentSession.run()`. */
 export interface AgentRunResult {
   readonly turnId: string;
   readonly message: string;
@@ -78,6 +92,10 @@ export interface AgentRunResult {
   readonly backendMetadata?: Readonly<Record<string, JsonValue>>;
 }
 
+/**
+ * Ordered Tool risk levels: `read < draft < write < external < destructive`.
+ * `AgentApprovalRule.riskAtLeast` compares risks using this order.
+ */
 export type AgentToolRisk =
   | 'read'
   | 'draft'
@@ -104,6 +122,7 @@ export interface AgentBackendTool {
   readonly definition: AgentToolDefinition;
 }
 
+/** Runtime identity and cancellation state supplied to a host Tool handler. */
 export interface AgentToolExecutionContext {
   readonly agentId: string;
   readonly sessionId: string;
@@ -112,6 +131,7 @@ export interface AgentToolExecutionContext {
   readonly signal: AbortSignal;
 }
 
+/** Synchronous or asynchronous host implementation of an Agent Tool. */
 export type AgentToolHandler<TInput = unknown, TOutput = unknown> = {
   bivarianceHack(
     input: TInput,
@@ -119,6 +139,7 @@ export type AgentToolHandler<TInput = unknown, TOutput = unknown> = {
   ): Promise<TOutput> | TOutput;
 }['bivarianceHack'];
 
+/** Complete Tool registration combining model metadata, policy risk, and host execution. */
 export interface AgentToolSpec<TInput = unknown, TOutput = unknown> {
   /** Stable logical ID used by policy and audit events. */
   readonly id: string;
@@ -130,11 +151,13 @@ export interface AgentToolSpec<TInput = unknown, TOutput = unknown> {
   readonly sensitiveFields?: readonly string[];
 }
 
+/** Policy outcome that allows, denies, or pauses a Tool call for host approval. */
 export type AgentPolicyDecision =
   | { readonly decision: 'allow'; readonly reason?: string }
   | { readonly decision: 'deny'; readonly reason: string }
   | { readonly decision: 'require-approval'; readonly reason: string };
 
+/** Sanitized facts available while a policy evaluates one requested Tool call. */
 export interface AgentPolicyContext {
   readonly agentId: string;
   readonly sessionId: string;
@@ -146,17 +169,20 @@ export interface AgentPolicyContext {
   readonly arguments: unknown;
 }
 
+/** Host policy contract evaluated before every runtime-managed Tool execution. */
 export interface AgentPolicy {
   evaluate(
     context: AgentPolicyContext
   ): AgentPolicyDecision | Promise<AgentPolicyDecision>;
 }
 
+/** Declarative matcher for Tools that require approval by risk threshold or ID. */
 export interface AgentApprovalRule {
   readonly riskAtLeast?: AgentToolRisk;
   readonly tools?: readonly string[];
 }
 
+/** Declarative allow, deny, and approval rules used by the default policy. */
 export interface AgentPolicyConfig {
   readonly defaultDecision: 'allow' | 'deny';
   readonly allowTools?: readonly string[];
@@ -164,6 +190,7 @@ export interface AgentPolicyConfig {
   readonly requireApproval?: AgentApprovalRule;
 }
 
+/** Sanitized Tool or backend operation presented to the host for a decision. */
 export interface AgentApprovalRequest {
   readonly id: string;
   readonly agentId: string;
@@ -177,8 +204,15 @@ export interface AgentApprovalRequest {
   readonly reason: string;
 }
 
+/** One-request approval outcome; it never grants permission for later requests. */
 export type AgentApprovalDecision = 'allow-once' | 'deny';
 
+/**
+ * Hook timing and values: `input` and `context` transform Turn inputs;
+ * `before-tool` and `after-tool` wrap Tool arguments and results;
+ * `draft-response` transforms text; `output` transforms the final result; and
+ * `after-turn` observes the terminal outcome. See `AgentHookValueMap`.
+ */
 export type AgentHookPhase =
   | 'input'
   | 'context'
@@ -198,6 +232,7 @@ type AgentAfterTurnHookValue =
       readonly error: AgentEventError;
     };
 
+/** Input and output value types passed through each `AgentHookPhase`. */
 export interface AgentHookValueMap {
   readonly input: {
     readonly input: AgentRunInput['input'];
@@ -223,6 +258,7 @@ export interface AgentHookValueMap {
   };
 }
 
+/** Shared identity, phase value, and cancellation signal supplied to a hook. */
 export interface AgentHookContext<TValue = unknown> {
   readonly agentId: string;
   readonly sessionId: string;
@@ -241,6 +277,10 @@ type AgentHookDefinition<TPhase extends AgentHookPhase, TInput, TOutput> = {
   run(context: AgentHookContext<TInput>): Promise<TOutput> | TOutput;
 };
 
+/**
+ * Phase-discriminated host extension that may transform a pipeline value.
+ * Explicit generic arguments preserve compatibility with legacy unknown hooks.
+ */
 export type AgentHook<TInput = AgentHookInferredValue, TOutput = TInput> = {
   [TPhase in AgentHookPhase]: AgentHookDefinition<
     TPhase,
@@ -251,6 +291,7 @@ export type AgentHook<TInput = AgentHookInferredValue, TOutput = TInput> = {
   >;
 }[AgentHookPhase];
 
+/** Feature flags declared by a backend and enforced by the Agent runtime. */
 export interface AgentBackendCapabilities {
   readonly text: boolean;
   readonly streaming: boolean;
@@ -261,6 +302,7 @@ export interface AgentBackendCapabilities {
   readonly detailedEvents: boolean;
 }
 
+/** Named numeric boundary advertised with a host-granted capability. */
 export interface AgentCapabilityLimit {
   readonly name: string;
   readonly value: number;
@@ -288,19 +330,23 @@ export interface AgentBackendCapability {
   readonly limits?: readonly AgentCapabilityLimit[];
 }
 
+/** JSON Artifact emitted by a backend before runtime provenance is attached. */
 export interface AgentBackendArtifact {
   readonly type: string;
   readonly title?: string;
   readonly data: JsonValue;
 }
 
+/** Backend approval outcome, including cancellation caused by Turn termination. */
 export type AgentBackendApprovalDecision = AgentApprovalDecision | 'cancel';
 
+/** Decision returned to a backend-owned approval request. */
 export interface AgentBackendApprovalResult {
   readonly approvalId: string;
   readonly decision: AgentBackendApprovalDecision;
 }
 
+/** Session identity and trust metadata provided when a backend Session starts. */
 export interface AgentBackendSessionDescriptor {
   readonly agentId: string;
   readonly sessionId: string;
@@ -309,6 +355,7 @@ export interface AgentBackendSessionDescriptor {
   readonly inputTrust: AgentInputTrust;
 }
 
+/** Full backend Session-start contract after Tools and capabilities are filtered. */
 export interface AgentBackendSessionInput
   extends AgentBackendSessionDescriptor {
   /** Natural-language identity, role, goals, and operating context. */
@@ -318,6 +365,7 @@ export interface AgentBackendSessionInput
   readonly backendSessionId?: string;
 }
 
+/** Stream protocol emitted by a backend and normalized into public `AgentEvent`s. */
 export type AgentBackendEvent =
   | { readonly type: 'message.delta'; readonly text: string }
   | { readonly type: 'message.completed'; readonly text: string }
@@ -344,6 +392,7 @@ export type AgentBackendEvent =
       readonly metadata?: Readonly<Record<string, JsonValue>>;
     };
 
+/** Backend-owned execution context for one Agent Session. */
 export interface AgentBackendSession {
   readonly id?: string;
   runStream(
@@ -361,6 +410,7 @@ export interface AgentBackendSession {
   close(): Promise<void>;
 }
 
+/** Success or structured failure returned to a backend-requested host Tool. */
 export type AgentBackendToolResult =
   | {
       readonly type: 'success';
@@ -373,12 +423,14 @@ export type AgentBackendToolResult =
       readonly error: AgentEventError;
     };
 
+/** Provider adapter that declares features and creates isolated backend Sessions. */
 export interface AgentBackend {
   readonly name: string;
   readonly backendCapabilities: Readonly<AgentBackendCapabilities>;
   startSession(input: AgentBackendSessionInput): Promise<AgentBackendSession>;
 }
 
+/** Host-selected identity, audience, permissions, and narrowed limits for a Session. */
 export interface AgentSessionOptions {
   readonly id?: string;
   readonly purpose: string;
@@ -390,10 +442,12 @@ export interface AgentSessionOptions {
   readonly limits?: AgentRuntimeLimits;
 }
 
+/** Session options plus the backend identifier that must be resumed. */
 export interface AgentResumeSessionOptions extends AgentSessionOptions {
   readonly backendSessionId: string;
 }
 
+/** Agent-wide or Session-narrowed safety limits enforced by the runtime. */
 export interface AgentRuntimeLimits {
   /** Maximum number of Tool calls accepted during one Turn. */
   readonly maxToolCallsPerTurn?: number;
@@ -401,6 +455,7 @@ export interface AgentRuntimeLimits {
   readonly approvalTimeoutMs?: number;
 }
 
+/** Persisted lifecycle state for preparing an Agent's workspace. */
 export type AgentWorkspaceStatus =
   | 'fresh'
   | 'bootstrapping'
@@ -437,6 +492,7 @@ export interface AgentWorkspaceMetadataStore {
   ): Promise<void>;
 }
 
+/** Retry, Tool-call, and elapsed-time bounds for workspace bootstrap. */
 export interface AgentBootstrapLimits {
   /** Attempts allowed for one bootstrap version. Defaults to 3. */
   readonly maxAttempts?: number;
@@ -452,6 +508,7 @@ export interface AgentBootstrapContext {
   readonly data: JsonValue;
 }
 
+/** Workspace store, version, permissions, context, and limits for bootstrap. */
 export interface AgentBootstrapOptions {
   readonly workspace: AgentWorkspaceMetadataStore;
   /** Bump when the host wants the Agent to revise its operating state. */
@@ -463,6 +520,7 @@ export interface AgentBootstrapOptions {
   readonly limits?: AgentBootstrapLimits;
 }
 
+/** Bootstrap action taken and the resulting persisted workspace metadata. */
 export interface AgentBootstrapResult {
   readonly action: 'bootstrapped' | 'resumed';
   readonly metadata: AgentWorkspaceMetadata;
@@ -470,6 +528,10 @@ export interface AgentBootstrapResult {
   readonly run?: AgentRunResult;
 }
 
+/**
+ * Host-facing conversation or task context. It runs one Turn at a time,
+ * resolves approvals, supports interruption when declared, and owns cleanup.
+ */
 export interface AgentSession {
   readonly id: string;
   readonly purpose: string;
@@ -491,6 +553,7 @@ export interface AgentSession {
   close(): Promise<void>;
 }
 
+/** Immutable definition and host-owned integrations used to create an Agent. */
 export interface AgentOptions {
   /** Stable application-owned identity used for events and persisted state. */
   readonly id: string;
@@ -508,6 +571,10 @@ export interface AgentOptions {
   readonly limits?: AgentRuntimeLimits;
 }
 
+/**
+ * Managed character runtime created by `createAgent`. It exposes backend
+ * feature flags and owns bootstrap, Session creation/resume, and cleanup.
+ */
 export interface Agent {
   readonly id: string;
   readonly brief: string;
@@ -518,6 +585,7 @@ export interface Agent {
   close(): Promise<void>;
 }
 
+/** JSON-safe error snapshot embedded in events and workspace metadata. */
 export interface AgentEventError {
   readonly name: string;
   readonly code: string;
@@ -525,6 +593,7 @@ export interface AgentEventError {
   readonly details?: Readonly<Record<string, JsonValue>>;
 }
 
+/** Correlation, time, and Agent/Session identity shared by every public event. */
 export interface AgentEventBase<TType extends string> {
   readonly id: string;
   readonly type: TType;
@@ -534,32 +603,38 @@ export interface AgentEventBase<TType extends string> {
   readonly turnId?: string;
 }
 
+/** Emitted before the first Turn of a newly started Session. */
 export interface AgentSessionStartedEvent
   extends AgentEventBase<'session.started'> {
   readonly purpose: string;
 }
 
+/** Emitted before the first Turn of a resumed backend Session. */
 export interface AgentSessionResumedEvent
   extends AgentEventBase<'session.resumed'> {
   readonly backendSessionId: string;
 }
 
+/** Marks the beginning of a Turn after any pending Session lifecycle event. */
 export interface AgentTurnStartedEvent extends AgentEventBase<'turn.started'> {
   readonly turnId: string;
 }
 
+/** Incremental assistant text from a streaming backend. */
 export interface AgentMessageDeltaEvent
   extends AgentEventBase<'message.delta'> {
   readonly turnId: string;
   readonly text: string;
 }
 
+/** Final transformed assistant text for the Turn. */
 export interface AgentMessageCompletedEvent
   extends AgentEventBase<'message.completed'> {
   readonly turnId: string;
   readonly text: string;
 }
 
+/** Sanitized arguments for a host Tool requested by the backend. */
 export interface AgentToolRequestedEvent
   extends AgentEventBase<'tool.requested'> {
   readonly turnId: string;
@@ -568,12 +643,14 @@ export interface AgentToolRequestedEvent
   readonly arguments: unknown;
 }
 
+/** Indicates that policy and approval passed and the host Tool handler is starting. */
 export interface AgentToolStartedEvent extends AgentEventBase<'tool.started'> {
   readonly turnId: string;
   readonly toolCallId: string;
   readonly toolId: string;
 }
 
+/** Records a host Tool handler's successfully transformed output. */
 export interface AgentToolCompletedEvent
   extends AgentEventBase<'tool.completed'> {
   readonly turnId: string;
@@ -582,6 +659,7 @@ export interface AgentToolCompletedEvent
   readonly output: unknown;
 }
 
+/** Records a structured host Tool failure before it is returned or ends the Turn. */
 export interface AgentToolFailedEvent extends AgentEventBase<'tool.failed'> {
   readonly turnId: string;
   readonly toolCallId: string;
@@ -589,12 +667,14 @@ export interface AgentToolFailedEvent extends AgentEventBase<'tool.failed'> {
   readonly error: AgentEventError;
 }
 
+/** Approval prompt emitted when a Tool or backend operation needs host authority. */
 export interface AgentApprovalRequestedEvent
   extends AgentEventBase<'approval.requested'> {
   readonly turnId: string;
   readonly request: AgentApprovalRequest;
 }
 
+/** Approval decision, optionally including an automatic handler error that caused denial. */
 export interface AgentApprovalResolvedEvent
   extends AgentEventBase<'approval.resolved'> {
   readonly turnId: string;
@@ -604,34 +684,46 @@ export interface AgentApprovalResolvedEvent
   readonly error?: AgentEventError;
 }
 
+/** Announces a validated structured Artifact before Turn completion. */
 export interface AgentArtifactCreatedEvent
   extends AgentEventBase<'artifact.created'> {
   readonly turnId: string;
   readonly artifact: AgentArtifact;
 }
 
+/** Successful terminal event containing the same result returned by `run()`. */
 export interface AgentTurnCompletedEvent
   extends AgentEventBase<'turn.completed'> {
   readonly turnId: string;
   readonly result: AgentRunResult;
 }
 
+/** Terminal event used when caller, host, or backend interruption ends a Turn. */
 export interface AgentTurnInterruptedEvent
   extends AgentEventBase<'turn.interrupted'> {
   readonly turnId: string;
   readonly error: AgentEventError;
 }
 
+/** Terminal event used when a non-interruption error ends a Turn. */
 export interface AgentTurnFailedEvent extends AgentEventBase<'turn.failed'> {
   readonly turnId: string;
   readonly error: AgentEventError;
 }
 
+/** Emitted only when host closure interrupts an active Turn. */
 export interface AgentSessionClosedEvent
   extends AgentEventBase<'session.closed'> {
   readonly reason?: string;
 }
 
+/**
+ * Public event stream for Session, Turn, message, Tool, approval, and Artifact
+ * activity. Every begun Turn produces exactly one of `turn.completed`,
+ * `turn.interrupted`, or `turn.failed`; `session.started` or `session.resumed`
+ * appears only before the Session's first Turn, while `session.closed` appears
+ * only when host closure interrupts an active Turn.
+ */
 export type AgentEvent =
   | AgentSessionStartedEvent
   | AgentSessionResumedEvent

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -327,7 +327,7 @@ export type AgentBackendToolResult =
 
 export interface AgentBackend {
   readonly name: string;
-  readonly capabilities: Readonly<AgentBackendCapabilities>;
+  readonly backendCapabilities: Readonly<AgentBackendCapabilities>;
   startSession(input: AgentBackendSessionInput): Promise<AgentBackendSession>;
 }
 
@@ -463,7 +463,7 @@ export interface AgentOptions {
 export interface Agent {
   readonly id: string;
   readonly brief: string;
-  readonly capabilities: Readonly<AgentBackendCapabilities>;
+  readonly backendCapabilities: Readonly<AgentBackendCapabilities>;
   bootstrap(options: AgentBootstrapOptions): Promise<AgentBootstrapResult>;
   startSession(options: AgentSessionOptions): Promise<AgentSession>;
   resumeSession(options: AgentResumeSessionOptions): Promise<AgentSession>;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -34,6 +34,18 @@ export interface AgentRunInput<
 export interface AgentRunOptions {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
+  /**
+   * Answers approval requests for both `run()` and `runStream()`. Throwing or
+   * returning an invalid decision denies the request and records the error.
+   */
+  readonly onApprovalRequest?: (
+    request: AgentApprovalRequest,
+    context: {
+      readonly sessionId: string;
+      readonly turnId: string;
+      readonly signal: AbortSignal;
+    }
+  ) => AgentApprovalDecision | Promise<AgentApprovalDecision>;
 }
 
 export interface AgentArtifactSource {
@@ -540,6 +552,8 @@ export interface AgentApprovalResolvedEvent
   readonly turnId: string;
   readonly requestId: string;
   readonly decision: AgentApprovalDecision;
+  /** Present when an automatic approval handler failed or returned invalid data. */
+  readonly error?: AgentEventError;
 }
 
 export interface AgentArtifactCreatedEvent

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -522,7 +522,7 @@ export interface AgentEventError {
   readonly name: string;
   readonly code: string;
   readonly message: string;
-  readonly details?: Readonly<Record<string, unknown>>;
+  readonly details?: Readonly<Record<string, JsonValue>>;
 }
 
 export interface AgentEventBase<TType extends string> {

--- a/packages/agent/test/dist-smoke.mjs
+++ b/packages/agent/test/dist-smoke.mjs
@@ -19,12 +19,26 @@ assert.equal(typeof esmChat.createChatServiceBackend, 'function');
 assert.equal(typeof cjsChat.createChatServiceBackend, 'function');
 assert.equal(typeof esmCodex.createCodexAppServerBackend, 'function');
 assert.equal(typeof cjsCodex.createCodexAppServerBackend, 'function');
+for (const chat of [esmChat, cjsChat]) {
+  const backend = chat.createChatServiceBackend({
+    provider: 'openai',
+    createChatService: () => {
+      throw new Error('The smoke test does not start a Session.');
+    },
+  });
+  assert.equal(backend.backendCapabilities.text, true);
+}
 for (const codex of [esmCodex, cjsCodex]) {
   assert.equal(codex.CODEX_APP_SERVER_VERIFIED_VERSION, '0.145.0');
   assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
   assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
   assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
   assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
+  const backend = codex.createCodexAppServerBackend({
+    allowPathLookup: true,
+    workingDirectory: '/path/to/character-workspace',
+  });
+  assert.equal(backend.backendCapabilities.approvals, true);
 }
 
 const browserOutputFiles = [

--- a/packages/agent/test/package-smoke.mjs
+++ b/packages/agent/test/package-smoke.mjs
@@ -128,6 +128,11 @@ assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
 assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
 assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
 assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
+const codexBackend = codex.createCodexAppServerBackend({
+  allowPathLookup: true,
+  workingDirectory: '/path/to/character-workspace',
+});
+assert.equal(codexBackend.backendCapabilities.approvals, true);
 `
   );
   await writeFile(
@@ -147,6 +152,11 @@ assert.equal(codex.CODEX_APP_SERVER_MINIMUM_VERSION, '0.136.0');
 assert.equal(codex.CODEX_APP_SERVER_PROTOCOL_GENERATION, 'v2');
 assert.equal(codex.CODEX_APP_SERVER_SUPPORTED_VERSION, undefined);
 assert.equal(codex.CODEX_APP_SERVER_SCHEMA_VERSION, undefined);
+const codexBackend = codex.createCodexAppServerBackend({
+  allowPathLookup: true,
+  workingDirectory: '/path/to/character-workspace',
+});
+assert.equal(codexBackend.backendCapabilities.approvals, true);
 `
   );
 
@@ -257,6 +267,7 @@ const workspaceWrite = defineAgentTool({
   execute: () => ({ saved: true }),
 });
 declare const backend: AgentBackend;
+void backend.backendCapabilities.text;
 const policy: AgentPolicyConfig = {
   defaultDecision: 'deny',
   allowTools: ['workspace.read', 'workspace.write'],

--- a/packages/agent/tests/AgentApproval.test.ts
+++ b/packages/agent/tests/AgentApproval.test.ts
@@ -86,6 +86,40 @@ describe('Agent approval flow', () => {
     expect(approvalTool.execute).not.toHaveBeenCalled();
   });
 
+  it('allows run() to answer an approval request', async () => {
+    const { session } = await createApprovalSession();
+
+    const result = await session.run(
+      { instruction: 'Publish the report.' },
+      {
+        onApprovalRequest: (request, context) => {
+          expect(request.toolId).toBe('report.publish');
+          expect(context).toMatchObject({
+            sessionId: request.sessionId,
+            turnId: request.turnId,
+          });
+          expect(context.signal.aborted).toBe(false);
+          return 'allow-once';
+        },
+      }
+    );
+
+    expect(result.message).toBe('Published');
+    expect(approvalTool.execute).toHaveBeenCalledOnce();
+  });
+
+  it('never executes a Tool when the run() approval handler denies it', async () => {
+    const { session } = await createApprovalSession();
+
+    const running = session.run(
+      { instruction: 'Publish the report.' },
+      { onApprovalRequest: () => 'deny' }
+    );
+
+    await expect(running).rejects.toThrow(AgentApprovalDeniedError);
+    expect(approvalTool.execute).not.toHaveBeenCalled();
+  });
+
   it('times out approval without executing the Tool', async () => {
     vi.useFakeTimers();
     try {
@@ -95,6 +129,26 @@ describe('Agent approval flow', () => {
       const running = session.run({ instruction: 'Publish the report.' });
       const rejected = expect(running).rejects.toThrow(
         AgentApprovalTimeoutError
+      );
+
+      await vi.advanceTimersByTimeAsync(40);
+
+      await rejected;
+      expect(approvalTool.execute).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('explains how run() must answer an approval request', async () => {
+    vi.useFakeTimers();
+    try {
+      const { session } = await createApprovalSession({
+        approvalTimeoutMs: 40,
+      });
+      const running = session.run({ instruction: 'Publish the report.' });
+      const rejected = expect(running).rejects.toThrow(
+        /onApprovalRequest.*runStream/
       );
 
       await vi.advanceTimersByTimeAsync(40);
@@ -211,6 +265,60 @@ describe('Agent approval flow', () => {
         { approvalId: 'codex-approval-1', decision: backendDecision },
       ]);
       expect(events.at(-1)?.type).toBe('turn.completed');
+    }
+  );
+
+  it.each([
+    [
+      'throws',
+      (): Promise<never> => Promise.reject(new Error('approval UI failed')),
+    ],
+    ['returns an invalid decision', (): string => 'always-allow'],
+  ] as const)(
+    'denies a backend approval when the run() handler %s and records the error',
+    async (_label, onApprovalRequest) => {
+      const backend = new MockBackend(backendApprovalStream, {
+        approvals: true,
+      });
+      const agent = createAgent({
+        id: 'miko',
+        brief: 'You are Miko, AI operations staff.',
+        backend,
+      });
+      const session = await agent.startSession({
+        purpose: 'workspace operations',
+        audience: 'operator',
+        inputTrust: 'trusted',
+      });
+      const events: AgentEvent[] = [];
+      const handler = onApprovalRequest as NonNullable<
+        NonNullable<Parameters<typeof session.run>[1]>['onApprovalRequest']
+      >;
+
+      const result = await session.run(
+        { instruction: 'Inspect the workspace.' },
+        { onApprovalRequest: handler }
+      );
+
+      expect(result.message).toBe('Workspace inspected.');
+      expect(backend.sessions[0].approvalResults).toEqual([
+        { approvalId: 'codex-approval-1', decision: 'deny' },
+      ]);
+      backend.sessions[0].approvalResults.length = 0;
+      for await (const event of session.runStream(
+        { instruction: 'Inspect the workspace again.' },
+        { onApprovalRequest: handler }
+      )) {
+        events.push(event);
+      }
+      expect(
+        events.find((event) => event.type === 'approval.resolved')
+      ).toMatchObject({
+        decision: 'deny',
+        error: {
+          code: 'AGENT_CONFIGURATION_ERROR',
+        },
+      });
     }
   );
 

--- a/packages/agent/tests/AgentRuntime.test.ts
+++ b/packages/agent/tests/AgentRuntime.test.ts
@@ -72,8 +72,8 @@ describe('AgentRuntime', () => {
 
     expect(agent.id).toBe(agentDefinition.id);
     expect(agent.brief).toBe(agentDefinition.brief);
-    expect(agent.capabilities).toEqual(backend.capabilities);
-    expect(Object.isFrozen(agent.capabilities)).toBe(true);
+    expect(agent.backendCapabilities).toEqual(backend.backendCapabilities);
+    expect(Object.isFrozen(agent.backendCapabilities)).toBe(true);
     expect(performer.allowedTools).toEqual([]);
     expect(operator.allowedTools).toEqual(['comments.analyze']);
     expect(backend.startInputs[0].brief).toBe(agentDefinition.brief);

--- a/packages/agent/tests/AgentSession.test.ts
+++ b/packages/agent/tests/AgentSession.test.ts
@@ -1,5 +1,6 @@
 import { createAgent } from '../src/index.js';
 import {
+  AgentBackendError,
   AgentBackendProtocolError,
   AgentHookError,
   AgentInterruptedError,
@@ -289,6 +290,40 @@ describe('AgentSession', () => {
     expect(events.at(-1)).toMatchObject({
       type: 'turn.failed',
       error: { code: 'AGENT_BACKEND_ERROR' },
+    });
+  });
+
+  it('emits JSON-safe details for errors carrying non-JSON values', async () => {
+    const details: Record<string, unknown> = {
+      callback: () => undefined,
+      missing: undefined,
+      count: 42n,
+      finite: 7,
+      nested: [undefined, () => undefined, 1],
+    };
+    details.circular = details;
+    const backend = new MockBackend(async function* () {
+      yield { type: 'message.delta', text: 'partial' };
+      throw new AgentBackendError('provider details failed', { details });
+    });
+    const agent = createAgent({ ...agentDefinition, backend });
+    const session = await startSession(agent);
+    const events: AgentEvent[] = [];
+
+    await expect(
+      consume(session.runStream({ instruction: 'Fail safely' }), events)
+    ).rejects.toBeInstanceOf(AgentBackendError);
+
+    const terminal = events.at(-1);
+    expect(terminal?.type).toBe('turn.failed');
+    if (terminal?.type !== 'turn.failed') return;
+    const roundTripped = JSON.parse(
+      JSON.stringify(terminal.error.details)
+    ) as unknown;
+    expect(roundTripped).toEqual({
+      count: '42',
+      finite: 7,
+      nested: [null, null, 1],
     });
   });
 

--- a/packages/agent/tests/AgentSession.test.ts
+++ b/packages/agent/tests/AgentSession.test.ts
@@ -73,10 +73,13 @@ describe('AgentSession', () => {
         id: 'normalize-input',
         phase: 'input',
         onError: 'fail-turn',
-        run: ({ value }) => ({
-          ...(value as Record<string, unknown>),
-          data: { text: 'normalized' },
-        }),
+        run: ({ value }) =>
+          value
+            ? {
+                ...value,
+                data: { text: 'normalized' },
+              }
+            : value,
       },
       {
         id: 'enrich-context',

--- a/packages/agent/tests/AgentSession.test.ts
+++ b/packages/agent/tests/AgentSession.test.ts
@@ -198,10 +198,11 @@ describe('AgentSession', () => {
           id: 'invalid-artifact',
           phase: 'output',
           onError: 'fail-turn',
-          run: ({ value }) => ({
-            ...(value as AgentRunResult),
-            artifacts: [{ id: 'missing-fields' }],
-          }),
+          run: ({ value }) =>
+            ({
+              ...value,
+              artifacts: [{ id: 'missing-fields' }],
+            }) as unknown as AgentRunResult,
         },
       ],
     });
@@ -222,19 +223,20 @@ describe('AgentSession', () => {
           id: 'non-json-artifact',
           phase: 'output',
           onError: 'fail-turn',
-          run: ({ value, agentId, sessionId, turnId }) => ({
-            ...(value as AgentRunResult),
-            artifacts: [
-              {
-                id: 'invalid-data',
-                type: 'stream-alert',
-                version: 1,
-                data: { callback: () => undefined },
-                createdAt: '2026-08-02T00:00:00.000Z',
-                source: { agentId, sessionId, turnId },
-              },
-            ],
-          }),
+          run: ({ value, agentId, sessionId, turnId }) =>
+            ({
+              ...value,
+              artifacts: [
+                {
+                  id: 'invalid-data',
+                  type: 'stream-alert',
+                  version: 1,
+                  data: { callback: () => undefined },
+                  createdAt: '2026-08-02T00:00:00.000Z',
+                  source: { agentId, sessionId, turnId },
+                },
+              ],
+            }) as unknown as AgentRunResult,
         },
       ],
     });

--- a/packages/agent/tests/ChatServiceBackend.test.ts
+++ b/packages/agent/tests/ChatServiceBackend.test.ts
@@ -68,7 +68,7 @@ describe('ChatServiceBackend', () => {
     const factoryInputs: ChatServiceFactoryInput[] = [];
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TEXT_CAPABILITIES,
+      backendCapabilities: TEXT_CAPABILITIES,
       createChatService: (input) => {
         factoryInputs.push(input);
         return createMockChatService('openai', async (messages) => {
@@ -147,7 +147,7 @@ describe('ChatServiceBackend', () => {
   it('converts streaming callbacks without duplicating final text', async () => {
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TEXT_CAPABILITIES,
+      backendCapabilities: TEXT_CAPABILITIES,
       createChatService: () =>
         createMockChatService(
           'openai',
@@ -236,7 +236,7 @@ describe('ChatServiceBackend', () => {
     });
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TOOL_CAPABILITIES,
+      backendCapabilities: TOOL_CAPABILITIES,
       createChatService: (input) => {
         factoryInputs.push(input);
         return createMockChatService('openai', async (messages) => {
@@ -338,7 +338,7 @@ describe('ChatServiceBackend', () => {
     });
     const backend = createChatServiceBackend({
       provider: 'claude',
-      capabilities: TOOL_CAPABILITIES,
+      backendCapabilities: TOOL_CAPABILITIES,
       createChatService: () =>
         createMockChatService('claude', async (messages) => {
           calls.push(messages);
@@ -402,7 +402,7 @@ describe('ChatServiceBackend', () => {
     const cause = new Error('provider unavailable');
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TEXT_CAPABILITIES,
+      backendCapabilities: TEXT_CAPABILITIES,
       createChatService: () =>
         createMockChatService('openai', async () => {
           throw cause;
@@ -441,7 +441,7 @@ describe('ChatServiceBackend', () => {
     });
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TOOL_CAPABILITIES,
+      backendCapabilities: TOOL_CAPABILITIES,
       createChatService: () =>
         createMockChatService('openai', async (messages) => {
           calls.push(messages);
@@ -491,7 +491,7 @@ describe('ChatServiceBackend', () => {
   it('rejects malformed completions and bounded Tool loops', async () => {
     const malformedBackend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TEXT_CAPABILITIES,
+      backendCapabilities: TEXT_CAPABILITIES,
       createChatService: () =>
         createMockChatService('openai', async () => ({
           blocks: [],
@@ -527,7 +527,7 @@ describe('ChatServiceBackend', () => {
     });
     const boundedBackend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TOOL_CAPABILITIES,
+      backendCapabilities: TOOL_CAPABILITIES,
       maxToolRounds: 1,
       createChatService: () =>
         createMockChatService('openai', async () => {
@@ -576,7 +576,7 @@ describe('ChatServiceBackend', () => {
     });
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TEXT_CAPABILITIES,
+      backendCapabilities: TEXT_CAPABILITIES,
       createChatService: () =>
         createMockChatService('openai', async () => {
           providerStarted();
@@ -629,7 +629,7 @@ describe('ChatServiceBackend', () => {
     });
     const backend = createChatServiceBackend({
       provider: 'openai',
-      capabilities: TOOL_CAPABILITIES,
+      backendCapabilities: TOOL_CAPABILITIES,
       createChatService: () =>
         createMockChatService('openai', async () => {
           providerCalls += 1;
@@ -673,7 +673,7 @@ describe('ChatServiceBackend', () => {
     await agent.close();
   });
 
-  it('uses registered provider capabilities as an optional fallback', async () => {
+  it('uses registered provider backend capabilities as an optional fallback', async () => {
     let streamArgument: boolean | undefined;
     let factoryInput: ChatServiceFactoryInput | undefined;
     const backend = createChatServiceBackend({
@@ -686,7 +686,7 @@ describe('ChatServiceBackend', () => {
         });
       },
     });
-    expect(backend.capabilities).toMatchObject({
+    expect(backend.backendCapabilities).toMatchObject({
       text: true,
       streaming: false,
       tools: false,
@@ -719,7 +719,7 @@ describe('ChatServiceBackend', () => {
 
     try {
       createChatServiceBackend({
-        capabilities: {
+        backendCapabilities: {
           ...TEXT_CAPABILITIES,
           sessionResume: true,
         } as unknown as ChatServiceBackendCapabilities,
@@ -728,18 +728,18 @@ describe('ChatServiceBackend', () => {
             finalCompletion('response')
           ),
       });
-      throw new Error('Expected invalid capabilities to be rejected.');
+      throw new Error('Expected invalid backendCapabilities to be rejected.');
     } catch (error) {
       expect(error).toBeInstanceOf(AgentConfigurationError);
       expect((error as AgentConfigurationError).issues).toContain(
-        'capabilities.sessionResume must be false'
+        'backendCapabilities.sessionResume must be false'
       );
     }
 
     try {
       createChatServiceBackend({
         provider: 'codex-sdk',
-        capabilities: {
+        backendCapabilities: {
           ...TOOL_CAPABILITIES,
           streaming: false,
         },
@@ -752,14 +752,14 @@ describe('ChatServiceBackend', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(AgentConfigurationError);
       expect((error as AgentConfigurationError).issues).toContain(
-        'capabilities.tools cannot enable Tools for provider "codex-sdk"'
+        'backendCapabilities.tools cannot enable Tools for provider "codex-sdk"'
       );
     }
 
     try {
       createChatServiceBackend({
         provider: 'codex-sdk',
-        capabilities: {
+        backendCapabilities: {
           ...TEXT_CAPABILITIES,
           streaming: true,
         },
@@ -772,7 +772,7 @@ describe('ChatServiceBackend', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(AgentConfigurationError);
       expect((error as AgentConfigurationError).issues).toContain(
-        'capabilities.streaming cannot enable streaming for provider "codex-sdk"'
+        'backendCapabilities.streaming cannot enable streaming for provider "codex-sdk"'
       );
     }
   });

--- a/packages/agent/tests/CodexAppServerTransport.test.ts
+++ b/packages/agent/tests/CodexAppServerTransport.test.ts
@@ -192,7 +192,7 @@ describe('CodexAppServerTransport', () => {
     await process.finish(() => transport.close());
   });
 
-  it('times out one request without closing the transport', async () => {
+  it('ignores a late response after timeout and keeps the transport alive', async () => {
     vi.useFakeTimers();
     try {
       const process = new FakeCodexProcess();
@@ -204,6 +204,9 @@ describe('CodexAppServerTransport', () => {
         expect(timedOut).rejects.toBeInstanceOf(AgentTimeoutError);
       await vi.advanceTimersByTimeAsync(20);
       await rejected;
+
+      process.send({ id: 1, result: { late: true } });
+      expect(process.kill).not.toHaveBeenCalled();
 
       const next = transport.request('fast', {});
       process.send({ id: 2, result: { ok: true } });

--- a/packages/agent/tests/contracts.test.ts
+++ b/packages/agent/tests/contracts.test.ts
@@ -17,7 +17,7 @@ const validAgentDefinition = {
   `,
 };
 
-const capabilities: AgentBackendCapabilities = {
+const backendCapabilities: AgentBackendCapabilities = {
   text: true,
   streaming: true,
   tools: true,
@@ -57,7 +57,7 @@ describe('Phase 1 contracts', () => {
   });
 
   it('takes an immutable copy of backend capabilities', () => {
-    const mutableCapabilities = { ...capabilities };
+    const mutableCapabilities = { ...backendCapabilities };
     const snapshot = snapshotBackendCapabilities(mutableCapabilities);
 
     mutableCapabilities.tools = false;

--- a/packages/agent/tests/helpers/mockBackend.ts
+++ b/packages/agent/tests/helpers/mockBackend.ts
@@ -72,17 +72,17 @@ export class MockBackendSession implements AgentBackendSession {
 
 export class MockBackend implements AgentBackend {
   readonly name = 'mock-backend';
-  readonly capabilities: Readonly<AgentBackendCapabilities>;
+  readonly backendCapabilities: Readonly<AgentBackendCapabilities>;
   readonly startInputs: AgentBackendSessionInput[] = [];
   readonly sessions: MockBackendSession[] = [];
 
   constructor(
     private readonly streamFactory: MockStreamFactory,
-    capabilities: Partial<AgentBackendCapabilities> = {}
+    backendCapabilities: Partial<AgentBackendCapabilities> = {}
   ) {
-    this.capabilities = {
+    this.backendCapabilities = {
       ...DEFAULT_BACKEND_CAPABILITIES,
-      ...capabilities,
+      ...backendCapabilities,
     };
   }
 

--- a/packages/agent/tests/type-contracts.test.ts
+++ b/packages/agent/tests/type-contracts.test.ts
@@ -137,7 +137,7 @@ describe('public type surface', () => {
     expect(capability.id).toBe('workspace.local');
   });
 
-  it('types hook values by phase and accepts legacy unknown hooks', () => {
+  it('types hook values by phase and constrains explicit unknown hooks', () => {
     const backend = {
       name: 'type-contract-backend',
       backendCapabilities: {
@@ -153,18 +153,31 @@ describe('public type surface', () => {
         throw new Error('Type contract only');
       },
     } satisfies AgentBackend;
-    const explicitLegacyHook: AgentHook<unknown> = {
-      id: 'explicit-legacy',
+    const contextUnknownHook: AgentHook<unknown> = {
+      id: 'context-unknown',
       phase: 'context',
       onError: 'skip',
       run: ({ value }) => value,
     };
-    const defaultLegacyHook: AgentHook = {
-      id: 'default-legacy',
+    const beforeToolUnknownHook: AgentHook<unknown> = {
+      id: 'before-tool-unknown',
       phase: 'before-tool',
       onError: 'skip',
       run: ({ value }: AgentHookContext<unknown>) => value,
     };
+    const outputUnknownHook: AgentHook<unknown> = {
+      id: 'output-unknown',
+      phase: 'output',
+      onError: 'skip',
+      run: ({ value }) => value,
+    };
+    const preserveUnknownHookType = (
+      hook: AgentHook<unknown>
+    ): AgentHook<unknown> => hook;
+    const nonNarrowedUnknownHook = preserveUnknownHookType({
+      ...contextUnknownHook,
+      id: 'non-narrowed-unknown',
+    });
 
     createAgent({
       id: 'hook-contract-agent',
@@ -210,8 +223,12 @@ describe('public type surface', () => {
           onError: 'skip',
           run: () => 'invalid',
         },
-        explicitLegacyHook,
-        defaultLegacyHook,
+        contextUnknownHook,
+        beforeToolUnknownHook,
+        // @ts-expect-error Typed output phases cannot return unknown values.
+        outputUnknownHook,
+        // @ts-expect-error A non-narrowed unknown hook may be a typed phase.
+        nonNarrowedUnknownHook,
       ],
     });
   });

--- a/packages/agent/tests/type-contracts.test.ts
+++ b/packages/agent/tests/type-contracts.test.ts
@@ -196,6 +196,20 @@ describe('public type surface', () => {
             return value;
           },
         },
+        // @ts-expect-error Draft response hooks must return a string.
+        {
+          id: 'invalid-draft-output',
+          phase: 'draft-response',
+          onError: 'fail-turn',
+          run: () => 42,
+        },
+        // @ts-expect-error After-turn hooks must return their phase value.
+        {
+          id: 'invalid-after-turn-output',
+          phase: 'after-turn',
+          onError: 'skip',
+          run: () => 'invalid',
+        },
         explicitLegacyHook,
         defaultLegacyHook,
       ],

--- a/packages/agent/tests/type-contracts.test.ts
+++ b/packages/agent/tests/type-contracts.test.ts
@@ -14,6 +14,8 @@ import type {
   AgentConversationInput,
   AgentEvent,
   AgentHook,
+  AgentHookContext,
+  AgentHookValueMap,
   AgentOptions,
   AgentPolicy,
   AgentPolicyConfig,
@@ -133,6 +135,71 @@ describe('public type surface', () => {
     };
 
     expect(capability.id).toBe('workspace.local');
+  });
+
+  it('types hook values by phase and accepts legacy unknown hooks', () => {
+    const backend = {
+      name: 'type-contract-backend',
+      backendCapabilities: {
+        text: true,
+        streaming: false,
+        tools: false,
+        interruption: false,
+        sessionResume: false,
+        approvals: false,
+        detailedEvents: false,
+      },
+      async startSession() {
+        throw new Error('Type contract only');
+      },
+    } satisfies AgentBackend;
+    const explicitLegacyHook: AgentHook<unknown> = {
+      id: 'explicit-legacy',
+      phase: 'context',
+      onError: 'skip',
+      run: ({ value }) => value,
+    };
+    const defaultLegacyHook: AgentHook = {
+      id: 'default-legacy',
+      phase: 'before-tool',
+      onError: 'skip',
+      run: ({ value }: AgentHookContext<unknown>) => value,
+    };
+
+    createAgent({
+      id: 'hook-contract-agent',
+      brief: 'Exercise hook type contracts.',
+      backend,
+      hooks: [
+        {
+          id: 'typed-draft',
+          phase: 'draft-response',
+          onError: 'fail-turn',
+          run: ({ value }) => {
+            expectTypeOf(value).toEqualTypeOf<string>();
+            return value;
+          },
+        },
+        {
+          id: 'typed-after-turn',
+          phase: 'after-turn',
+          onError: 'skip',
+          run: ({ value }) => {
+            expectTypeOf(value).toEqualTypeOf<
+              AgentHookValueMap['after-turn']['input']
+            >();
+            if (value.status === 'completed') {
+              expectTypeOf(value.result).toEqualTypeOf<AgentRunResult>();
+            } else {
+              expectTypeOf(value.error.code).toEqualTypeOf<string>();
+            }
+            return value;
+          },
+        },
+        explicitLegacyHook,
+        defaultLegacyHook,
+      ],
+    });
   });
 
   it('exports Chat backend contracts without constructing a service', () => {


### PR DESCRIPTION
## Summary

Prepare the first public alpha of `@aituber-onair/agent` (`0.0.1`), an embeddable runtime for giving an AI character a job inside a JavaScript/TypeScript product, and fix the issues found in the pre-release review.

### Pre-release fixes

- **Codex transport**: a reply arriving after `requestTimeoutMs` for an already timed-out request no longer kills the whole app-server session. Timed-out request IDs are kept in a bounded set and their late response is ignored; never-issued or duplicate IDs remain fatal.
- **Approvals from `run()`**: add `AgentRunOptions.onApprovalRequest` so both `session.run()` and `session.runStream()` can answer `approval.requested`. A handler that throws or returns an invalid decision denies the request and records the error on `approval.resolved`. `run()` without a handler now fails with actionable guidance instead of a bare timeout.
- **Naming**: rename the backend feature-flag fields (`Agent.capabilities`, `AgentBackend.capabilities`, Chat/Codex backend options) to `backendCapabilities` so they are no longer confused with host-granted capability descriptors (`capabilityCatalog` / `allowedCapabilities`).
- **Typed hooks**: add `AgentHookValueMap` and phase-discriminated `AgentHook` typing so inline hooks get typed `value` and a checked return type per phase. `AgentHook<unknown>` stays assignable only for phases whose value is `unknown`; the contract tests state this explicitly.
- **JSON-safe error details**: `AgentEventError.details` is now `Record<string, JsonValue>`, sanitized through a shared helper used by the session runtime, bootstrap metadata, and the Chat backend.
- **JSDoc**: document every exported symbol in the public entry points, including `AgentAudience` semantics, `AgentToolRisk` ordering, hook phases, and the per-Turn event invariants.

### Release preparation

- `packages/agent/package.json`: version `0.0.1`, drop `private`, add `publishConfig.access: public` and `prepublishOnly`.
- `CHANGELOG.md` rewritten as the initial alpha release note; package READMEs (EN/JA) switch from the "unreleased" banner to alpha status with an install snippet.
- Root `README.md` / `README_ja.md`: add the package section and project-tree entry. `CLAUDE.md`: add the package to the list and tree.
- `.github/workflows/ci.yml`: build `@aituber-onair/agent` explicitly.
- `package-lock.json` regenerated (`packages/agent` → `0.0.1`).

No changeset file is needed: `release.yml` publishes any non-private workspace whose version is not yet on the registry.

## Validation

- `packages/agent`: `npm run fmt && npm run lint && npm run test && npm run build` (32 files, 239 tests; dist-smoke and package-smoke included)
- Repository root, in order: `npm run fmt`, `npm run lint`, `npm run test`, `npm run build`
- `npm install --package-lock-only` is idempotent; `npm ci` passes
- `npm pack --dry-run`: 213 files; only `dist/`, `CHANGELOG.md`, `README.md`, `README.ja.md`, `package.json` (no `src/`, `images/`, or `examples/`)
- Ran `public-release-check` over the branch diff, changed files, and the packed tarball: no Block or Warn findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
