### PR TITLE
feat(transcription): add Gemini 3.5 Transcribe Live support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8791,7 +8791,7 @@
         },
         "packages/transcription": {
             "name": "@aituber-onair/transcription",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aituber-onair/transcription
 
+## Unreleased
+
+### Added
+
+- Added Gemini 3.5 Transcribe Live support over browser WebSocket with
+  ephemeral-token and explicitly acknowledged browser BYOK authentication.
+- Added 16 kHz PCM16 microphone streaming, interim and final transcript
+  snapshots, language hints, custom vocabulary, and verbatim or smart modes.
+- Added Gemini controls, English/Japanese guidance, capability detection, and
+  connection-limit guidance to the browser example and package documentation.
+
 ## 0.0.2
 
 ### Added

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -10,6 +10,10 @@
   snapshots, language hints, custom vocabulary, and verbatim or smart modes.
 - Added Gemini controls, English/Japanese guidance, capability detection, and
   connection-limit guidance to the browser example and package documentation.
+- Preserved Gemini WebSocket close codes and reasons so authentication,
+  provider-policy, and transport failures can be diagnosed separately.
+- Accepted Gemini WebSocket responses delivered as text, `Blob`, or
+  `ArrayBuffer`, and distinguished socket-open from setup-response timeouts.
 
 ## 0.0.2
 

--- a/packages/transcription/CHANGELOG.md
+++ b/packages/transcription/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @aituber-onair/transcription
 
-## Unreleased
+## 0.0.3
 
 ### Added
 
@@ -10,6 +10,9 @@
   snapshots, language hints, custom vocabulary, and verbatim or smart modes.
 - Added Gemini controls, English/Japanese guidance, capability detection, and
   connection-limit guidance to the browser example and package documentation.
+
+### Fixed
+
 - Preserved Gemini WebSocket close codes and reasons so authentication,
   provider-policy, and transport failures can be diagnosed separately.
 - Accepted Gemini WebSocket responses delivered as text, `Blob`, or

--- a/packages/transcription/README.ja.md
+++ b/packages/transcription/README.ja.md
@@ -9,28 +9,36 @@ AITuber OnAir 向けの、プロバイダーに依存しないリアルタイム
 > このパッケージはα版です。安定版になるまでに公開 API が変更される可能性が
 > あります。
 
-Web Speech、ブラウザ WebRTC を利用する OpenAI Realtime、WebGPU でローカル推論する
-Whisper Tiny、Base、Small に対応しています。すべてのプロバイダーが、発話ごとに
-同じ形式のスナップショットイベントを発行します。ファイルの文字起こし、サーバー
-WebSocket入力、チャットへの自動送信、プロバイダーのフォールバックは、意図的に
-対象外です。
+Web Speech、ブラウザ WebRTC を利用する OpenAI Realtime、ブラウザ WebSocket を
+利用する Gemini Live、WebGPU でローカル推論する Whisper Tiny、Base、Small に
+対応しています。すべてのプロバイダーが、発話ごとに同じ形式のスナップショット
+イベントを発行します。ファイルの文字起こし、サーバー WebSocket入力、チャットへの
+自動送信、プロバイダーのフォールバックは、意図的に対象外です。
 
 ## ブラウザサンプル
 
-AITuber OnAir Core に依存せず、3つのプロバイダーを試せるフレームワーク非依存の
-ブラウザサンプルが含まれています。
+AITuber OnAir Core に依存せず、4つのプロバイダーを試せるフレームワーク非依存の
+ブラウザサンプルが含まれています。リポジトリルートで依存関係をインストールした後、
+サンプルのディレクトリから起動できます。
+
+```sh
+cd packages/transcription/examples/browser-basic
+npm run dev
+```
+
+リポジトリルートからワークスペースコマンドで起動することもできます。
 
 ```sh
 npm -w @aituber-onair/transcription run example:dev
 ```
 
 表示された localhost の URL を開き、セッション開始時にマイクの使用を許可して
-ください。Web Speech と Local Whisper にキーは不要です。OpenAI を利用する場合は、
-エンドユーザー自身が所有する API キーを画面に入力します。サンプルはブラウザから
-OpenAI へ直接接続するため、共有端末での利用は避けてください。Local Whisper には
-WebGPU が必要で、初回開始時にモデルとランタイムをダウンロードしてブラウザに
-キャッシュします。画面は日本語・英語を切り替えられ、初期表示にはブラウザの言語
-設定が使われます。詳細は
+ください。Web Speech と Local Whisper にキーは不要です。OpenAI または Gemini を
+利用する場合は、エンドユーザー自身が所有する API キーを画面に入力します。サンプルは
+選択したサービスへブラウザから直接接続するため、共有端末での利用は避けてください。
+Local Whisper には WebGPU が必要で、初回開始時にモデルとランタイムをダウンロード
+してブラウザにキャッシュします。画面は日本語・英語を切り替えられ、初期表示には
+ブラウザの言語設定が使われます。詳細は
 [サンプルの README](https://github.com/shinshin86/aituber-onair/blob/main/packages/transcription/examples/browser-basic/README.md)
 を参照してください。
 
@@ -61,8 +69,8 @@ await session.dispose();
 ```
 
 進捗イベントを発行するのは、時間のかかる初期化を伴うプロバイダーだけです。現在は
-`local-whisper` のみが `onProgress` を発行し、Web Speech と OpenAI Realtime は
-発行しません。
+`local-whisper` のみが `onProgress` を発行し、Web Speech、OpenAI Realtime、
+Gemini Live は発行しません。
 
 ### Local Whisper
 
@@ -184,35 +192,86 @@ const session = createRealtimeTranscriptionSession({
 });
 ```
 
+### Gemini Live
+
+Gemini Live は `gemini-3.5-transcribe-live` を使用し、16bit PCMの生音声をブラウザの
+WebSocketからストリーミングします。低遅延の途中結果と、発話ごとの確定結果を発行します。
+言語の自動判定、言語ヒント、カスタム語彙、逐語・スマート文字起こしモードに対応します。
+
+推奨するブラウザ認証方式では、アプリケーションのバックエンドから有効期間の短い
+Ephemeral Tokenを取得します。
+
+```ts
+const session = createRealtimeTranscriptionSession({
+  provider: 'gemini-live',
+  auth: {
+    type: 'ephemeral-token',
+    getEphemeralToken: async () => {
+      const response = await fetch('/api/gemini/ephemeral-token', {
+        method: 'POST',
+      });
+      const data = await response.json();
+      return data.name;
+    },
+  },
+  languages: ['ja-JP', 'en-US'],
+  keywords: ['AITuber OnAir'],
+  mode: 'smart',
+});
+```
+
+フロントエンドのみで動作するセルフホスト型アプリケーションでは、エンドユーザーが
+所有する API キーを明示的に使って直接接続することもできます。
+
+```ts
+const session = createRealtimeTranscriptionSession({
+  provider: 'gemini-live',
+  auth: {
+    type: 'browser-api-key',
+    getApiKey: async () => readEndUserKeyAtRuntime(),
+    acknowledgeBrowserKeyRisk: true,
+  },
+  languages: [], // 言語を自動判定
+  mode: 'verbatim',
+});
+```
+
+Gemini Live Transcribe の1接続は現在最大10分です。サーバーから予期せず切断された場合、
+このプロバイダーは型付きの接続エラーを発行します。10分を超えて利用するアプリケーション
+では、新しいセッションを開始してください。Liveストリーミングでは、話者分離と単語単位の
+タイムスタンプを利用できません。現在のプレビュー状況、対応言語、制限、料金へのリンクは
+[Gemini Live文字起こしの公式ドキュメント](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe)
+を参照してください。
+
 ## セキュリティ
 
-OpenAI は、標準 API キーをサーバーに保管し、有効期間の短いクライアント
-シークレットを発行する方式を推奨しています。ブラウザ BYOK 方式は、信頼できる
+OpenAI と Google は、標準 API キーをサーバーに保管し、有効期間の短いブラウザ用
+認証情報を発行する方式を推奨しています。ブラウザ BYOK 方式は、信頼できる
 フロントエンドのみのアプリケーションやセルフホスト環境向けです。この方式では、
 エンドユーザー自身が所有・提供するキーを使用する必要があります。アプリケーション
 所有者のキーを、ソースコードやビルド成果物に含めないでください。
 
-このパッケージは `start()` のたびに `getApiKey()` を通じてキーを要求し、保存、
-キャッシュ、返却、ログ出力は行いません。ただし、保存方法は利用側のアプリケーションが
-管理します。ブラウザにキーを保存すると、XSS、拡張機能、ローカル端末へのアクセス、
-侵害された依存パッケージなどを通じて漏洩する可能性があります。また、クライアント
-シークレットの直接発行は、OpenAI エンドポイントの現在のブラウザ/CORS 動作にも
-依存します。失敗した場合は型付きエラーを返し、別の認証方式へ自動的にフォールバック
-することはありません。
+このパッケージは `start()` のたびに `getApiKey()`、`getClientSecret()`、または
+`getEphemeralToken()` を通じて認証情報を要求し、保存、キャッシュ、返却、ログ出力は
+行いません。ただし、保存方法は利用側のアプリケーションが管理します。ブラウザにキーを
+保存すると、XSS、拡張機能、ローカル端末へのアクセス、侵害された依存パッケージなどを
+通じて漏洩する可能性があります。認証情報の取得に失敗した場合は型付きエラーを返し、
+別の認証方式へ自動的にフォールバックすることはありません。
 
 ## プロバイダーの違い
 
-| 機能 | Web Speech | OpenAI Realtime | Local Whisper |
-| --- | --- | --- | --- |
-| 途中経過のスナップショット | 対応 | 対応 | 非対応 |
-| 複数の想定言語 | 非対応 | 対応 | 非対応 |
-| キーワードと文脈プロンプト | 非対応 | 対応 | 非対応 |
-| 遅延の設定 | 非対応 | 対応 | 対応 |
-| 発話境界の判定 | ブラウザ実装 | ブラウザの音量検出 | ブラウザのPCM/VAD |
+| 機能 | Web Speech | OpenAI Realtime | Gemini Live | Local Whisper |
+| --- | --- | --- | --- | --- |
+| 途中経過のスナップショット | 対応 | 対応 | 対応 | 非対応 |
+| 複数の想定言語 | 非対応 | 対応 | 対応 | 非対応 |
+| キーワード / カスタム語彙 | 非対応 | 対応 | 対応 | 非対応 |
+| スマート文字起こし | 非対応 | 非対応 | 対応 | 非対応 |
+| 遅延の設定 | 非対応 | 対応 | 非対応 | 対応 |
+| 発話境界の判定 | ブラウザ実装 | ブラウザの音量検出 | GeminiのサーバーVAD | ブラウザのPCM/VAD |
 
-すべてのプロバイダーに、対応ブラウザとマイクの使用許可が必要です。OpenAI WebRTC と
-Local Whisper では Web Audio API と HTTPS または localhost も必要で、Local
-Whisper はさらに WebGPU を必要とします。Web Speech の利用可否と動作はブラウザに
-よって異なります。無音中でも待機によって OpenAI の利用料金が発生する可能性がある
-ため、アプリケーションでは状態を明確に表示し、未使用時にはセッションを停止して
-ください。
+すべてのプロバイダーに、対応ブラウザとマイクの使用許可が必要です。OpenAI WebRTC、
+Gemini Live、Local Whisper では Web Audio API と HTTPS または localhost も必要です。
+Gemini Live はさらに WebSocket、Local Whisper は WebGPU を必要とします。Web Speech の
+利用可否と動作はブラウザによって異なります。リモートプロバイダーでは待機中も利用料金が
+発生する可能性があるため、アプリケーションでは状態を明確に表示し、未使用時には
+セッションを停止してください。

--- a/packages/transcription/README.md
+++ b/packages/transcription/README.md
@@ -10,27 +10,36 @@ Provider-neutral realtime microphone transcription for AITuber OnAir.
 > release.
 
 The package supports Web Speech, OpenAI Realtime transcription over browser
-WebRTC, and local Whisper Tiny, Base, and Small inference through WebGPU. All
-providers emit the same per-utterance snapshot events. File transcription,
-server WebSocket input, automatic chat submission, and provider fallback are
-intentionally out of scope.
+WebRTC, Gemini Live transcription over browser WebSocket, and local Whisper
+Tiny, Base, and Small inference through WebGPU. All providers emit the same
+per-utterance snapshot events. File transcription, server WebSocket input,
+automatic chat submission, and provider fallback are intentionally out of
+scope.
 
 ## Browser example
 
-The package includes a framework-free browser example that exercises all three
+The package includes a framework-free browser example that exercises all four
 providers without depending on AITuber OnAir Core:
+
+```sh
+cd packages/transcription/examples/browser-basic
+npm run dev
+```
+
+After installing dependencies from the repository root, you can also start the
+example with a workspace command:
 
 ```sh
 npm -w @aituber-onair/transcription run example:dev
 ```
 
 Open the displayed localhost URL and grant microphone permission when starting
-a session. Web Speech and Local Whisper need no key. For OpenAI, enter an
-end-user-owned API key in the page. The sample connects to OpenAI directly from
-the browser, so avoid using it on a shared device. Local Whisper requires
-WebGPU; its first start downloads model/runtime assets and caches them in the
-browser. The interface supports English and Japanese and selects the initial
-display from the browser language. See the
+a session. Web Speech and Local Whisper need no key. For OpenAI or Gemini,
+enter an end-user-owned API key in the page. The sample connects to the selected
+service directly from the browser, so avoid using it on a shared device. Local
+Whisper requires WebGPU; its first start downloads model/runtime assets and
+caches them in the browser. The interface supports English and Japanese and
+selects the initial display from the browser language. See the
 [example README](https://github.com/shinshin86/aituber-onair/blob/main/packages/transcription/examples/browser-basic/README.md)
 for details.
 
@@ -61,8 +70,8 @@ await session.dispose();
 ```
 
 Only providers with potentially long initialization emit `onProgress` events.
-Currently, only `local-whisper` emits them; Web Speech and OpenAI Realtime do
-not.
+Currently, only `local-whisper` emits them; Web Speech, OpenAI Realtime, and
+Gemini Live do not.
 
 ### Local Whisper
 
@@ -189,33 +198,88 @@ const session = createRealtimeTranscriptionSession({
 });
 ```
 
+### Gemini Live
+
+Gemini Live uses `gemini-3.5-transcribe-live` and streams raw 16-bit PCM audio
+over a browser WebSocket. It emits low-latency interim snapshots and a final
+snapshot for each detected utterance. The model supports automatic language
+detection, language hints, custom vocabulary, and verbatim or smart
+transcription modes.
+
+The recommended browser authentication mode obtains a short-lived ephemeral
+token from an application backend:
+
+```ts
+const session = createRealtimeTranscriptionSession({
+  provider: 'gemini-live',
+  auth: {
+    type: 'ephemeral-token',
+    getEphemeralToken: async () => {
+      const response = await fetch('/api/gemini/ephemeral-token', {
+        method: 'POST',
+      });
+      const data = await response.json();
+      return data.name;
+    },
+  },
+  languages: ['ja-JP', 'en-US'],
+  keywords: ['AITuber OnAir'],
+  mode: 'smart',
+});
+```
+
+Frontend-only, self-hosted applications may explicitly connect with an
+end-user-owned API key:
+
+```ts
+const session = createRealtimeTranscriptionSession({
+  provider: 'gemini-live',
+  auth: {
+    type: 'browser-api-key',
+    getApiKey: async () => readEndUserKeyAtRuntime(),
+    acknowledgeBrowserKeyRisk: true,
+  },
+  languages: [], // Automatic language detection
+  mode: 'verbatim',
+});
+```
+
+Gemini Live Transcribe currently has a 10-minute connection limit. This
+provider reports an unexpected server disconnect as a typed connection error;
+applications that need longer listening periods should start a new session.
+Live streaming does not provide speaker diarization or word-level timestamps.
+See the
+[Gemini Live transcription documentation](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe)
+for current preview status, supported languages, limits, and pricing links.
+
 ## Security
 
-OpenAI recommends keeping standard API keys on a server and minting short-lived
-client secrets for browser sessions. The browser-BYOK mode exists for trusted
-frontend-only or self-hosted use. It must use a key owned and supplied by the
+OpenAI and Google recommend keeping standard API keys on a server and minting
+short-lived browser credentials. The browser-BYOK modes exist for trusted
+frontend-only or self-hosted use. They must use a key owned and supplied by the
 end user; never bundle an application-owner key in source code or built assets.
 
-The package requests the key through `getApiKey()` for each `start()` and does
-not persist, cache, return, or log it. A consuming application still controls
-its own storage. Browser persistence can expose the key to XSS, extensions,
-local device access, or compromised dependencies. Direct client-secret minting
-also depends on the OpenAI endpoint's current browser/CORS behavior; failures
-are returned as typed errors and never trigger an authentication fallback.
+The package requests credentials through `getApiKey()`, `getClientSecret()`, or
+`getEphemeralToken()` for each `start()` and does not persist, cache, return, or
+log them. A consuming application still controls its own storage. Browser
+persistence can expose a key to XSS, extensions, local device access, or
+compromised dependencies. Credential failures are returned as typed errors and
+never trigger an authentication fallback.
 
 ## Provider differences
 
-| Capability | Web Speech | OpenAI Realtime | Local Whisper |
-| --- | --- | --- | --- |
-| Interim snapshots | Yes | Yes | No |
-| Multiple expected languages | No | Yes | No |
-| Keywords and context prompt | No | Yes | No |
-| Configurable delay | No | Yes | Yes |
-| Utterance boundary | Browser implementation | Browser audio-level detection | Browser PCM/VAD |
+| Capability | Web Speech | OpenAI Realtime | Gemini Live | Local Whisper |
+| --- | --- | --- | --- | --- |
+| Interim snapshots | Yes | Yes | Yes | No |
+| Multiple expected languages | No | Yes | Yes | No |
+| Keywords / custom vocabulary | No | Yes | Yes | No |
+| Smart transcription | No | No | Yes | No |
+| Configurable delay | No | Yes | No | Yes |
+| Utterance boundary | Browser implementation | Browser audio-level detection | Gemini server VAD | Browser PCM/VAD |
 
 All providers require a supported browser and microphone permission. OpenAI
-WebRTC and Local Whisper also require the Web Audio API and HTTPS or localhost;
-Local Whisper additionally requires WebGPU. Web Speech availability and
-behavior vary by browser. Listening can incur OpenAI usage charges even during
-silence, so applications should expose state clearly and stop sessions when
-unused.
+WebRTC, Gemini Live, and Local Whisper also require the Web Audio API and HTTPS
+or localhost; Gemini Live additionally requires WebSocket and Local Whisper
+requires WebGPU. Web Speech availability and behavior vary by browser. Remote
+providers can incur usage charges while listening, so applications should
+expose state clearly and stop sessions when unused.

--- a/packages/transcription/examples/browser-basic/README.md
+++ b/packages/transcription/examples/browser-basic/README.md
@@ -5,15 +5,25 @@ AITuber OnAir Core or a UI framework. The interface automatically starts in
 Japanese for Japanese browser preferences and otherwise starts in English. Use
 the language selector in the page to switch at any time.
 
-From the repository root:
+Install the repository dependencies from the repository root first. Then start
+the example from this directory:
+
+```sh
+cd packages/transcription/examples/browser-basic
+npm run dev
+```
+
+You can also start it from the repository root:
 
 ```sh
 npm -w @aituber-onair/transcription run example:dev
 ```
 
-Web Speech and Local Whisper require no API key. To use OpenAI, select OpenAI
-Realtime and enter an API key from your own OpenAI account. The example connects
-to OpenAI directly from the browser, so avoid using it on a shared device.
+Web Speech and Local Whisper require no API key. To use OpenAI or Gemini, select
+the provider and enter an API key from your own account. The example connects
+to the selected service directly from the browser, so avoid using it on a
+shared device. Production Gemini integrations should use a backend-issued
+ephemeral token instead of a standard API key in the browser.
 
 Use localhost or HTTPS and grant microphone access when prompted. Local Whisper
 requires WebGPU. Select Tiny (about 122 MB), Base (about 209 MB), or Small
@@ -21,7 +31,8 @@ requires WebGPU. Select Tiny (about 122 MB), Base (about 209 MB), or Small
 Tiny. Assets are cached in the browser. The example aggregates known per-file
 totals to show overall download progress, then shows model initialization and
 hides the progress row when listening starts. Microphone audio stays in the
-browser. OpenAI usage may incur charges while a session is listening.
+browser. OpenAI and Gemini usage may incur charges while a session is
+listening. Gemini Live Transcribe connections are limited to 10 minutes.
 
 ## Local Whisper worker URL
 

--- a/packages/transcription/examples/browser-basic/index.html
+++ b/packages/transcription/examples/browser-basic/index.html
@@ -25,8 +25,8 @@
         </div>
         <h1 data-i18n="heroTitle">Try realtime transcription</h1>
         <p class="hero-copy" data-i18n="heroCopy">
-          Transcribe microphone audio with Web Speech, OpenAI Realtime, or
-          Local Whisper. Results are not submitted as chat messages
+          Transcribe microphone audio with Web Speech, OpenAI Realtime, Gemini
+          Live, or Local Whisper. Results are not submitted as chat messages
           automatically.
         </p>
       </header>
@@ -49,6 +49,7 @@
           <select id="provider">
             <option value="web-speech">Web Speech</option>
             <option value="openai-realtime">OpenAI Realtime</option>
+            <option value="gemini-live">Gemini Live</option>
             <option value="local-whisper">Local Whisper</option>
           </select>
         </label>
@@ -131,6 +132,70 @@ An English conversation recorded through a microphone.</textarea
           <p class="notice cost" data-i18n="openAICost">
             OpenAI usage may be billed while transcription is running,
             including during silence.
+          </p>
+        </div>
+
+        <div id="gemini-fields" hidden>
+          <label class="field">
+            <span data-i18n="geminiApiKey">Gemini API key</span>
+            <input
+              id="gemini-api-key"
+              type="password"
+              autocomplete="off"
+              placeholder="Enter your Gemini API key"
+              data-i18n-placeholder="geminiApiKeyPlaceholder"
+            />
+            <small data-i18n="geminiApiKeyHint">
+              Use a key from your own Google AI Studio account.
+            </small>
+          </label>
+          <p class="notice info" data-i18n="geminiBrowserByokNotice">
+            This example connects to Gemini directly from your browser. Avoid
+            using it on a shared device. Production apps should use a
+            backend-issued ephemeral token.
+          </p>
+
+          <div class="field-grid">
+            <label class="field">
+              <span data-i18n="geminiLanguages">Language hints</span>
+              <input id="gemini-languages" value="ja-JP,en-US" />
+              <small data-i18n="geminiLanguagesHint">
+                Optional comma-separated BCP 47 codes (for example:
+                ja-JP,en-US). Leave blank for automatic detection.
+              </small>
+            </label>
+            <label class="field">
+              <span data-i18n="geminiMode">Transcription mode</span>
+              <select id="gemini-mode">
+                <option value="verbatim" data-i18n="geminiModeVerbatim">
+                  Verbatim
+                </option>
+                <option value="smart" data-i18n="geminiModeSmart">
+                  Smart
+                </option>
+              </select>
+              <small data-i18n="geminiModeHint">
+                Smart mode removes fillers and formats the result for
+                readability.
+              </small>
+            </label>
+          </div>
+
+          <label class="field">
+            <span data-i18n="geminiKeywords">Custom vocabulary</span>
+            <input
+              id="gemini-keywords"
+              value="AITuber OnAir, Gemini"
+              data-i18n-value="geminiKeywordsValue"
+            />
+            <small data-i18n="geminiKeywordsHint">
+              Comma-separated names or technical terms. Up to 1,000 terms are
+              accepted; 100 or fewer is recommended.
+            </small>
+          </label>
+          <p class="notice cost" data-i18n="geminiCost">
+            Gemini usage may be billed while transcription is running. A Live
+            Transcribe connection is limited to 10 minutes.
           </p>
         </div>
 

--- a/packages/transcription/examples/browser-basic/package.json
+++ b/packages/transcription/examples/browser-basic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@aituber-onair/transcription-browser-basic-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --config vite.config.ts",
+    "build": "tsc --project tsconfig.json --noEmit && vite build --config vite.config.ts"
+  }
+}

--- a/packages/transcription/examples/browser-basic/src/i18n.test.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.test.ts
@@ -38,6 +38,7 @@ describe('browser example i18n', () => {
     expect(translate('ja', 'localWhisperModelSmallHint')).toContain('約589MB');
     expect(translate('ja', 'progressDownloadModel')).toContain('初回のみ');
     expect(translate('ja', 'progressInitializeModel')).toBe('モデルを初期化中');
+    expect(translate('ja', 'errorTechnicalDetails')).toBe('詳細');
     expect(translate('en', 'progressDownloadModel')).toContain(
       'first use only'
     );

--- a/packages/transcription/examples/browser-basic/src/i18n.test.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.test.ts
@@ -25,6 +25,14 @@ describe('browser example i18n', () => {
       'An English conversation recorded through a microphone.',
       'マイクから入力された日本語の会話です。',
     ]);
+    expect(translatedValues('geminiKeywordsValue')).toEqual([
+      'AITuber OnAir, Gemini',
+      'AITuber OnAir, Gemini',
+    ]);
+    expect(translate('ja', 'geminiCost')).toContain('最大10分');
+    expect(translate('en', 'geminiBrowserByokNotice')).toContain(
+      'ephemeral token'
+    );
     expect(translate('ja', 'localWhisperModelTinyHint')).toContain('約122MB');
     expect(translate('ja', 'localWhisperModelBaseHint')).toContain('約209MB');
     expect(translate('ja', 'localWhisperModelSmallHint')).toContain('約589MB');

--- a/packages/transcription/examples/browser-basic/src/i18n.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.ts
@@ -8,7 +8,7 @@ const englishMessages = {
   displayLanguage: 'Language',
   heroTitle: 'Try realtime transcription',
   heroCopy:
-    'Transcribe microphone audio with Web Speech, OpenAI Realtime, or Local Whisper. Results are not submitted as chat messages automatically.',
+    'Transcribe microphone audio with Web Speech, OpenAI Realtime, Gemini Live, or Local Whisper. Results are not submitted as chat messages automatically.',
   sessionSettings: 'Transcription settings',
   checkingSupport: 'Checking availability',
   browserSupported: 'Available',
@@ -38,6 +38,25 @@ const englishMessages = {
   contextPromptValue: 'An English conversation recorded through a microphone.',
   openAICost:
     'OpenAI usage may be billed while transcription is running, including during silence.',
+  geminiApiKey: 'Gemini API key',
+  geminiApiKeyPlaceholder: 'Enter your Gemini API key',
+  geminiApiKeyHint: 'Use a key from your own Google AI Studio account.',
+  geminiBrowserByokNotice:
+    'This example connects to Gemini directly from your browser. Avoid using it on a shared device. Production apps should use a backend-issued ephemeral token.',
+  geminiLanguages: 'Language hints',
+  geminiLanguagesHint:
+    'Optional comma-separated BCP 47 codes (for example: ja-JP,en-US). Leave blank for automatic detection.',
+  geminiKeywords: 'Custom vocabulary',
+  geminiKeywordsValue: 'AITuber OnAir, Gemini',
+  geminiKeywordsHint:
+    'Comma-separated names or technical terms. Up to 1,000 terms are accepted; 100 or fewer is recommended.',
+  geminiMode: 'Transcription mode',
+  geminiModeVerbatim: 'Verbatim',
+  geminiModeSmart: 'Smart',
+  geminiModeHint:
+    'Smart mode removes fillers and formats the result for readability.',
+  geminiCost:
+    'Gemini usage may be billed while transcription is running. A Live Transcribe connection is limited to 10 minutes.',
   localWhisperLanguage: 'Language hint',
   localWhisperLanguageHint:
     'Optional BCP 47 language code. Leave blank for automatic detection.',
@@ -75,9 +94,11 @@ const englishMessages = {
   errorPermissionDenied: 'Microphone permission was denied.',
   errorNoSpeech: 'No speech was detected.',
   errorAuthenticationFailed:
-    'OpenAI authentication failed. Check the API key and try again.',
+    'Provider authentication failed. Check the API key and try again.',
   errorClientSecretFailed:
     'OpenAI connection setup failed. Wait a moment and try again.',
+  errorEphemeralTokenFailed:
+    'Gemini token setup failed. Wait a moment and try again.',
   errorConnectionFailed:
     'The transcription service could not be reached. Wait a moment and try again.',
   errorProvider: 'Transcription failed. Please try again.',
@@ -94,7 +115,7 @@ const japaneseMessages: Messages = {
   displayLanguage: '表示言語',
   heroTitle: 'リアルタイム文字起こしを試す',
   heroCopy:
-    'Web Speech、OpenAI Realtime、Local Whisperで、マイク音声をリアルタイムに文字起こしできます。結果がチャットへ自動送信されることはありません。',
+    'Web Speech、OpenAI Realtime、Gemini Live、Local Whisperで、マイク音声をリアルタイムに文字起こしできます。結果がチャットへ自動送信されることはありません。',
   sessionSettings: '文字起こし設定',
   checkingSupport: '利用可否を確認中',
   browserSupported: '利用可能',
@@ -122,6 +143,26 @@ const japaneseMessages: Messages = {
   contextPromptValue: 'マイクから入力された日本語の会話です。',
   openAICost:
     '文字起こし中は、無音の時間を含めてOpenAIの利用料金が発生する場合があります。',
+  geminiApiKey: 'Gemini APIキー',
+  geminiApiKeyPlaceholder: 'Gemini APIキーを入力',
+  geminiApiKeyHint:
+    'ご自身のGoogle AI StudioアカウントのAPIキーを入力してください。',
+  geminiBrowserByokNotice:
+    'このサンプルはブラウザからGeminiへ直接接続します。共有端末での利用は避けてください。本番環境ではバックエンド発行の短期トークンを使用してください。',
+  geminiLanguages: '言語ヒント',
+  geminiLanguagesHint:
+    '任意のBCP 47言語コードをカンマ区切りで入力（例：ja-JP,en-US）。空欄にすると自動判定します。',
+  geminiKeywords: 'カスタム語彙',
+  geminiKeywordsValue: 'AITuber OnAir, Gemini',
+  geminiKeywordsHint:
+    '固有名詞や専門用語をカンマ区切りで入力します。最大1,000語、推奨は100語以下です。',
+  geminiMode: '文字起こしモード',
+  geminiModeVerbatim: '逐語',
+  geminiModeSmart: 'スマート',
+  geminiModeHint:
+    'スマートモードでは、フィラーを除去して読みやすく整形します。',
+  geminiCost:
+    '文字起こし中はGeminiの利用料金が発生する場合があります。Live Transcribeの1接続は最大10分です。',
   localWhisperLanguage: '言語ヒント',
   localWhisperLanguageHint:
     '任意のBCP 47言語コードです。空欄にすると自動判定します。',
@@ -158,9 +199,11 @@ const japaneseMessages: Messages = {
     'マイクを使用できません。ブラウザの権限設定を確認してください。',
   errorNoSpeech: '音声を検出できませんでした。',
   errorAuthenticationFailed:
-    'OpenAIの認証に失敗しました。APIキーを確認してください。',
+    'プロバイダーの認証に失敗しました。APIキーを確認してください。',
   errorClientSecretFailed:
     'OpenAIへの接続準備に失敗しました。しばらく待ってからもう一度お試しください。',
+  errorEphemeralTokenFailed:
+    'Geminiへの接続トークンを取得できませんでした。しばらく待ってからもう一度お試しください。',
   errorConnectionFailed:
     '文字起こしサービスへ接続できませんでした。しばらく待ってからもう一度お試しください。',
   errorProvider: '文字起こし中にエラーが発生しました。もう一度お試しください。',

--- a/packages/transcription/examples/browser-basic/src/i18n.ts
+++ b/packages/transcription/examples/browser-basic/src/i18n.ts
@@ -102,6 +102,7 @@ const englishMessages = {
   errorConnectionFailed:
     'The transcription service could not be reached. Wait a moment and try again.',
   errorProvider: 'Transcription failed. Please try again.',
+  errorTechnicalDetails: 'Details',
   errorInvalidConfiguration: 'Check the transcription settings and try again.',
   errorSessionDisposed: 'The transcription session has already been disposed.',
 } as const;
@@ -207,6 +208,7 @@ const japaneseMessages: Messages = {
   errorConnectionFailed:
     '文字起こしサービスへ接続できませんでした。しばらく待ってからもう一度お試しください。',
   errorProvider: '文字起こし中にエラーが発生しました。もう一度お試しください。',
+  errorTechnicalDetails: '詳細',
   errorInvalidConfiguration: '入力内容を確認してください。',
   errorSessionDisposed: '文字起こしセッションはすでに終了しています。',
 };

--- a/packages/transcription/examples/browser-basic/src/main.ts
+++ b/packages/transcription/examples/browser-basic/src/main.ts
@@ -168,7 +168,17 @@ function localizeStaticContent(): void {
 function translatedErrorMessage(error: TranscriptionError | Error): string {
   if (displayLanguage !== 'ja' || !('code' in error)) return error.message;
   const key = errorTranslationKeys[error.code as TranscriptionErrorCode];
-  return key ? translate(displayLanguage, key) : error.message;
+  if (!key) return error.message;
+  const summary = translate(displayLanguage, key);
+  if (
+    error.provider !== 'gemini-live' ||
+    !['authentication-failed', 'connection-failed', 'provider-error'].includes(
+      error.code as TranscriptionErrorCode
+    )
+  ) {
+    return summary;
+  }
+  return `${summary}\n${translate(displayLanguage, 'errorTechnicalDetails')}: ${error.message}`;
 }
 
 function setError(error: TranscriptionError | Error | null): void {

--- a/packages/transcription/examples/browser-basic/src/main.ts
+++ b/packages/transcription/examples/browser-basic/src/main.ts
@@ -1,6 +1,7 @@
 import {
   createRealtimeTranscriptionSession,
   isTranscriptionProviderSupported,
+  type GeminiTranscriptionMode,
   type LocalWhisperModelSize,
   type RealtimeTranscriptionSession,
   type TranscriptUpdate,
@@ -40,6 +41,11 @@ const openAILanguages = element<HTMLInputElement>('#openai-languages');
 const openAIKeywords = element<HTMLInputElement>('#openai-keywords');
 const openAIPrompt = element<HTMLTextAreaElement>('#openai-prompt');
 const openAIDelay = element<HTMLSelectElement>('#openai-delay');
+const geminiFields = element<HTMLDivElement>('#gemini-fields');
+const geminiApiKey = element<HTMLInputElement>('#gemini-api-key');
+const geminiLanguages = element<HTMLInputElement>('#gemini-languages');
+const geminiKeywords = element<HTMLInputElement>('#gemini-keywords');
+const geminiMode = element<HTMLSelectElement>('#gemini-mode');
 const localWhisperFields = element<HTMLDivElement>('#local-whisper-fields');
 const localWhisperModel = element<HTMLSelectElement>('#local-whisper-model');
 const localWhisperModelHint = element<HTMLElement>('#local-whisper-model-hint');
@@ -82,6 +88,7 @@ const errorTranslationKeys: Record<TranscriptionErrorCode, TranslationKey> = {
   'no-speech': 'errorNoSpeech',
   'authentication-failed': 'errorAuthenticationFailed',
   'client-secret-failed': 'errorClientSecretFailed',
+  'ephemeral-token-failed': 'errorEphemeralTokenFailed',
   'connection-failed': 'errorConnectionFailed',
   'provider-error': 'errorProvider',
   'invalid-configuration': 'errorInvalidConfiguration',
@@ -301,6 +308,18 @@ function createSession(): RealtimeTranscriptionSession {
         prompt: openAIPrompt.value,
         delay: openAIDelay.value as TranscriptionDelay,
       });
+    case 'gemini-live':
+      return createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => geminiApiKey.value,
+          acknowledgeBrowserKeyRisk: true,
+        },
+        languages: commaSeparated(geminiLanguages.value),
+        keywords: commaSeparated(geminiKeywords.value),
+        mode: geminiMode.value as GeminiTranscriptionMode,
+      });
     case 'local-whisper':
       return createRealtimeTranscriptionSession({
         provider: 'local-whisper',
@@ -363,11 +382,14 @@ function clearTranscripts(): void {
 
 function syncSettings(): void {
   const provider = selectedProvider();
+  const webSpeechSelected = provider === 'web-speech';
   const openAISelected = provider === 'openai-realtime';
+  const geminiSelected = provider === 'gemini-live';
   const localWhisperSelected = provider === 'local-whisper';
 
-  webSpeechFields.hidden = openAISelected || localWhisperSelected;
+  webSpeechFields.hidden = !webSpeechSelected;
   openAIFields.hidden = !openAISelected;
+  geminiFields.hidden = !geminiSelected;
   localWhisperFields.hidden = !localWhisperSelected;
   renderLocalWhisperModelHint();
 

--- a/packages/transcription/examples/browser-basic/src/style.css
+++ b/packages/transcription/examples/browser-basic/src/style.css
@@ -307,6 +307,8 @@ button:disabled {
   color: #991b1b;
   font-size: 0.82rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
 }
 
 .transcript-block {

--- a/packages/transcription/package.json
+++ b/packages/transcription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/transcription",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Provider-neutral realtime transcription for AITuber OnAir",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/transcription/src/createRealtimeTranscriptionSession.ts
+++ b/packages/transcription/src/createRealtimeTranscriptionSession.ts
@@ -3,6 +3,7 @@ import type {
   RealtimeTranscriptionSession,
 } from './types';
 import { LocalWhisperTranscriptionSession } from './providers/LocalWhisperTranscriptionSession';
+import { GeminiLiveTranscriptionSession } from './providers/GeminiLiveTranscriptionSession';
 import { OpenAIRealtimeTranscriptionSession } from './providers/OpenAIRealtimeTranscriptionSession';
 import { WebSpeechTranscriptionSession } from './providers/WebSpeechTranscriptionSession';
 
@@ -14,6 +15,8 @@ export function createRealtimeTranscriptionSession(
       return new WebSpeechTranscriptionSession(options);
     case 'openai-realtime':
       return new OpenAIRealtimeTranscriptionSession(options);
+    case 'gemini-live':
+      return new GeminiLiveTranscriptionSession(options);
     case 'local-whisper':
       return new LocalWhisperTranscriptionSession(options);
     default: {

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -2,6 +2,9 @@ export { createRealtimeTranscriptionSession } from './createRealtimeTranscriptio
 export { TranscriptionSessionError } from './errors';
 export { isTranscriptionProviderSupported } from './support';
 export type {
+  GeminiLiveAuth,
+  GeminiLiveTranscriptionOptions,
+  GeminiTranscriptionMode,
   LocalWhisperModelSize,
   LocalWhisperTranscriptionOptions,
   OpenAIRealtimeAuth,

--- a/packages/transcription/src/providers/BrowserPcmStreamCapture.ts
+++ b/packages/transcription/src/providers/BrowserPcmStreamCapture.ts
@@ -1,0 +1,238 @@
+import { resampleTo16k } from './resampleTo16k';
+
+const TARGET_SAMPLE_RATE = 16_000;
+const CHUNK_DURATION_MS = 100;
+const FLUSH_TIMEOUT_MS = 500;
+const WORKLET_PROCESSOR_NAME = 'aituber-pcm-stream-capture';
+
+const WORKLET_SOURCE = `
+class AITuberPcmStreamCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.targetSampleCount = Math.max(
+      128,
+      Math.round(sampleRate * ${CHUNK_DURATION_MS / 1000})
+    );
+    this.buffer = new Float32Array(this.targetSampleCount);
+    this.bufferOffset = 0;
+    this.port.onmessage = (event) => {
+      if (event.data && event.data.type === 'flush') {
+        if (this.bufferOffset > 0) {
+          const chunk = this.buffer.slice(0, this.bufferOffset);
+          this.port.postMessage(chunk, [chunk.buffer]);
+          this.buffer = new Float32Array(this.targetSampleCount);
+          this.bufferOffset = 0;
+        }
+        this.port.postMessage({ type: 'flushed' });
+      }
+    };
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    const channel = input && input[0];
+    if (channel && channel.length > 0) {
+      let sourceOffset = 0;
+      while (sourceOffset < channel.length) {
+        const copyCount = Math.min(
+          channel.length - sourceOffset,
+          this.targetSampleCount - this.bufferOffset
+        );
+        this.buffer.set(
+          channel.subarray(sourceOffset, sourceOffset + copyCount),
+          this.bufferOffset
+        );
+        sourceOffset += copyCount;
+        this.bufferOffset += copyCount;
+
+        if (this.bufferOffset === this.targetSampleCount) {
+          const chunk = this.buffer;
+          this.port.postMessage(chunk, [chunk.buffer]);
+          this.buffer = new Float32Array(this.targetSampleCount);
+          this.bufferOffset = 0;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor(
+  '${WORKLET_PROCESSOR_NAME}',
+  AITuberPcmStreamCaptureProcessor
+);
+`;
+
+type AudioContextConstructor = new (
+  contextOptions?: AudioContextOptions
+) => AudioContext;
+
+interface BrowserAudioWindow extends Window {
+  AudioContext?: AudioContextConstructor;
+  webkitAudioContext?: AudioContextConstructor;
+}
+
+export interface BrowserPcmStreamCaptureOptions {
+  onChunk: (pcm16: Uint8Array) => void;
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const browser = window as BrowserAudioWindow;
+  return browser.AudioContext ?? browser.webkitAudioContext;
+}
+
+function createAudioContext(
+  AudioContextClass: AudioContextConstructor
+): AudioContext {
+  try {
+    return new AudioContextClass({ sampleRate: TARGET_SAMPLE_RATE });
+  } catch {
+    return new AudioContextClass();
+  }
+}
+
+export function float32ToPcm16LittleEndian(input: Float32Array): Uint8Array {
+  const output = new Uint8Array(input.length * 2);
+  const view = new DataView(output.buffer);
+  for (let index = 0; index < input.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, input[index]));
+    const value = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+    view.setInt16(index * 2, Math.round(value), true);
+  }
+  return output;
+}
+
+export class BrowserPcmStreamCapture {
+  private audioContext: AudioContext | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  private muteGainNode: GainNode | null = null;
+  private acceptingSamples = false;
+  private flushResolve: (() => void) | null = null;
+
+  constructor(
+    private readonly stream: MediaStream,
+    private readonly options: BrowserPcmStreamCaptureOptions
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.acceptingSamples) return;
+    const AudioContextClass = getAudioContextConstructor();
+    if (!AudioContextClass) {
+      throw new Error('The Web Audio API is unavailable.');
+    }
+    if (typeof AudioWorkletNode === 'undefined') {
+      throw new Error('AudioWorkletNode is unavailable.');
+    }
+
+    try {
+      const audioContext = createAudioContext(AudioContextClass);
+      this.audioContext = audioContext;
+      if (!audioContext.audioWorklet) {
+        throw new Error('AudioWorklet is unavailable.');
+      }
+
+      const workletUrl = URL.createObjectURL(
+        new Blob([WORKLET_SOURCE], { type: 'text/javascript' })
+      );
+      try {
+        await audioContext.audioWorklet.addModule(workletUrl);
+      } finally {
+        URL.revokeObjectURL(workletUrl);
+      }
+
+      const sourceNode = audioContext.createMediaStreamSource(this.stream);
+      const workletNode = new AudioWorkletNode(
+        audioContext,
+        WORKLET_PROCESSOR_NAME,
+        {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          outputChannelCount: [1],
+          channelCount: 1,
+          channelCountMode: 'explicit',
+        }
+      );
+      const muteGainNode = audioContext.createGain();
+      muteGainNode.gain.value = 0;
+      sourceNode.connect(workletNode);
+      workletNode.connect(muteGainNode);
+      muteGainNode.connect(audioContext.destination);
+
+      this.sourceNode = sourceNode;
+      this.workletNode = workletNode;
+      this.muteGainNode = muteGainNode;
+      workletNode.port.onmessage = (event: MessageEvent<unknown>) => {
+        if (
+          typeof event.data === 'object' &&
+          event.data !== null &&
+          'type' in event.data &&
+          event.data.type === 'flushed'
+        ) {
+          this.flushResolve?.();
+          this.flushResolve = null;
+          return;
+        }
+        if (!this.acceptingSamples || !(event.data instanceof Float32Array)) {
+          return;
+        }
+        const samples = resampleTo16k(event.data, audioContext.sampleRate);
+        this.options.onChunk(float32ToPcm16LittleEndian(samples));
+      };
+
+      if (audioContext.state === 'suspended') await audioContext.resume();
+      if (audioContext.state !== 'running') {
+        throw new Error('The Web Audio API could not start.');
+      }
+      this.acceptingSamples = true;
+    } catch (cause) {
+      await this.releaseResources();
+      throw cause;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.acceptingSamples && this.workletNode) {
+      await this.flush(this.workletNode).catch(() => undefined);
+    }
+    this.acceptingSamples = false;
+    await this.releaseResources();
+  }
+
+  private flush(workletNode: AudioWorkletNode): Promise<void> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.flushResolve === complete) this.flushResolve = null;
+        resolve();
+      }, FLUSH_TIMEOUT_MS);
+      const complete = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      this.flushResolve = complete;
+      workletNode.port.postMessage({ type: 'flush' });
+    });
+  }
+
+  private async releaseResources(): Promise<void> {
+    this.acceptingSamples = false;
+    this.flushResolve?.();
+    this.flushResolve = null;
+    if (this.workletNode) this.workletNode.port.onmessage = null;
+    this.sourceNode?.disconnect();
+    this.workletNode?.disconnect();
+    this.muteGainNode?.disconnect();
+    this.sourceNode = null;
+    this.workletNode = null;
+    this.muteGainNode = null;
+
+    for (const track of this.stream.getTracks()) track.stop();
+
+    const audioContext = this.audioContext;
+    this.audioContext = null;
+    if (audioContext && audioContext.state !== 'closed') {
+      await audioContext.close().catch(() => undefined);
+    }
+  }
+}

--- a/packages/transcription/src/providers/GeminiLiveTranscriptionSession.ts
+++ b/packages/transcription/src/providers/GeminiLiveTranscriptionSession.ts
@@ -1,0 +1,670 @@
+import { BaseRealtimeTranscriptionSession } from '../BaseRealtimeTranscriptionSession';
+import { TranscriptionSessionError } from '../errors';
+import type {
+  GeminiLiveAuth,
+  GeminiLiveTranscriptionOptions,
+  TranscriptionError,
+} from '../types';
+import { BrowserPcmStreamCapture } from './BrowserPcmStreamCapture';
+
+const GEMINI_TRANSCRIPTION_MODEL = 'gemini-3.5-transcribe-live';
+const API_KEY_WEBSOCKET_URL =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+const EPHEMERAL_TOKEN_WEBSOCKET_URL =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContentConstrained';
+const CONNECTION_TIMEOUT_MS = 10_000;
+const STOP_FINALIZATION_TIMEOUT_MS = 5_000;
+
+interface GeminiLiveCredential {
+  type: GeminiLiveAuth['type'];
+  value: string;
+}
+
+interface GeminiLiveServerMessage {
+  setupComplete?: unknown;
+  serverContent?: {
+    interimInputTranscription?: { text?: unknown };
+    inputTranscription?: { text?: unknown };
+  };
+  error?: {
+    code?: unknown;
+    message?: unknown;
+    status?: unknown;
+  };
+}
+
+interface StopFinalization {
+  resolve: () => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+class SessionOperationCancelled extends Error {}
+
+function isPermissionDenied(cause: unknown): boolean {
+  return (
+    cause instanceof DOMException &&
+    (cause.name === 'NotAllowedError' || cause.name === 'SecurityError')
+  );
+}
+
+function validateOptions(options: GeminiLiveTranscriptionOptions): void {
+  if (options.languages?.some((language) => !language.trim())) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'gemini-live',
+      'Gemini transcription language codes cannot be empty.'
+    );
+  }
+  if (options.keywords?.some((keyword) => !keyword.trim())) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'gemini-live',
+      'Gemini transcription keywords cannot be empty.'
+    );
+  }
+  if ((options.keywords?.length ?? 0) > 1_000) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'gemini-live',
+      'Gemini transcription accepts at most 1,000 keywords.'
+    );
+  }
+  if (
+    options.mode !== undefined &&
+    options.mode !== 'verbatim' &&
+    options.mode !== 'smart'
+  ) {
+    throw new TranscriptionSessionError(
+      'invalid-configuration',
+      'gemini-live',
+      'Gemini transcription mode must be verbatim or smart.'
+    );
+  }
+}
+
+function createSetupMessage(
+  options: GeminiLiveTranscriptionOptions
+): Record<string, unknown> {
+  const inputAudioTranscription: Record<string, unknown> = {
+    languageCodes: options.languages?.map((language) => language.trim()) ?? [],
+    mode: (options.mode ?? 'verbatim').toUpperCase(),
+  };
+  if (options.keywords?.length) {
+    inputAudioTranscription.customVocabulary = options.keywords.map((keyword) =>
+      keyword.trim()
+    );
+  }
+
+  return {
+    setup: {
+      model: `models/${GEMINI_TRANSCRIPTION_MODEL}`,
+      generationConfig: {
+        responseModalities: ['TEXT'],
+      },
+      inputAudioTranscription,
+    },
+  };
+}
+
+export function pcm16BytesToBase64(input: Uint8Array): string {
+  let binary = '';
+  for (let index = 0; index < input.length; index += 1) {
+    binary += String.fromCharCode(input[index]);
+  }
+  return btoa(binary);
+}
+
+export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSession {
+  private startPromise: Promise<void> | null = null;
+  private stopPromise: Promise<void> | null = null;
+  private operationId = 0;
+  private socket: WebSocket | null = null;
+  private mediaStream: MediaStream | null = null;
+  private capture: BrowserPcmStreamCapture | null = null;
+  private utteranceSequence = 0;
+  private activeUtteranceId: string | null = null;
+  private stopFinalization: StopFinalization | null = null;
+  private connectionCancel: (() => void) | null = null;
+
+  constructor(private readonly options: GeminiLiveTranscriptionOptions) {
+    super('gemini-live', {
+      interimResults: true,
+      multipleLanguages: true,
+      keywords: true,
+      configurableDelay: false,
+    });
+    validateOptions(options);
+  }
+
+  start(): Promise<void> {
+    this.assertNotDisposed();
+    if (this.startPromise) return this.startPromise;
+    if (this.state === 'listening') return Promise.resolve();
+
+    const promise = this.startWhenReady();
+    this.startPromise = promise;
+    void promise.then(
+      () => {
+        if (this.startPromise === promise) this.startPromise = null;
+      },
+      () => {
+        if (this.startPromise === promise) this.startPromise = null;
+      }
+    );
+    return promise;
+  }
+
+  private async startWhenReady(): Promise<void> {
+    if (this.stopPromise) await this.stopPromise;
+    this.assertNotDisposed();
+    if (this.state === 'listening') return;
+
+    this.operationId += 1;
+    const operationId = this.operationId;
+    this.changeState('connecting');
+    await this.connect(operationId);
+  }
+
+  private async connect(operationId: number): Promise<void> {
+    let localStream: MediaStream | null = null;
+    let localSocket: WebSocket | null = null;
+    let localCapture: BrowserPcmStreamCapture | null = null;
+
+    try {
+      this.assertBrowserSupport();
+      const credential = await this.getCredential();
+      this.assertOperation(operationId);
+
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            channelCount: 1,
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          },
+        });
+      } catch (cause) {
+        throw isPermissionDenied(cause)
+          ? new TranscriptionSessionError(
+              'permission-denied',
+              this.provider,
+              'Microphone permission was denied.',
+              { cause }
+            )
+          : new TranscriptionSessionError(
+              'provider-error',
+              this.provider,
+              'The microphone could not be opened for Gemini Live.',
+              { cause }
+            );
+      }
+      this.assertOperation(operationId);
+
+      localSocket = new WebSocket(this.createWebSocketUrl(credential));
+      const connectedSocket = localSocket;
+      this.socket = localSocket;
+      this.mediaStream = localStream;
+      await this.openAndConfigure(localSocket, operationId);
+      this.assertOperation(operationId);
+
+      localCapture = new BrowserPcmStreamCapture(localStream, {
+        onChunk: (pcm16) => this.sendAudioChunk(connectedSocket, pcm16),
+      });
+      this.capture = localCapture;
+      await localCapture.start();
+      this.assertOperation(operationId);
+
+      this.attachRuntimeListeners(localSocket);
+      this.changeState('listening');
+    } catch (cause) {
+      if (localCapture) await localCapture.stop().catch(() => undefined);
+      else for (const track of localStream?.getTracks() ?? []) track.stop();
+      if (this.capture === localCapture) this.capture = null;
+      if (this.mediaStream === localStream) this.mediaStream = null;
+      if (this.socket === localSocket) this.socket = null;
+      this.closeSocket(localSocket);
+
+      if (
+        cause instanceof SessionOperationCancelled ||
+        operationId !== this.operationId
+      ) {
+        if (this.state === 'disposed') {
+          throw new TranscriptionSessionError(
+            'session-disposed',
+            this.provider,
+            'The transcription session was disposed while connecting.'
+          );
+        }
+        return;
+      }
+
+      const error =
+        cause instanceof TranscriptionSessionError
+          ? cause
+          : new TranscriptionSessionError(
+              'connection-failed',
+              this.provider,
+              'Gemini Live transcription could not start.',
+              { cause }
+            );
+      this.changeState('error');
+      this.emitError(error);
+      throw error;
+    }
+  }
+
+  stop(): Promise<void> {
+    if (this.state === 'disposed' || this.state === 'idle') {
+      return Promise.resolve();
+    }
+    if (this.stopPromise) return this.stopPromise;
+
+    const wasConnecting = this.state === 'connecting';
+    this.operationId += 1;
+    const pendingStart = this.startPromise;
+    this.changeState('stopping');
+    const promise = this.stopAndFinalize(pendingStart, wasConnecting);
+    this.stopPromise = promise;
+    void promise.then(
+      () => {
+        if (this.stopPromise === promise) this.stopPromise = null;
+      },
+      () => {
+        if (this.stopPromise === promise) this.stopPromise = null;
+      }
+    );
+    return promise;
+  }
+
+  private async stopAndFinalize(
+    pendingStart: Promise<void> | null,
+    wasConnecting: boolean
+  ): Promise<void> {
+    if (wasConnecting) this.cleanupResources();
+    const capture = this.capture;
+    this.capture = null;
+    await capture?.stop().catch(() => undefined);
+    await pendingStart?.catch(() => undefined);
+
+    const socket = this.socket;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ realtimeInput: { audioStreamEnd: true } }));
+      await this.waitForFinalTranscript();
+    }
+
+    this.cleanupResources();
+    if (this.state === 'stopping') this.changeState('idle');
+  }
+
+  async dispose(): Promise<void> {
+    if (this.state === 'disposed') return;
+
+    this.operationId += 1;
+    this.changeState('disposed');
+    const capture = this.capture;
+    this.capture = null;
+    await capture?.stop().catch(() => undefined);
+    this.cleanupResources();
+    this.clearListeners();
+  }
+
+  private async getCredential(): Promise<GeminiLiveCredential> {
+    if (this.options.auth.type === 'ephemeral-token') {
+      let token: string;
+      try {
+        token = (await this.options.auth.getEphemeralToken()).trim();
+      } catch (cause) {
+        throw new TranscriptionSessionError(
+          'ephemeral-token-failed',
+          this.provider,
+          'The Gemini ephemeral-token endpoint was unavailable.',
+          { cause }
+        );
+      }
+      if (!token) {
+        throw new TranscriptionSessionError(
+          'ephemeral-token-failed',
+          this.provider,
+          'The Gemini ephemeral-token endpoint returned an empty token.'
+        );
+      }
+      return { type: 'ephemeral-token', value: token };
+    }
+
+    if (this.options.auth.acknowledgeBrowserKeyRisk !== true) {
+      throw new TranscriptionSessionError(
+        'invalid-configuration',
+        this.provider,
+        'Browser API-key mode requires explicit risk acknowledgement.'
+      );
+    }
+
+    let apiKey: string;
+    try {
+      apiKey = (await this.options.auth.getApiKey()).trim();
+    } catch (cause) {
+      throw new TranscriptionSessionError(
+        'authentication-failed',
+        this.provider,
+        'The browser API key could not be obtained.',
+        { cause }
+      );
+    }
+    if (!apiKey) {
+      throw new TranscriptionSessionError(
+        'authentication-failed',
+        this.provider,
+        'An end-user Gemini API key is required for browser BYOK mode.'
+      );
+    }
+    return { type: 'browser-api-key', value: apiKey };
+  }
+
+  private createWebSocketUrl(credential: GeminiLiveCredential): string {
+    const value = encodeURIComponent(credential.value);
+    return credential.type === 'ephemeral-token'
+      ? `${EPHEMERAL_TOKEN_WEBSOCKET_URL}?access_token=${value}`
+      : `${API_KEY_WEBSOCKET_URL}?key=${value}`;
+  }
+
+  private openAndConfigure(
+    socket: WebSocket,
+    operationId: number
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let setupSent = false;
+      let settled = false;
+      const complete = (operation: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this.connectionCancel === cancel) this.connectionCancel = null;
+        operation();
+      };
+      const cancel = () =>
+        complete(() => reject(new SessionOperationCancelled()));
+      this.connectionCancel = cancel;
+      const timer = setTimeout(() => {
+        complete(() =>
+          reject(
+            new TranscriptionSessionError(
+              'connection-failed',
+              this.provider,
+              'Timed out while connecting to Gemini Live.'
+            )
+          )
+        );
+      }, CONNECTION_TIMEOUT_MS);
+
+      socket.onopen = () => {
+        if (operationId !== this.operationId) {
+          cancel();
+          return;
+        }
+        setupSent = true;
+        socket.send(JSON.stringify(createSetupMessage(this.options)));
+      };
+      socket.onmessage = (event) => {
+        const message = this.parseServerMessage(event.data);
+        if (!message) return;
+        const providerError = this.providerErrorFromMessage(message);
+        if (providerError) {
+          complete(() => reject(providerError));
+          return;
+        }
+        if (setupSent && message.setupComplete !== undefined) {
+          complete(resolve);
+        }
+      };
+      socket.onerror = () => {
+        complete(() =>
+          reject(
+            new TranscriptionSessionError(
+              'connection-failed',
+              this.provider,
+              'The Gemini Live WebSocket connection failed.'
+            )
+          )
+        );
+      };
+      socket.onclose = (event) => {
+        const code =
+          event.code === 1008 ? 'authentication-failed' : 'connection-failed';
+        complete(() =>
+          reject(
+            new TranscriptionSessionError(
+              code,
+              this.provider,
+              `Gemini Live closed before setup completed (code ${event.code}).`
+            )
+          )
+        );
+      };
+    });
+  }
+
+  private attachRuntimeListeners(socket: WebSocket): void {
+    socket.onopen = null;
+    socket.onmessage = (event) => this.handleServerMessage(event.data);
+    socket.onerror = () => {
+      if (this.state === 'listening') {
+        this.handleConnectionFailure(
+          new TranscriptionSessionError(
+            'connection-failed',
+            this.provider,
+            'The Gemini Live WebSocket connection failed.'
+          )
+        );
+      }
+    };
+    socket.onclose = (event) => {
+      if (this.state === 'stopping') {
+        this.completeStopFinalization();
+        return;
+      }
+      if (this.state === 'listening') {
+        const code =
+          event.code === 1008 ? 'authentication-failed' : 'connection-failed';
+        this.handleConnectionFailure(
+          new TranscriptionSessionError(
+            code,
+            this.provider,
+            `The Gemini Live connection closed unexpectedly (code ${event.code}).`
+          )
+        );
+      }
+    };
+  }
+
+  private sendAudioChunk(socket: WebSocket, pcm16: Uint8Array): void {
+    if (
+      (this.state !== 'listening' && this.state !== 'stopping') ||
+      socket !== this.socket ||
+      socket.readyState !== WebSocket.OPEN
+    ) {
+      return;
+    }
+    socket.send(
+      JSON.stringify({
+        realtimeInput: {
+          audio: {
+            data: pcm16BytesToBase64(pcm16),
+            mimeType: 'audio/pcm;rate=16000',
+          },
+        },
+      })
+    );
+  }
+
+  private handleServerMessage(raw: unknown): void {
+    const message = this.parseServerMessage(raw);
+    if (!message) return;
+
+    const providerError = this.providerErrorFromMessage(message);
+    if (providerError) {
+      if (this.state === 'stopping') {
+        this.completeStopFinalization();
+      } else {
+        this.handleConnectionFailure(providerError);
+      }
+      return;
+    }
+
+    const interim = message.serverContent?.interimInputTranscription?.text;
+    if (typeof interim === 'string') {
+      const utteranceId = this.currentUtteranceId();
+      this.emitTranscript({ utteranceId, text: interim, isFinal: false });
+    }
+
+    const final = message.serverContent?.inputTranscription?.text;
+    if (typeof final === 'string') {
+      const utteranceId = this.currentUtteranceId();
+      this.activeUtteranceId = null;
+      this.emitTranscript({ utteranceId, text: final, isFinal: true });
+      this.completeStopFinalization();
+    }
+  }
+
+  private parseServerMessage(raw: unknown): GeminiLiveServerMessage | null {
+    if (typeof raw !== 'string') return null;
+    try {
+      return JSON.parse(raw) as GeminiLiveServerMessage;
+    } catch {
+      return null;
+    }
+  }
+
+  private providerErrorFromMessage(
+    message: GeminiLiveServerMessage
+  ): TranscriptionError | null {
+    if (!message.error) return null;
+    const errorText =
+      typeof message.error.message === 'string'
+        ? message.error.message
+        : 'Gemini Live transcription reported an error.';
+    const status =
+      typeof message.error.status === 'string' ? message.error.status : '';
+    const code =
+      status === 'UNAUTHENTICATED' || status === 'PERMISSION_DENIED'
+        ? 'authentication-failed'
+        : 'provider-error';
+    return new TranscriptionSessionError(code, this.provider, errorText);
+  }
+
+  private currentUtteranceId(): string {
+    if (!this.activeUtteranceId) {
+      this.activeUtteranceId = `gemini-live:${++this.utteranceSequence}`;
+    }
+    return this.activeUtteranceId;
+  }
+
+  private waitForFinalTranscript(): Promise<void> {
+    if (!this.activeUtteranceId) return Promise.resolve();
+    const stopFinalization = this.stopFinalization;
+    if (stopFinalization) {
+      return new Promise((resolve) => {
+        const currentResolve = stopFinalization.resolve;
+        stopFinalization.resolve = () => {
+          currentResolve();
+          resolve();
+        };
+      });
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.stopFinalization?.timer === timer) {
+          this.stopFinalization = null;
+        }
+        resolve();
+      }, STOP_FINALIZATION_TIMEOUT_MS);
+      this.stopFinalization = { resolve, timer };
+    });
+  }
+
+  private completeStopFinalization(): void {
+    if (!this.stopFinalization) return;
+    const { resolve, timer } = this.stopFinalization;
+    this.stopFinalization = null;
+    clearTimeout(timer);
+    resolve();
+  }
+
+  private handleConnectionFailure(error: TranscriptionError): void {
+    if (this.state === 'disposed' || this.state === 'error') return;
+    this.operationId += 1;
+    this.changeState('error');
+    this.emitError(error);
+    const capture = this.capture;
+    this.capture = null;
+    void capture?.stop().catch(() => undefined);
+    this.cleanupResources();
+  }
+
+  private cleanupResources(): void {
+    this.connectionCancel?.();
+    this.connectionCancel = null;
+    this.completeStopFinalization();
+    this.activeUtteranceId = null;
+    const socket = this.socket;
+    this.socket = null;
+    this.closeSocket(socket);
+    const stream = this.mediaStream;
+    this.mediaStream = null;
+    for (const track of stream?.getTracks() ?? []) track.stop();
+  }
+
+  private closeSocket(socket: WebSocket | null): void {
+    if (!socket) return;
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onerror = null;
+    socket.onclose = null;
+    if (
+      socket.readyState === WebSocket.CONNECTING ||
+      socket.readyState === WebSocket.OPEN
+    ) {
+      socket.close();
+    }
+  }
+
+  private assertBrowserSupport(): void {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'Gemini Live transcription requires a browser.'
+      );
+    }
+    if (window.isSecureContext === false) {
+      throw new TranscriptionSessionError(
+        'insecure-context',
+        this.provider,
+        'Gemini Live transcription requires HTTPS or localhost.'
+      );
+    }
+    const browser = window as Window & {
+      AudioContext?: typeof AudioContext;
+      webkitAudioContext?: typeof AudioContext;
+    };
+    if (
+      typeof WebSocket === 'undefined' ||
+      !navigator.mediaDevices?.getUserMedia ||
+      !(browser.AudioContext ?? browser.webkitAudioContext) ||
+      typeof AudioWorkletNode === 'undefined'
+    ) {
+      throw new TranscriptionSessionError(
+        'unsupported-provider',
+        this.provider,
+        'This browser does not support the WebSocket and Web Audio microphone APIs required by Gemini Live.'
+      );
+    }
+  }
+
+  private assertOperation(operationId: number): void {
+    if (operationId !== this.operationId) {
+      throw new SessionOperationCancelled();
+    }
+    this.assertNotDisposed();
+  }
+}

--- a/packages/transcription/src/providers/GeminiLiveTranscriptionSession.ts
+++ b/packages/transcription/src/providers/GeminiLiveTranscriptionSession.ts
@@ -14,6 +14,8 @@ const EPHEMERAL_TOKEN_WEBSOCKET_URL =
   'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContentConstrained';
 const CONNECTION_TIMEOUT_MS = 10_000;
 const STOP_FINALIZATION_TIMEOUT_MS = 5_000;
+const WEBSOCKET_CLOSE_GRACE_MS = 500;
+const MAX_CLOSE_REASON_LENGTH = 300;
 
 interface GeminiLiveCredential {
   type: GeminiLiveAuth['type'];
@@ -39,6 +41,34 @@ interface StopFinalization {
 }
 
 class SessionOperationCancelled extends Error {}
+
+function normalizedCloseReason(reason: string): string {
+  return reason.trim().replace(/\s+/g, ' ').slice(0, MAX_CLOSE_REASON_LENGTH);
+}
+
+function isAuthenticationCloseReason(reason: string): boolean {
+  return /api.?key|authenticat|unauthenticated|credential|permission.?denied/i.test(
+    reason
+  );
+}
+
+function errorFromCloseEvent(
+  event: CloseEvent,
+  phase: 'setup' | 'runtime'
+): TranscriptionSessionError {
+  const reason = normalizedCloseReason(event.reason);
+  const detail = `code ${event.code}${reason ? `: ${reason}` : ''}`;
+  const code = isAuthenticationCloseReason(reason)
+    ? 'authentication-failed'
+    : event.code === 1006 || event.code >= 1011
+      ? 'connection-failed'
+      : 'provider-error';
+  const message =
+    phase === 'setup'
+      ? `Gemini Live closed before setup completed (${detail}).`
+      : `The Gemini Live connection closed unexpectedly (${detail}).`;
+  return new TranscriptionSessionError(code, 'gemini-live', message);
+}
 
 function isPermissionDenied(cause: unknown): boolean {
   return (
@@ -125,6 +155,7 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
   private activeUtteranceId: string | null = null;
   private stopFinalization: StopFinalization | null = null;
   private connectionCancel: (() => void) | null = null;
+  private socketErrorFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly options: GeminiLiveTranscriptionOptions) {
     super('gemini-live', {
@@ -375,27 +406,37 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
     return new Promise((resolve, reject) => {
       let setupSent = false;
       let settled = false;
+      let closeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+      let timer: ReturnType<typeof setTimeout> | null = null;
       const complete = (operation: () => void) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
+        if (closeGraceTimer) clearTimeout(closeGraceTimer);
         if (this.connectionCancel === cancel) this.connectionCancel = null;
         operation();
       };
       const cancel = () =>
         complete(() => reject(new SessionOperationCancelled()));
       this.connectionCancel = cancel;
-      const timer = setTimeout(() => {
-        complete(() =>
-          reject(
-            new TranscriptionSessionError(
-              'connection-failed',
-              this.provider,
-              'Timed out while connecting to Gemini Live.'
-            )
-          )
-        );
-      }, CONNECTION_TIMEOUT_MS);
+      const scheduleTimeout = () => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          const error = setupSent
+            ? new TranscriptionSessionError(
+                'provider-error',
+                this.provider,
+                'The Gemini Live WebSocket opened, but the setup response did not arrive within 10 seconds.'
+              )
+            : new TranscriptionSessionError(
+                'connection-failed',
+                this.provider,
+                'The Gemini Live WebSocket did not open within 10 seconds.'
+              );
+          complete(() => reject(error));
+        }, CONNECTION_TIMEOUT_MS);
+      };
+      scheduleTimeout();
 
       socket.onopen = () => {
         if (operationId !== this.operationId) {
@@ -403,78 +444,79 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
           return;
         }
         setupSent = true;
+        scheduleTimeout();
         socket.send(JSON.stringify(createSetupMessage(this.options)));
       };
       socket.onmessage = (event) => {
-        const message = this.parseServerMessage(event.data);
-        if (!message) return;
-        const providerError = this.providerErrorFromMessage(message);
-        if (providerError) {
-          complete(() => reject(providerError));
-          return;
-        }
-        if (setupSent && message.setupComplete !== undefined) {
-          complete(resolve);
-        }
+        void this.parseServerMessage(event.data).then((message) => {
+          if (settled || !message) return;
+          const providerError = this.providerErrorFromMessage(message);
+          if (providerError) {
+            complete(() => reject(providerError));
+            return;
+          }
+          if (setupSent && message.setupComplete !== undefined) {
+            complete(resolve);
+          }
+        });
       };
       socket.onerror = () => {
-        complete(() =>
-          reject(
-            new TranscriptionSessionError(
-              'connection-failed',
-              this.provider,
-              'The Gemini Live WebSocket connection failed.'
+        if (settled || closeGraceTimer) return;
+        closeGraceTimer = setTimeout(() => {
+          complete(() =>
+            reject(
+              new TranscriptionSessionError(
+                'connection-failed',
+                this.provider,
+                'The Gemini Live WebSocket connection failed before the browser received close details.'
+              )
             )
-          )
-        );
+          );
+        }, WEBSOCKET_CLOSE_GRACE_MS);
       };
       socket.onclose = (event) => {
-        const code =
-          event.code === 1008 ? 'authentication-failed' : 'connection-failed';
-        complete(() =>
-          reject(
-            new TranscriptionSessionError(
-              code,
-              this.provider,
-              `Gemini Live closed before setup completed (code ${event.code}).`
-            )
-          )
-        );
+        complete(() => reject(errorFromCloseEvent(event, 'setup')));
       };
     });
   }
 
   private attachRuntimeListeners(socket: WebSocket): void {
     socket.onopen = null;
-    socket.onmessage = (event) => this.handleServerMessage(event.data);
-    socket.onerror = () => {
-      if (this.state === 'listening') {
-        this.handleConnectionFailure(
-          new TranscriptionSessionError(
-            'connection-failed',
-            this.provider,
-            'The Gemini Live WebSocket connection failed.'
-          )
-        );
-      }
+    socket.onmessage = (event) => {
+      void this.handleServerMessage(event.data);
     };
+    socket.onerror = () => this.scheduleSocketErrorFallback(socket);
     socket.onclose = (event) => {
+      this.clearSocketErrorFallback();
       if (this.state === 'stopping') {
         this.completeStopFinalization();
         return;
       }
       if (this.state === 'listening') {
-        const code =
-          event.code === 1008 ? 'authentication-failed' : 'connection-failed';
-        this.handleConnectionFailure(
-          new TranscriptionSessionError(
-            code,
-            this.provider,
-            `The Gemini Live connection closed unexpectedly (code ${event.code}).`
-          )
-        );
+        this.handleConnectionFailure(errorFromCloseEvent(event, 'runtime'));
       }
     };
+  }
+
+  private scheduleSocketErrorFallback(socket: WebSocket): void {
+    if (this.socketErrorFallbackTimer) return;
+    this.socketErrorFallbackTimer = setTimeout(() => {
+      this.socketErrorFallbackTimer = null;
+      if (this.socket !== socket || this.state !== 'listening') return;
+      this.handleConnectionFailure(
+        new TranscriptionSessionError(
+          'connection-failed',
+          this.provider,
+          'The Gemini Live WebSocket connection failed before the browser received close details.'
+        )
+      );
+    }, WEBSOCKET_CLOSE_GRACE_MS);
+  }
+
+  private clearSocketErrorFallback(): void {
+    if (!this.socketErrorFallbackTimer) return;
+    clearTimeout(this.socketErrorFallbackTimer);
+    this.socketErrorFallbackTimer = null;
   }
 
   private sendAudioChunk(socket: WebSocket, pcm16: Uint8Array): void {
@@ -497,8 +539,8 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
     );
   }
 
-  private handleServerMessage(raw: unknown): void {
-    const message = this.parseServerMessage(raw);
+  private async handleServerMessage(raw: unknown): Promise<void> {
+    const message = await this.parseServerMessage(raw);
     if (!message) return;
 
     const providerError = this.providerErrorFromMessage(message);
@@ -526,10 +568,19 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
     }
   }
 
-  private parseServerMessage(raw: unknown): GeminiLiveServerMessage | null {
-    if (typeof raw !== 'string') return null;
+  private async parseServerMessage(
+    raw: unknown
+  ): Promise<GeminiLiveServerMessage | null> {
     try {
-      return JSON.parse(raw) as GeminiLiveServerMessage;
+      const json =
+        typeof raw === 'string'
+          ? raw
+          : typeof Blob !== 'undefined' && raw instanceof Blob
+            ? await raw.text()
+            : Object.prototype.toString.call(raw) === '[object ArrayBuffer]'
+              ? new TextDecoder().decode(raw as ArrayBuffer)
+              : null;
+      return json ? (JSON.parse(json) as GeminiLiveServerMessage) : null;
     } catch {
       return null;
     }
@@ -604,6 +655,7 @@ export class GeminiLiveTranscriptionSession extends BaseRealtimeTranscriptionSes
   private cleanupResources(): void {
     this.connectionCancel?.();
     this.connectionCancel = null;
+    this.clearSocketErrorFallback();
     this.completeStopFinalization();
     this.activeUtteranceId = null;
     const socket = this.socket;

--- a/packages/transcription/src/support.ts
+++ b/packages/transcription/src/support.ts
@@ -10,6 +10,7 @@ interface BrowserGlobal {
   webkitSpeechRecognition?: unknown;
   navigator?: TranscriptionNavigator;
   RTCPeerConnection?: unknown;
+  WebSocket?: unknown;
   AudioContext?: unknown;
   webkitAudioContext?: unknown;
   AudioWorkletNode?: unknown;
@@ -41,6 +42,16 @@ export function isTranscriptionProviderSupported(
         browser.AudioWorkletNode &&
         browser.Worker &&
         browser.navigator?.gpu
+    );
+  }
+
+  if (provider === 'gemini-live') {
+    return Boolean(
+      browser.isSecureContext !== false &&
+        browser.WebSocket &&
+        browser.navigator?.mediaDevices?.getUserMedia &&
+        (browser.AudioContext ?? browser.webkitAudioContext) &&
+        browser.AudioWorkletNode
     );
   }
 

--- a/packages/transcription/src/types.ts
+++ b/packages/transcription/src/types.ts
@@ -1,6 +1,7 @@
 export type TranscriptionProviderName =
   | 'web-speech'
   | 'openai-realtime'
+  | 'gemini-live'
   | 'local-whisper';
 
 export interface TranscriptUpdate {
@@ -41,6 +42,7 @@ export type TranscriptionErrorCode =
   | 'no-speech'
   | 'authentication-failed'
   | 'client-secret-failed'
+  | 'ephemeral-token-failed'
   | 'connection-failed'
   | 'provider-error'
   | 'invalid-configuration'
@@ -61,6 +63,19 @@ export type OpenAIRealtimeAuth =
       getApiKey: () => Promise<string>;
       acknowledgeBrowserKeyRisk: true;
     };
+
+export type GeminiLiveAuth =
+  | {
+      type: 'ephemeral-token';
+      getEphemeralToken: () => Promise<string>;
+    }
+  | {
+      type: 'browser-api-key';
+      getApiKey: () => Promise<string>;
+      acknowledgeBrowserKeyRisk: true;
+    };
+
+export type GeminiTranscriptionMode = 'verbatim' | 'smart';
 
 export type TranscriptionDelay =
   | 'minimal'
@@ -84,6 +99,32 @@ export interface OpenAIRealtimeTranscriptionOptions {
   keywords?: string[];
   prompt?: string;
   delay?: TranscriptionDelay;
+}
+
+export interface GeminiLiveTranscriptionOptions {
+  provider: 'gemini-live';
+  auth: GeminiLiveAuth;
+
+  /**
+   * Optional BCP 47 language hints. An empty or omitted list enables automatic
+   * language detection, including code-switching within a session.
+   */
+  languages?: string[];
+
+  /**
+   * Terms used to bias recognition toward names, jargon, and other uncommon
+   * vocabulary. Gemini accepts up to 1,000 terms; Google recommends using no
+   * more than 100 for best results.
+   */
+  keywords?: string[];
+
+  /**
+   * "verbatim" preserves fillers and false starts. "smart" cleans and formats
+   * the transcript for readability.
+   *
+   * Default: "verbatim"
+   */
+  mode?: GeminiTranscriptionMode;
 }
 
 export interface LocalWhisperTranscriptionOptions {
@@ -127,6 +168,7 @@ export interface LocalWhisperTranscriptionOptions {
 export type RealtimeTranscriptionOptions =
   | WebSpeechTranscriptionOptions
   | OpenAIRealtimeTranscriptionOptions
+  | GeminiLiveTranscriptionOptions
   | LocalWhisperTranscriptionOptions;
 
 export interface RealtimeTranscriptionSession {

--- a/packages/transcription/tests/BrowserPcmStreamCapture.test.ts
+++ b/packages/transcription/tests/BrowserPcmStreamCapture.test.ts
@@ -1,0 +1,120 @@
+import {
+  BrowserPcmStreamCapture,
+  float32ToPcm16LittleEndian,
+} from '../src/providers/BrowserPcmStreamCapture';
+
+class MockAudioNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockAudioWorkletNode extends MockAudioNode {
+  static instances: MockAudioWorkletNode[] = [];
+
+  readonly port = {
+    onmessage: null as ((event: MessageEvent<unknown>) => void) | null,
+    postMessage: vi.fn((message: unknown) => {
+      if (
+        typeof message === 'object' &&
+        message !== null &&
+        'type' in message &&
+        message.type === 'flush'
+      ) {
+        this.port.onmessage?.(
+          new MessageEvent('message', { data: { type: 'flushed' } })
+        );
+      }
+    }),
+  };
+
+  constructor() {
+    super();
+    MockAudioWorkletNode.instances.push(this);
+  }
+}
+
+class MockAudioContext {
+  readonly sampleRate = 48_000;
+  state: AudioContextState = 'running';
+  readonly destination = new MockAudioNode();
+  readonly audioWorklet = { addModule: vi.fn(async () => undefined) };
+  readonly sourceNode = new MockAudioNode();
+  readonly gainNode = Object.assign(new MockAudioNode(), {
+    gain: { value: 1 },
+  });
+
+  createMediaStreamSource = vi.fn(() => this.sourceNode);
+  createGain = vi.fn(() => this.gainNode);
+  resume = vi.fn(async () => {
+    this.state = 'running';
+  });
+  close = vi.fn(async () => {
+    this.state = 'closed';
+  });
+}
+
+class MockBlob {
+  constructor(readonly parts: BlobPart[]) {}
+}
+
+const createObjectURL = vi.fn((_blob: Blob) => 'blob:stream-worklet');
+const revokeObjectURL = vi.fn((_url: string) => undefined);
+
+describe('BrowserPcmStreamCapture', () => {
+  beforeEach(() => {
+    MockAudioWorkletNode.instances = [];
+    vi.stubGlobal('AudioContext', MockAudioContext);
+    vi.stubGlobal('AudioWorkletNode', MockAudioWorkletNode);
+    vi.stubGlobal('Blob', MockBlob);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
+  it('converts normalized float samples to signed little-endian PCM16', () => {
+    const output = float32ToPcm16LittleEndian(
+      new Float32Array([-1, -0.5, 0, 0.5, 1])
+    );
+    const view = new DataView(output.buffer);
+
+    expect(
+      Array.from({ length: 5 }, (_, index) => view.getInt16(index * 2, true))
+    ).toEqual([-32_768, -16_384, 0, 16_384, 32_767]);
+  });
+
+  it('resamples worklet chunks to 16kHz and emits PCM16 bytes', async () => {
+    const track = { stop: vi.fn() };
+    const stream = {
+      getTracks: () => [track],
+    } as unknown as MediaStream;
+    const onChunk = vi.fn();
+    const capture = new BrowserPcmStreamCapture(stream, { onChunk });
+
+    await capture.start();
+    const worklet = MockAudioWorkletNode.instances[0];
+    worklet?.port.onmessage?.(
+      new MessageEvent('message', {
+        data: new Float32Array(4_800).fill(0.5),
+      })
+    );
+
+    expect(onChunk).toHaveBeenCalledOnce();
+    expect(onChunk.mock.calls[0]?.[0]).toBeInstanceOf(Uint8Array);
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(3_200);
+
+    await capture.stop();
+    expect(worklet?.port.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+    expect(track.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/transcription/tests/GeminiLiveTranscriptionSession.test.ts
+++ b/packages/transcription/tests/GeminiLiveTranscriptionSession.test.ts
@@ -1,0 +1,398 @@
+import {
+  createRealtimeTranscriptionSession,
+  isTranscriptionProviderSupported,
+  type RealtimeTranscriptionSession,
+  type TranscriptUpdate,
+} from '../src';
+
+class MockMediaStreamTrack {
+  stop = vi.fn();
+}
+
+class MockMediaStream {
+  readonly track = new MockMediaStreamTrack();
+
+  getTracks(): MediaStreamTrack[] {
+    return [this.track as unknown as MediaStreamTrack];
+  }
+}
+
+class MockAudioNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockAudioWorkletNode extends MockAudioNode {
+  static instances: MockAudioWorkletNode[] = [];
+
+  readonly port = {
+    onmessage: null as ((event: MessageEvent<unknown>) => void) | null,
+    postMessage: vi.fn((message: unknown) => {
+      if (
+        typeof message === 'object' &&
+        message !== null &&
+        'type' in message &&
+        message.type === 'flush'
+      ) {
+        this.port.onmessage?.(
+          new MessageEvent('message', { data: { type: 'flushed' } })
+        );
+      }
+    }),
+  };
+
+  constructor() {
+    super();
+    MockAudioWorkletNode.instances.push(this);
+  }
+}
+
+class MockAudioContext {
+  readonly sampleRate = 16_000;
+  state: AudioContextState = 'running';
+  readonly destination = new MockAudioNode();
+  readonly audioWorklet = { addModule: vi.fn(async () => undefined) };
+  readonly sourceNode = new MockAudioNode();
+  readonly gainNode = Object.assign(new MockAudioNode(), {
+    gain: { value: 1 },
+  });
+
+  createMediaStreamSource = vi.fn(() => this.sourceNode);
+  createGain = vi.fn(() => this.gainNode);
+  resume = vi.fn(async () => {
+    this.state = 'running';
+  });
+  close = vi.fn(async () => {
+    this.state = 'closed';
+  });
+}
+
+class MockBlob {
+  constructor(readonly parts: BlobPart[]) {}
+}
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly sent: string[] = [];
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  emit(message: Record<string, unknown>): void {
+    this.onmessage?.(
+      new MessageEvent('message', { data: JSON.stringify(message) })
+    );
+  }
+}
+
+const createObjectURL = vi.fn((_blob: Blob) => 'blob:stream-worklet');
+const revokeObjectURL = vi.fn((_url: string) => undefined);
+let activeSessions: RealtimeTranscriptionSession[] = [];
+
+function trackSession(
+  session: RealtimeTranscriptionSession
+): RealtimeTranscriptionSession {
+  activeSessions.push(session);
+  return session;
+}
+
+function installBrowserMocks(): MockMediaStream {
+  const stream = new MockMediaStream();
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia: vi.fn(async () => stream) },
+  });
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  vi.stubGlobal('AudioContext', MockAudioContext);
+  vi.stubGlobal('AudioWorkletNode', MockAudioWorkletNode);
+  vi.stubGlobal('Blob', MockBlob);
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: createObjectURL,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: revokeObjectURL,
+  });
+  return stream;
+}
+
+async function openSession(socket: MockWebSocket): Promise<void> {
+  socket.open();
+  socket.emit({ setupComplete: {} });
+  await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+}
+
+describe('GeminiLiveTranscriptionSession', () => {
+  beforeEach(() => {
+    activeSessions = [];
+    MockWebSocket.instances = [];
+    MockAudioWorkletNode.instances = [];
+    installBrowserMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(activeSessions.map((session) => session.dispose()));
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'mediaDevices');
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
+  it('connects to Gemini Live with a constrained transcription setup', async () => {
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'key with spaces',
+          acknowledgeBrowserKeyRisk: true,
+        },
+        languages: ['ja-JP', 'en-US'],
+        keywords: ['AITuber OnAir'],
+        mode: 'smart',
+      })
+    );
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    await openSession(socket);
+    await startPromise;
+
+    expect(socket.url).toContain('BidiGenerateContent?key=key%20with%20spaces');
+    expect(JSON.parse(socket.sent[0] ?? '')).toEqual({
+      setup: {
+        model: 'models/gemini-3.5-transcribe-live',
+        generationConfig: { responseModalities: ['TEXT'] },
+        inputAudioTranscription: {
+          languageCodes: ['ja-JP', 'en-US'],
+          customVocabulary: ['AITuber OnAir'],
+          mode: 'SMART',
+        },
+      },
+    });
+    expect(session.state).toBe('listening');
+    expect(session.capabilities).toEqual({
+      interimResults: true,
+      multipleLanguages: true,
+      keywords: true,
+      configurableDelay: false,
+    });
+  });
+
+  it('maps interim and final server snapshots to one utterance', async () => {
+    const updates: TranscriptUpdate[] = [];
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+    session.onTranscript((update) => updates.push(update));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    await openSession(socket);
+    await startPromise;
+
+    socket.emit({
+      serverContent: {
+        interimInputTranscription: { text: 'こんにちは' },
+      },
+    });
+    socket.emit({
+      serverContent: { inputTranscription: { text: 'こんにちは。' } },
+    });
+
+    expect(updates).toEqual([
+      {
+        utteranceId: 'gemini-live:1',
+        text: 'こんにちは',
+        isFinal: false,
+      },
+      {
+        utteranceId: 'gemini-live:1',
+        text: 'こんにちは。',
+        isFinal: true,
+      },
+    ]);
+  });
+
+  it('streams captured audio as base64 PCM16 and finalizes on stop', async () => {
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    await openSession(socket);
+    await startPromise;
+
+    const worklet = MockAudioWorkletNode.instances[0];
+    worklet?.port.onmessage?.(
+      new MessageEvent('message', {
+        data: new Float32Array(1_600).fill(0.5),
+      })
+    );
+    const audioMessage = JSON.parse(socket.sent[1] ?? '');
+    expect(audioMessage.realtimeInput.audio.mimeType).toBe(
+      'audio/pcm;rate=16000'
+    );
+    expect(atob(audioMessage.realtimeInput.audio.data)).toHaveLength(3_200);
+
+    await session.stop();
+    expect(JSON.parse(socket.sent.at(-1) ?? '')).toEqual({
+      realtimeInput: { audioStreamEnd: true },
+    });
+    expect(session.state).toBe('idle');
+  });
+
+  it('waits for the active final transcript before closing', async () => {
+    const updates: TranscriptUpdate[] = [];
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+    session.onTranscript((update) => updates.push(update));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    await openSession(socket);
+    await startPromise;
+    socket.emit({
+      serverContent: { interimInputTranscription: { text: 'active' } },
+    });
+
+    const stopPromise = session.stop();
+    await vi.waitFor(() =>
+      expect(
+        socket.sent.some((value) => value.includes('audioStreamEnd'))
+      ).toBe(true)
+    );
+    expect(session.state).toBe('stopping');
+    socket.emit({
+      serverContent: { inputTranscription: { text: 'active final' } },
+    });
+    await stopPromise;
+
+    expect(updates.at(-1)).toEqual({
+      utteranceId: 'gemini-live:1',
+      text: 'active final',
+      isFinal: true,
+    });
+    expect(session.state).toBe('idle');
+  });
+
+  it('cancels an in-flight WebSocket setup when stopped', async () => {
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+
+    await session.stop();
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(session.state).toBe('idle');
+    expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED);
+  });
+
+  it('uses the constrained endpoint for ephemeral tokens', async () => {
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'ephemeral-token',
+          getEphemeralToken: async () => 'auth_tokens/token-value',
+        },
+      })
+    );
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    expect(socket.url).toContain(
+      'BidiGenerateContentConstrained?access_token=auth_tokens%2Ftoken-value'
+    );
+    await openSession(socket);
+    await startPromise;
+  });
+
+  it('reports support only when WebSocket and AudioWorklet are available', () => {
+    expect(isTranscriptionProviderSupported('gemini-live')).toBe(true);
+
+    Reflect.deleteProperty(globalThis, 'AudioWorkletNode');
+
+    expect(isTranscriptionProviderSupported('gemini-live')).toBe(false);
+  });
+
+  it('rejects more than 1,000 custom vocabulary terms', () => {
+    expect(() =>
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'ephemeral-token',
+          getEphemeralToken: async () => 'token',
+        },
+        keywords: Array.from({ length: 1_001 }, (_, index) => `term-${index}`),
+      })
+    ).toThrow('at most 1,000 keywords');
+  });
+});

--- a/packages/transcription/tests/GeminiLiveTranscriptionSession.test.ts
+++ b/packages/transcription/tests/GeminiLiveTranscriptionSession.test.ts
@@ -69,6 +69,12 @@ class MockAudioContext {
 
 class MockBlob {
   constructor(readonly parts: BlobPart[]) {}
+
+  async text(): Promise<string> {
+    return this.parts
+      .map((part) => (typeof part === 'string' ? part : ''))
+      .join('');
+  }
 }
 
 class MockWebSocket {
@@ -103,9 +109,20 @@ class MockWebSocket {
   }
 
   emit(message: Record<string, unknown>): void {
-    this.onmessage?.(
-      new MessageEvent('message', { data: JSON.stringify(message) })
-    );
+    this.emitRaw(JSON.stringify(message));
+  }
+
+  emitRaw(data: unknown): void {
+    this.onmessage?.(new MessageEvent('message', { data }));
+  }
+
+  fail(): void {
+    this.onerror?.(new Event('error'));
+  }
+
+  emitClose(code: number, reason: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close', { code, reason, wasClean: false }));
   }
 }
 
@@ -236,18 +253,63 @@ describe('GeminiLiveTranscriptionSession', () => {
       serverContent: { inputTranscription: { text: 'こんにちは。' } },
     });
 
-    expect(updates).toEqual([
-      {
-        utteranceId: 'gemini-live:1',
-        text: 'こんにちは',
-        isFinal: false,
-      },
-      {
-        utteranceId: 'gemini-live:1',
-        text: 'こんにちは。',
-        isFinal: true,
-      },
-    ]);
+    await vi.waitFor(() =>
+      expect(updates).toEqual([
+        {
+          utteranceId: 'gemini-live:1',
+          text: 'こんにちは',
+          isFinal: false,
+        },
+        {
+          utteranceId: 'gemini-live:1',
+          text: 'こんにちは。',
+          isFinal: true,
+        },
+      ])
+    );
+  });
+
+  it('accepts Blob setup messages and ArrayBuffer transcript messages', async () => {
+    const updates: TranscriptUpdate[] = [];
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+    session.onTranscript((update) => updates.push(update));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    socket.open();
+    socket.emitRaw(
+      new Blob([JSON.stringify({ setupComplete: {} })]) as unknown as Blob
+    );
+    await startPromise;
+
+    socket.emitRaw(
+      new TextEncoder().encode(
+        JSON.stringify({
+          serverContent: { inputTranscription: { text: 'binary response' } },
+        })
+      ).buffer
+    );
+
+    await vi.waitFor(() =>
+      expect(updates).toEqual([
+        {
+          utteranceId: 'gemini-live:1',
+          text: 'binary response',
+          isFinal: true,
+        },
+      ])
+    );
   });
 
   it('streams captured audio as base64 PCM16 and finalizes on stop', async () => {
@@ -373,6 +435,103 @@ describe('GeminiLiveTranscriptionSession', () => {
     );
     await openSession(socket);
     await startPromise;
+  });
+
+  it('preserves a policy close reason without assuming authentication failed', async () => {
+    const errors: Array<{ code: string; message: string }> = [];
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+    session.onError((error) => errors.push(error));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    socket.open();
+    socket.fail();
+    socket.emitClose(
+      1008,
+      'Operation is not implemented, or supported, or enabled.'
+    );
+
+    await expect(startPromise).rejects.toMatchObject({
+      code: 'provider-error',
+      message: expect.stringContaining(
+        'code 1008: Operation is not implemented, or supported, or enabled.'
+      ),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      code: 'provider-error',
+      message:
+        'Gemini Live closed before setup completed (code 1008: Operation is not implemented, or supported, or enabled.).',
+    });
+  });
+
+  it('classifies a close reason that explicitly identifies an invalid API key', async () => {
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    socket.open();
+    socket.emitClose(1008, 'API key not valid. Please pass a valid API key.');
+
+    await expect(startPromise).rejects.toMatchObject({
+      code: 'authentication-failed',
+      message: expect.stringContaining('API key not valid'),
+    });
+  });
+
+  it('preserves close details after a session starts listening', async () => {
+    const errors: Array<{ code: string; message: string }> = [];
+    const session = trackSession(
+      createRealtimeTranscriptionSession({
+        provider: 'gemini-live',
+        auth: {
+          type: 'browser-api-key',
+          getApiKey: async () => 'test-key',
+          acknowledgeBrowserKeyRisk: true,
+        },
+      })
+    );
+    session.onError((error) => errors.push(error));
+
+    const startPromise = session.start();
+    await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected a Gemini Live WebSocket.');
+    await openSession(socket);
+    await startPromise;
+
+    socket.fail();
+    socket.emitClose(1011, 'Temporary server failure.');
+
+    expect(session.state).toBe('error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      code: 'connection-failed',
+      message:
+        'The Gemini Live connection closed unexpectedly (code 1011: Temporary server failure.).',
+    });
   });
 
   it('reports support only when WebSocket and AudioWorklet are available', () => {


### PR DESCRIPTION
## Summary

- add a browser-based Gemini 3.5 Transcribe Live provider over the Gemini Live WebSocket API
- support ephemeral tokens and explicitly acknowledged browser BYOK authentication
- stream 16 kHz PCM16 microphone audio with interim and final transcript events
- expose language hints, custom vocabulary, and verbatim or smart transcription modes
- update the browser example and English/Japanese documentation with Gemini controls and setup guidance
- handle text, Blob, and ArrayBuffer WebSocket responses while preserving close details for diagnostics
- prepare the @aituber-onair/transcription 0.0.3 patch release, including the changelog and root lockfile

## Testing

- npm ci
- npm run fmt
- npm run lint
- npm run test
- npm run build
- manually verified the browser example against the live Gemini transcription service

## Security

Production browser integrations should use ephemeral tokens. Browser API-key mode requires explicit acknowledgement and is intended for end-user BYOK testing.