### PR TITLE
feat(chat): add Gemini 3.8 Flash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7138,7 +7138,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "devDependencies": {
-                "@aituber-onair/chat": "^0.53.0",
+                "@aituber-onair/chat": "^0.54.0",
                 "@biomejs/biome": "1.9.4",
                 "@types/node": "^18.15.0",
                 "@vitest/coverage-v8": "^1.3.1",
@@ -7147,7 +7147,7 @@
                 "vitest": "^1.3.1"
             },
             "peerDependencies": {
-                "@aituber-onair/chat": "^0.53.0"
+                "@aituber-onair/chat": "^0.54.0"
             },
             "peerDependenciesMeta": {
                 "@aituber-onair/chat": {
@@ -7693,7 +7693,7 @@
         },
         "packages/chat": {
             "name": "@aituber-onair/chat",
-            "version": "0.53.0",
+            "version": "0.54.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -8051,7 +8051,7 @@
             "version": "0.26.12",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.53.0",
+                "@aituber-onair/chat": "^0.54.0",
                 "@aituber-onair/voice": "^0.20.0"
             },
             "devDependencies": {
@@ -8612,7 +8612,7 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@aituber-onair/chat": "^0.53.0"
+                "@aituber-onair/chat": "^0.54.0"
             },
             "devDependencies": {
                 "@aituber-onair/kizuna": "^0.0.3",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@aituber-onair/chat": "^0.53.0"
+    "@aituber-onair/chat": "^0.54.0"
   },
   "peerDependenciesMeta": {
     "@aituber-onair/chat": {
@@ -66,7 +66,7 @@
     }
   },
   "devDependencies": {
-    "@aituber-onair/chat": "^0.53.0",
+    "@aituber-onair/chat": "^0.54.0",
     "@biomejs/biome": "1.9.4",
     "@types/node": "^18.15.0",
     "@vitest/coverage-v8": "^1.3.1",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @aituber-onair/chat
 
+## 0.54.0
+
+### Minor Changes
+
+- Added native Gemini 3.8 Flash (`gemini-3.8-flash`) as an explicit stable,
+  vision-capable model with streaming and tool/function-calling support. It
+  exposes `low`, `medium`, and `high` reasoning efforts and defaults to `low`
+  for responsive chat because the model does not support `minimal`. Gemini 3.1
+  Flash-Lite remains the default Gemini model.
+
+### Patch Changes
+
+- Updated the React basic model selector, capability metadata tests, transport
+  tests, and English/Japanese documentation for Gemini 3.8 Flash.
+
 ## 0.53.0
 
 ### Minor Changes

--- a/packages/chat/README.ja.md
+++ b/packages/chat/README.ja.md
@@ -607,9 +607,9 @@ const geminiService = ChatServiceFactory.createChatService('gemini', {
 
 `gemini-3.1-flash-lite` は既定の Flash-Lite モデルとして維持します。
 最新の安定版・低遅延 Flash-Lite として `gemini-3.5-flash-lite` を利用できます。
-より高度なコーディング・エージェント・マルチモーダル用途向けの安定版として
-`gemini-3.7-flash` を明示的に選択でき、`gemini-3.6-flash` と
-`gemini-3.5-flash` も引き続き利用できます。
+低遅延のコーディング・エージェント・マルチモーダル用途向けの最新安定版として
+`gemini-3.8-flash` を明示的に選択できます。`gemini-3.7-flash`、
+`gemini-3.6-flash`、`gemini-3.5-flash` も引き続き利用できます。
 `gemini-3.1-flash-lite-preview`、`gemini-3-pro-preview`、
 `gemini-2.5-flash-lite-preview-06-17` などの preview / deprecated
 モデルは後方互換のため明示的な model string では利用できますが、本番用途では
@@ -622,7 +622,8 @@ Gemini 3 モデルでは `reasoning_effort` を指定できます。この値は
 - `minimal` 対応の Flash / Flash-Lite は `minimal`, `low`, `medium`, `high`
   を公開し、既定値は `minimal` です。
 - `minimal` 非対応モデルは `low`, `medium`, `high` を公開し、既定値は `low`
-  です。現在該当するのは Gemini 3.7 Flash と Gemini 3 Pro です。
+  です。現在該当するのは Gemini 3.8 Flash、Gemini 3.7 Flash、
+  Gemini 3 Pro です。
 
 これにより各モデルで利用可能な最小の thinking level を使い、短い出力上限を
 hidden thinking が使い切るリスクを抑えます。Gemini 2.5 は
@@ -1288,7 +1289,7 @@ vision、JSON mode、reasoning 設定を使うべきかを provider 固有ロジ
 
 - **OpenAI**: GPT-5.6（Sol/Terra/Luna）、GPT-5.5、GPT-5.4 Pro、GPT-5.4、GPT-5.4 Mini、GPT-5.4 Nano、GPT-5.1、GPT-5（Nano/Mini/Standard）、GPT-4.1(miniとnanoを含む), GPT-4, GPT-4o-mini, O3-mini, o1, o1-miniのモデルをサポート
 - **OpenAI-Compatible**: OpenAI互換 endpoint 経由で任意のローカル/セルフホスト model ID を利用できます。vision 対応可否は endpoint ごとに差があるため、原則 `unknown` 扱いです
-- **Gemini**: Gemini 3.7 Flash、Gemini 3.6 Flash、Gemini 3.5 Flash、Gemini 3.5 Flash-Lite、Gemini 3.1 Flash-Lite、Gemini 3.1 Pro Preview、Gemini 3 Flash Preview、Gemini 2.5 Pro、Gemini 2.5 Flash、Gemini 2.5 Flash Lite、Gemma 4 31B IT、Gemma 4 26B A4B IT などの推奨モデルをサポート。`minimal` 非対応の Gemini 3.7 Flash と Gemini 3 Pro は low thinking、その他の Gemini 3 Flash は minimal thinking をチャット用途向けの既定値にします。Gemini 3.1 Flash-Lite Preview、Gemini 3 Pro Preview、Gemini 2.5 Flash Lite Preview などの lifecycle 上 deprecated なモデルは明示指定用に export を残しています
+- **Gemini**: Gemini 3.8 Flash、Gemini 3.7 Flash、Gemini 3.6 Flash、Gemini 3.5 Flash、Gemini 3.5 Flash-Lite、Gemini 3.1 Flash-Lite、Gemini 3.1 Pro Preview、Gemini 3 Flash Preview、Gemini 2.5 Pro、Gemini 2.5 Flash、Gemini 2.5 Flash Lite、Gemma 4 31B IT、Gemma 4 26B A4B IT などの推奨モデルをサポート。Gemini 3 はチャット用途向けに利用可能な最小の thinking を既定値にします。`minimal` 非対応の Gemini 3.8 Flash、Gemini 3.7 Flash、Gemini 3 Pro は `low`、その他の Gemini 3 Flash は `minimal` を使います。Gemini 3.1 Flash-Lite Preview、Gemini 3 Pro Preview、Gemini 2.5 Flash Lite Preview などの lifecycle 上 deprecated なモデルは明示指定用に export を残しています
 - **Claude**: Claude Fable 5, Claude Opus 5, Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5 をサポート。調整可能な`reasoning_effort`は対応モデルに限り`output_config.effort`として送信し、refusal metadataは終端completionとして保持します
 - **OpenRouter**: OpenAI/Claude/Gemini/Z.ai/xAI/Kimi/DeepSeek/Qwen/Kwaipilotのキュレーション済み一覧をサポート。GLM-5.3、Qwen3.8 Flash、DeepSeek V4 Flash Vision Exp、Claude Sonnet 5/Opus 4.8、Kimi K2.6も含みます
 - **Z.ai**: GLM-5.3/GLM-5.2/GLM-5.1/GLM-5/GLM-5-TurboとGLM-4.7/4.6のテキストモデル、GLM-5.3-Flash/GLM-5V-Turbo/GLM-4.6V系のビジョンモデルをサポート。GLM-5.3はthinking必須で`low`、GLM-5.2は`none`を既定値にします

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -623,9 +623,10 @@ const geminiService = ChatServiceFactory.createChatService('gemini', {
 
 `gemini-3.1-flash-lite` remains the default Flash-Lite model.
 `gemini-3.5-flash-lite` is available as the latest stable, low-latency
-Flash-Lite option. `gemini-3.7-flash` is available as an explicit stable option
-for stronger coding, agentic, and multimodal tasks, while `gemini-3.6-flash`
-remains available for compatibility. Deprecated
+Flash-Lite option. `gemini-3.8-flash` is available as the newest explicit stable
+Flash option for low-latency coding, agentic, and multimodal tasks.
+`gemini-3.7-flash` and `gemini-3.6-flash` remain available for compatibility.
+Deprecated
 preview and shutdown-scheduled models such as `gemini-3.1-flash-lite-preview`,
 `gemini-3-pro-preview`, and `gemini-2.5-flash-lite-preview-06-17` remain usable
 by explicit model string for backward compatibility, but are no longer
@@ -639,7 +640,8 @@ Gemini 3 models accept `reasoning_effort`, which maps to Gemini
 - Flash / Flash-Lite models that support `minimal` expose `minimal`, `low`,
   `medium`, and `high`, and default to `minimal`.
 - Models that do not support `minimal` expose `low`, `medium`, and `high`, and
-  default to `low`. Current instances are Gemini 3.7 Flash and Gemini 3 Pro.
+  default to `low`. Current instances are Gemini 3.8 Flash, Gemini 3.7 Flash,
+  and Gemini 3 Pro.
 
 This uses the lowest supported thinking level for chat and reduces the risk of
 hidden thinking exhausting short output limits. Gemini 2.5 uses
@@ -1311,7 +1313,7 @@ Currently, the following AI providers are built-in:
 
 - **OpenAI**: Supports models like GPT-5.6 (Sol/Terra/Luna), GPT-5.5, GPT-5.4 Pro, GPT-5.4, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5.1, GPT-5 (Nano/Mini/Standard), GPT-4.1 (including mini and nano), GPT-4, GPT-4o-mini, O3-mini, o1, o1-mini
 - **OpenAI-Compatible**: Supports arbitrary local/self-hosted model IDs via OpenAI-compatible endpoints. Vision capability is treated as `unknown` unless your app knows the endpoint-specific model catalog.
-- **Gemini**: Supports recommended models like Gemini 3.7 Flash, Gemini 3.6 Flash, Gemini 3.5 Flash, Gemini 3.5 Flash-Lite, Gemini 3.1 Flash-Lite, Gemini 3.1 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite, Gemma 4 31B IT, and Gemma 4 26B A4B IT. Gemini 3.7 Flash and Gemini 3 Pro default to low thinking because they do not support minimal; other Gemini 3 Flash models default to minimal for chat-style responses. Deprecated lifecycle models such as Gemini 3.1 Flash-Lite Preview, Gemini 3 Pro Preview, and Gemini 2.5 Flash Lite Preview remain exported for explicit use.
+- **Gemini**: Supports recommended models like Gemini 3.8 Flash, Gemini 3.7 Flash, Gemini 3.6 Flash, Gemini 3.5 Flash, Gemini 3.5 Flash-Lite, Gemini 3.1 Flash-Lite, Gemini 3.1 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite, Gemma 4 31B IT, and Gemma 4 26B A4B IT. Gemini 3 models default to their lowest supported thinking level for chat-style responses. Gemini 3.8 Flash, Gemini 3.7 Flash, and Gemini 3 Pro use low because they do not support minimal; other Gemini 3 Flash models use minimal. Deprecated lifecycle models such as Gemini 3.1 Flash-Lite Preview, Gemini 3 Pro Preview, and Gemini 2.5 Flash Lite Preview remain exported for explicit use.
 - **Claude**: Supports current Claude API model IDs including Claude Fable 5, Claude Opus 5, Claude Sonnet 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, and Claude Haiku 4.5. Adjustable `reasoning_effort` is sent as `output_config.effort` only for models that support it; refusal metadata is preserved as a terminal completion.
 - **OpenRouter**: Supports a curated OpenRouter model list (OpenAI/Claude/Gemini/Z.ai/xAI/Kimi/DeepSeek/Qwen/Kwaipilot), including GLM-5.3, Qwen3.8 Flash, DeepSeek V4 Flash Vision Exp, Claude Sonnet 5/Opus 4.8, and Kimi K2.6. See the OpenRouter section for model IDs.
 - **Z.ai**: Supports GLM-5.3/GLM-5.2/GLM-5.1/GLM-5/GLM-5-Turbo and GLM-4.7/4.6 text models, plus GLM-5.3-Flash/GLM-5V-Turbo/GLM-4.6V vision models. GLM-5.3 always thinks and defaults to `low`; GLM-5.2 defaults to `none`.

--- a/packages/chat/examples/react-basic/README.md
+++ b/packages/chat/examples/react-basic/README.md
@@ -142,9 +142,9 @@ built-in model status is `available`.
 - Best for: Long context, tool use + advanced reasoning
 
 **Gemini**
-- Models: Gemini 3.7 Flash, Gemini 3.6 Flash, Gemini 3.5 Flash/Flash-Lite, Gemini 3.1 Flash-Lite, Gemini 3.1 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro/Flash/Flash Lite, Gemma 4 31B IT, Gemma 4 26B A4B IT
+- Models: Gemini 3.8 Flash, Gemini 3.7 Flash, Gemini 3.6 Flash, Gemini 3.5 Flash/Flash-Lite, Gemini 3.1 Flash-Lite, Gemini 3.1 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro/Flash/Flash Lite, Gemma 4 31B IT, Gemma 4 26B A4B IT
 - Vision: Supported for all listed Gemini models. Deprecated lifecycle models remain selectable with a deprecated label for explicit compatibility.
-- Reasoning Effort: Gemini 3 models default to their lowest supported effort. Minimal-capable Flash/Flash-Lite models expose Minimal/Low/Medium/High; models without Minimal expose Low/Medium/High. The latter currently includes Gemini 3.7 Flash and Gemini 3 Pro. Gemini 2.5 uses `thinkingBudget`, so this control is disabled for 2.5 models.
+- Reasoning Effort: Gemini 3 models default to their lowest supported effort. Minimal-capable Flash/Flash-Lite models expose Minimal/Low/Medium/High; models without Minimal expose Low/Medium/High. The latter currently includes Gemini 3.8 Flash, Gemini 3.7 Flash, and Gemini 3 Pro. Gemini 2.5 uses `thinkingBudget`, so this control is disabled for 2.5 models.
 - Best for: Fast responses and multimodal chat. The lowest supported thinking level keeps latency and hidden-token usage low.
 
 **OpenRouter**

--- a/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
+++ b/packages/chat/examples/react-basic/src/components/ProviderSelector.tsx
@@ -70,6 +70,7 @@ import {
   // Gemini models
   MODEL_GEMMA_4_31B_IT,
   MODEL_GEMMA_4_26B_A4B_IT,
+  MODEL_GEMINI_3_8_FLASH,
   MODEL_GEMINI_3_6_FLASH,
   MODEL_GEMINI_3_5_FLASH,
   MODEL_GEMINI_3_5_FLASH_LITE,
@@ -685,6 +686,12 @@ export const allModels: ProviderModel[] = [
   },
 
   // Gemini models
+  {
+    id: MODEL_GEMINI_3_8_FLASH,
+    name: 'Gemini 3.8 Flash',
+    provider: 'gemini',
+    default: false,
+  },
   {
     id: MODEL_GEMINI_3_7_FLASH,
     name: 'Gemini 3.7 Flash',

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/chat",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Chat and LLM API integration library for AITuber OnAir",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/chat/src/constants/gemini.ts
+++ b/packages/chat/src/constants/gemini.ts
@@ -4,6 +4,7 @@ export const ENDPOINT_GEMINI_API = 'https://generativelanguage.googleapis.com';
 // Gemini / Gemma models
 export const MODEL_GEMMA_4_31B_IT = 'gemma-4-31b-it';
 export const MODEL_GEMMA_4_26B_A4B_IT = 'gemma-4-26b-a4b-it';
+export const MODEL_GEMINI_3_8_FLASH = 'gemini-3.8-flash';
 export const MODEL_GEMINI_3_7_FLASH = 'gemini-3.7-flash';
 export const MODEL_GEMINI_3_6_FLASH = 'gemini-3.6-flash';
 export const MODEL_GEMINI_3_5_FLASH = 'gemini-3.5-flash';
@@ -24,6 +25,7 @@ export const MODEL_GEMINI_2_5_FLASH_LITE_PREVIEW_06_17 =
   'gemini-2.5-flash-lite-preview-06-17';
 
 export const GEMINI_RECOMMENDED_MODELS = [
+  MODEL_GEMINI_3_8_FLASH,
   MODEL_GEMINI_3_7_FLASH,
   MODEL_GEMINI_3_6_FLASH,
   MODEL_GEMINI_3_5_FLASH,
@@ -60,13 +62,7 @@ const GEMINI_FLASH_REASONING_EFFORTS: readonly GeminiReasoningEffort[] = [
   'high',
 ];
 
-const GEMINI_PRO_REASONING_EFFORTS: readonly GeminiReasoningEffort[] = [
-  'low',
-  'medium',
-  'high',
-];
-
-const GEMINI_3_7_FLASH_REASONING_EFFORTS: readonly GeminiReasoningEffort[] = [
+const GEMINI_LOW_MINIMUM_REASONING_EFFORTS: readonly GeminiReasoningEffort[] = [
   'low',
   'medium',
   'high',
@@ -81,7 +77,9 @@ const GEMINI_FLASH_REASONING_EFFORT_MODELS = [
   MODEL_GEMINI_3_FLASH_PREVIEW,
 ];
 
-const GEMINI_PRO_REASONING_EFFORT_MODELS = [
+const GEMINI_LOW_MINIMUM_REASONING_EFFORT_MODELS = [
+  MODEL_GEMINI_3_8_FLASH,
+  MODEL_GEMINI_3_7_FLASH,
   MODEL_GEMINI_3_1_PRO_PREVIEW,
   MODEL_GEMINI_3_PRO_PREVIEW,
 ];
@@ -93,16 +91,12 @@ const GEMINI_PRO_REASONING_EFFORT_MODELS = [
 export function getGeminiSupportedReasoningEfforts(
   model: string,
 ): readonly GeminiReasoningEffort[] {
-  if (model === MODEL_GEMINI_3_7_FLASH) {
-    return GEMINI_3_7_FLASH_REASONING_EFFORTS;
-  }
-
   if (GEMINI_FLASH_REASONING_EFFORT_MODELS.includes(model)) {
     return GEMINI_FLASH_REASONING_EFFORTS;
   }
 
-  if (GEMINI_PRO_REASONING_EFFORT_MODELS.includes(model)) {
-    return GEMINI_PRO_REASONING_EFFORTS;
+  if (GEMINI_LOW_MINIMUM_REASONING_EFFORT_MODELS.includes(model)) {
+    return GEMINI_LOW_MINIMUM_REASONING_EFFORTS;
   }
 
   return [];
@@ -113,7 +107,7 @@ export function isGeminiReasoningEffortModel(model: string): boolean {
 }
 
 /**
- * Chat-oriented default: minimal for Flash families, low for Pro families.
+ * Chat-oriented default: the lowest thinking level supported by each model.
  */
 export function getDefaultGeminiReasoningEffort(
   model: string,

--- a/packages/chat/tests/ChatServiceFactory.test.ts
+++ b/packages/chat/tests/ChatServiceFactory.test.ts
@@ -21,6 +21,7 @@ import {
   MODEL_GROK_4_6,
   MODEL_GROK_4_5,
   MODEL_GROK_4_3,
+  MODEL_GEMINI_3_8_FLASH,
   MODEL_GEMINI_3_7_FLASH,
 } from '../src/constants';
 
@@ -410,12 +411,26 @@ describe('ChatServiceFactory', () => {
     it('returns Gemini reasoning effort capabilities', () => {
       const capabilities = ChatServiceFactory.getProviderCapabilities('gemini');
 
+      expect(capabilities?.models).toContain(MODEL_GEMINI_3_8_FLASH);
+      expect(capabilities?.tools).toBe(true);
       expect(capabilities?.reasoningEffort).toEqual([
         'minimal',
         'low',
         'medium',
         'high',
       ]);
+      expect(
+        ChatServiceFactory.getProviderCapabilities(
+          'gemini',
+          MODEL_GEMINI_3_8_FLASH,
+        )?.reasoningEffort,
+      ).toEqual(['low', 'medium', 'high']);
+      expect(
+        ChatServiceFactory.getProviderCapabilities(
+          'gemini',
+          MODEL_GEMINI_3_8_FLASH,
+        )?.vision,
+      ).toBe('supported');
       expect(
         ChatServiceFactory.getProviderCapabilities(
           'gemini',

--- a/packages/chat/tests/constants/gemini.test.ts
+++ b/packages/chat/tests/constants/gemini.test.ts
@@ -5,6 +5,7 @@ import {
   MODEL_GEMINI_3_5_FLASH_LITE,
   MODEL_GEMINI_3_6_FLASH,
   MODEL_GEMINI_3_7_FLASH,
+  MODEL_GEMINI_3_8_FLASH,
   getDefaultGeminiReasoningEffort,
   getGeminiSupportedReasoningEfforts,
   isGeminiReasoningEffortModel,
@@ -25,17 +26,18 @@ describe('Gemini reasoning effort helpers', () => {
     },
   );
 
-  it('excludes unsupported minimal thinking for Gemini 3.7 Flash', () => {
-    expect(getGeminiSupportedReasoningEfforts(MODEL_GEMINI_3_7_FLASH)).toEqual([
-      'low',
-      'medium',
-      'high',
-    ]);
-    expect(getDefaultGeminiReasoningEffort(MODEL_GEMINI_3_7_FLASH)).toBe('low');
-    expect(
-      normalizeGeminiReasoningEffort(MODEL_GEMINI_3_7_FLASH, 'minimal'),
-    ).toBe('low');
-  });
+  it.each([MODEL_GEMINI_3_8_FLASH, MODEL_GEMINI_3_7_FLASH])(
+    'excludes unsupported minimal thinking for %s',
+    (model) => {
+      expect(getGeminiSupportedReasoningEfforts(model)).toEqual([
+        'low',
+        'medium',
+        'high',
+      ]);
+      expect(getDefaultGeminiReasoningEffort(model)).toBe('low');
+      expect(normalizeGeminiReasoningEffort(model, 'minimal')).toBe('low');
+    },
+  );
 
   it('uses low as the minimum supported Gemini Pro effort', () => {
     expect(

--- a/packages/chat/tests/providers/GeminiChatService.test.ts
+++ b/packages/chat/tests/providers/GeminiChatService.test.ts
@@ -9,6 +9,7 @@ import {
   MODEL_GEMMA_4_31B_IT,
   MODEL_GEMMA_4_26B_A4B_IT,
   MODEL_GEMINI_2_5_FLASH,
+  MODEL_GEMINI_3_8_FLASH,
   MODEL_GEMINI_3_7_FLASH,
   MODEL_GEMINI_3_6_FLASH,
   MODEL_GEMINI_3_5_FLASH,
@@ -65,54 +66,56 @@ describe('GeminiChatService API version selection', () => {
     });
   });
 
-  it('streams Gemini 3.7 through v1beta with low thinking and parses its response', async () => {
-    const streamPayload = {
-      candidates: [
-        {
-          content: {
-            parts: [{ text: 'Fast response' }],
+  it.each([
+    [MODEL_GEMINI_3_8_FLASH, 'gemini-3.8-flash'],
+    [MODEL_GEMINI_3_7_FLASH, 'gemini-3.7-flash'],
+  ])(
+    'streams %s through v1beta with low thinking and parses its response',
+    async (model, modelId) => {
+      const streamPayload = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'Fast response' }],
+            },
+          },
+        ],
+      };
+      const postSpy = vi
+        .spyOn(ChatServiceHttpClient, 'post')
+        .mockResolvedValue(
+          new Response(`data: ${JSON.stringify(streamPayload)}\n\n`),
+        );
+      const service = new GeminiChatService('test-key', model, model);
+
+      const completion = await service.chatOnce(messages, true);
+
+      expect(postSpy).toHaveBeenCalledTimes(1);
+      expect(postSpy.mock.calls[0][0]).toContain(
+        `/v1beta/models/${modelId}:streamGenerateContent?alt=sse&key=test-key`,
+      );
+      expect(postSpy.mock.calls[0][1]).toMatchObject({
+        generationConfig: {
+          thinkingConfig: {
+            includeThoughts: false,
+            thinkingLevel: 'LOW',
           },
         },
-      ],
-    };
-    const postSpy = vi
-      .spyOn(ChatServiceHttpClient, 'post')
-      .mockResolvedValue(
-        new Response(`data: ${JSON.stringify(streamPayload)}\n\n`),
+      });
+      expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
+        'generationConfig.temperature',
       );
-    const service = new GeminiChatService(
-      'test-key',
-      MODEL_GEMINI_3_7_FLASH,
-      MODEL_GEMINI_3_7_FLASH,
-    );
-
-    const completion = await service.chatOnce(messages, true);
-
-    expect(postSpy).toHaveBeenCalledTimes(1);
-    expect(postSpy.mock.calls[0][0]).toContain(
-      '/v1beta/models/gemini-3.7-flash:streamGenerateContent?alt=sse&key=test-key',
-    );
-    expect(postSpy.mock.calls[0][1]).toMatchObject({
-      generationConfig: {
-        thinkingConfig: {
-          includeThoughts: false,
-          thinkingLevel: 'LOW',
-        },
-      },
-    });
-    expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
-      'generationConfig.temperature',
-    );
-    expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
-      'generationConfig.topP',
-    );
-    expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
-      'generationConfig.topK',
-    );
-    expect(completion.blocks).toEqual([
-      { type: 'text', text: 'Fast response' },
-    ]);
-  });
+      expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
+        'generationConfig.topP',
+      );
+      expect(postSpy.mock.calls[0][1]).not.toHaveProperty(
+        'generationConfig.topK',
+      );
+      expect(completion.blocks).toEqual([
+        { type: 'text', text: 'Fast response' },
+      ]);
+    },
+  );
 
   it.each([
     [MODEL_GEMINI_3_6_FLASH, 'gemini-3.6-flash'],

--- a/packages/chat/tests/providers/GeminiChatServiceProvider.test.ts
+++ b/packages/chat/tests/providers/GeminiChatServiceProvider.test.ts
@@ -6,6 +6,7 @@ import type { MCPServerConfig } from '../../src/types/mcp';
 import {
   MODEL_GEMMA_4_31B_IT,
   MODEL_GEMMA_4_26B_A4B_IT,
+  MODEL_GEMINI_3_8_FLASH,
   MODEL_GEMINI_3_7_FLASH,
   MODEL_GEMINI_3_6_FLASH,
   MODEL_GEMINI_3_5_FLASH,
@@ -43,6 +44,7 @@ describe('GeminiChatServiceProvider', () => {
     it('should return array of supported models', () => {
       const models = provider.getSupportedModels();
       expect(models).toEqual([
+        MODEL_GEMINI_3_8_FLASH,
         MODEL_GEMINI_3_7_FLASH,
         MODEL_GEMINI_3_6_FLASH,
         MODEL_GEMINI_3_5_FLASH,
@@ -89,6 +91,9 @@ describe('GeminiChatServiceProvider', () => {
         provider.supportsVisionForModel(MODEL_GEMINI_3_1_PRO_PREVIEW),
       ).toBe(true);
       expect(provider.supportsVisionForModel(MODEL_GEMINI_3_5_FLASH)).toBe(
+        true,
+      );
+      expect(provider.supportsVisionForModel(MODEL_GEMINI_3_8_FLASH)).toBe(
         true,
       );
       expect(provider.supportsVisionForModel(MODEL_GEMINI_3_7_FLASH)).toBe(
@@ -448,23 +453,26 @@ describe('GeminiChatServiceProvider', () => {
       );
     });
 
-    it('should normalize unsupported minimal reasoning to low for Gemini 3.7', () => {
-      provider.createChatService({
-        apiKey: 'test-api-key',
-        model: MODEL_GEMINI_3_7_FLASH,
-        reasoning_effort: 'minimal',
-      });
+    it.each([MODEL_GEMINI_3_8_FLASH, MODEL_GEMINI_3_7_FLASH])(
+      'should normalize unsupported minimal reasoning to low for %s',
+      (model) => {
+        provider.createChatService({
+          apiKey: 'test-api-key',
+          model,
+          reasoning_effort: 'minimal',
+        });
 
-      expect(GeminiChatService).toHaveBeenCalledWith(
-        'test-api-key',
-        MODEL_GEMINI_3_7_FLASH,
-        MODEL_GEMINI_3_7_FLASH,
-        [],
-        [],
-        undefined,
-        'low',
-      );
-    });
+        expect(GeminiChatService).toHaveBeenCalledWith(
+          'test-api-key',
+          model,
+          model,
+          [],
+          [],
+          undefined,
+          'low',
+        );
+      },
+    );
 
     it('should reject reasoning_effort for Gemini 2.5 models', () => {
       expect(() =>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   "author": "shinshin86 (https://github.com/shinshin86)",
   "license": "MIT",
   "dependencies": {
-    "@aituber-onair/chat": "^0.53.0",
+    "@aituber-onair/chat": "^0.54.0",
     "@aituber-onair/voice": "^0.20.0"
   },
   "peerDependencies": {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -74,7 +74,7 @@
     "directory": "packages/noise"
   },
   "dependencies": {
-    "@aituber-onair/chat": "^0.53.0"
+    "@aituber-onair/chat": "^0.54.0"
   },
   "devDependencies": {
     "@aituber-onair/kizuna": "^0.0.3",


### PR DESCRIPTION
## Summary

- add native Gemini 3.8 Flash (`gemini-3.8-flash`) as an explicit stable model
- enable the existing Gemini streaming, vision, MCP, and tool/function-calling paths for the model
- expose only `low`, `medium`, and `high` thinking levels and default to `low` for responsive chat
- keep Gemini 3.1 Flash-Lite as the provider default and leave Gemini 3.8 Flash Cyber out of the public catalog because it has no public Gemini API model ID
- update the React example, English/Japanese documentation, capability metadata tests, and transport tests
- prepare the minor release of `@aituber-onair/chat` as `0.54.0`, including dependent package ranges and the root lockfile

## Validation

- `npm ci`
- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm pack --dry-run --json` for `@aituber-onair/chat`
- manually verified the React example model selector and Gemini thinking options

## Notes

- Gemini 3.8 Flash uses `v1beta` Generate Content endpoints through the existing Gemini 3 transport.
- The package sends `thinkingLevel: LOW` with `includeThoughts: false` by default because `minimal` and disabled thinking are not supported by this model.
