### PR TITLE
docs(avatar): introduce Still2Rig PSD as a related tool

### DIFF
--- a/docs/avatar.ja.md
+++ b/docs/avatar.ja.md
@@ -90,6 +90,9 @@ PSD では、PSDTool 風の静的レイヤー切り替え、または Anime2.5DR
 [`packages/core/examples/react-psd-app`](../packages/core/examples/react-psd-app)
 を参照してください。
 
+静止画 1 枚から自分でレイヤー付き PSD を作ってみたい場合は、後述する
+Still2Rig PSD のワークフローも利用できます。
+
 ### Pet
 
 人型アバターではなく、小さな相棒キャラクターを使いたい場合に向いています。
@@ -185,6 +188,37 @@ Codex や Claude Code などの AI エージェント向け作業ガイドも含
 [`packages/core/examples/react-live2d-app/models/`](../packages/core/examples/react-live2d-app/models/)
 配下へ配置してください。モデルデータや参照素材を移動、改変、公開、再配布する
 前に、それぞれの利用条件も確認してください。
+
+## 関連ツール: Still2Rig PSD
+
+[Still2Rig PSD](https://github.com/shinshin86/still2rig-psd)
+は、アニメキャラクターの静止画 1 枚から、PSD サンプルで使えるレイヤー付き
+PSD アバターを作るための関連リポジトリです。レイヤーを 1 枚ずつ手で切り分ける
+必要はありません。
+
+画像を添付して AI エージェントに変換を依頼すると、エージェントが See-through で
+画像をパーツに分解し、固定した前後順で PSD を組み立て、構造品質を確認します。
+生成される PSD は `face`, `front hair`, `mouth_open`, `eye_close` などの
+Anime2.5DRig 互換レイヤー名を使うため、PSD サンプルで待機モーションや
+髪揺れ付きのモーションモードとして読み込めます。
+
+組み込み WebUI では、配信で使う前に、まばたき、口の切り替え、髪や全身の動き、
+ドラッグ、拡大縮小まで一通り動作チェックできます。レイヤーの調整もここで行え、
+腕や前髪を手前・奥へ動かして重なりを直し、変更前と比較したうえで、元の PSD を
+上書きせずに修正版を保存できます。元画像がニュートラルな表情だけの場合は、
+位置を合わせた `mouth_open` と `eye_close` の画像を追加すると、実際の
+リップシンクとまばたきが有効になります。足りない素材はツールが隠さずに
+報告します。
+
+同梱のワークフローは Codex とユーザーが承認した Google Colab GPU を前提に
+していますが、どちらも必須ではありません。処理は CLI コマンドに分かれているため、
+利用する AI エージェントに指示すれば Colab の代わりにローカル GPU で
+See-through を実行でき、Codex 以外の Claude Code や Hermes Agent などの
+エージェントでも同じ手順を進められます。
+
+PSD を生成したら、PSD サンプルを起動し、Settings の Visual セクションにある
+PSD avatar からファイルを選択してください。元画像や生成した素材の権利は、
+ツールのライセンスとは別に確認してください。
 
 ## 関連リソースと利用条件の確認
 

--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -82,6 +82,9 @@ and hair physics. A bundled motion sample works without additional setup.
 Start from
 [`packages/core/examples/react-psd-app`](../packages/core/examples/react-psd-app).
 
+To create your own layered PSD from a single still image, you can use the
+Still2Rig PSD workflow described below.
+
 ### Pet
 
 Use the pet example when you want a compact animated companion instead of a
@@ -181,6 +184,37 @@ folder—including the updated `.model3.json` and all referenced assets—under
 [`packages/core/examples/react-live2d-app/models/`](../packages/core/examples/react-live2d-app/models/).
 Check the terms for the model and its source assets before moving, modifying,
 publishing, or redistributing them.
+
+## Related Tool: Still2Rig PSD
+
+[Still2Rig PSD](https://github.com/shinshin86/still2rig-psd) is a companion
+repository for turning one still image of an anime character into a layered
+PSD avatar for the PSD example, without cutting every layer by hand.
+
+Attach the image and ask your AI agent to convert it. The agent decomposes the
+image into parts with See-through, assembles the PSD in a fixed back-to-front
+layer order, and runs structural QA. The generated PSD uses
+Anime2.5DRig-compatible layer names such as `face`, `front hair`, `mouth_open`,
+and `eye_close`, so the PSD example can load it in motion mode with idle motion
+and hair physics.
+
+The built-in WebUI lets you check the result end to end before streaming with
+it: blinking, mouth states, hair and full-body motion, drag, and zoom. You can
+also adjust layers there, for example moving arms or front hair forward or
+backward to fix overlaps, compare the edit with the original, and export the
+fixed copy without overwriting the source PSD. If the source image has only a
+neutral expression, supply aligned `mouth_open` and `eye_close` artwork to
+enable real lip-sync and blinking; the tool reports what is still missing
+instead of hiding it.
+
+The bundled workflow targets Codex and a user-approved Google Colab GPU, but
+neither is required. The pipeline is exposed as CLI steps, so you can instruct
+your agent to run See-through on a local GPU instead, and agents other than
+Codex, such as Claude Code or Hermes Agent, can follow the same steps.
+
+After generating the PSD, start the PSD example and choose the file from
+**PSD avatar** in **Settings → Visual**. Check the rights for source images and
+generated assets separately from the tool licenses.
 
 ## Related Resources and License Checks
 


### PR DESCRIPTION
## Summary

- Add a **Related Tool: Still2Rig PSD** section to `docs/avatar.md` and `docs/avatar.ja.md`, placed alongside the existing VRM and Live2D companion-tool sections.
- Link to it from the PSD avatar style, matching how the PuruPuru PNGTuber section points to its asset production kit.
- Describe what users get from [Still2Rig PSD](https://github.com/shinshin86/still2rig-psd): a layered PSD avatar built from a single still image, Anime2.5DRig-compatible layer names so the PSD example loads it in motion mode, a built-in WebUI for checking blink / mouth / hair / body motion and adjusting layer order, and the option to add `mouth_open` / `eye_close` artwork for real lip-sync and blinking.
- Note that the bundled Codex + Google Colab workflow is not mandatory: See-through can run on a local GPU, and AI agents other than Codex (Claude Code, Hermes Agent, etc.) can follow the same CLI steps.

## Verification

- `npm run fmt` and `npm run lint` pass.
- Docs-only change, so `build` and `test` were not run.
- Public-release check (diff mode) reported no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFABAiFG6XtB8YqJsYyc3m