### PR TITLE
fix(core): keep PSD settings visible after file selection

### DIFF
--- a/packages/core/examples/react-psd-app/src/styles/app.css
+++ b/packages/core/examples/react-psd-app/src/styles/app.css
@@ -60,7 +60,7 @@ body {
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: clip;
 }
 
 .settings-dialog-header {
@@ -272,6 +272,7 @@ body {
 }
 
 .settings-file-picker-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -463,6 +464,7 @@ body {
 }
 
 .settings-motion-profile-actions {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr;
   gap: 7px;


### PR DESCRIPTION
## Summary

- prevent the PSD settings dialog from becoming a programmatically scrollable container
- scope visually hidden file inputs to their local picker controls
- apply the same positioning guard to PSD motion profile imports

## Problem

Focusing a hidden PSD file input could scroll the outer settings dialog in Chrome, moving the header and settings content outside the visible area and leaving an apparently blank dialog.

## Verification

- `npm run fmt`
- `npm run lint`
- `npm run test`
- `npm run build`
- manually selected both bundled motion and static PSD files in Chrome and confirmed that the outer dialog remains at `scrollTop: 0` while the settings panel remains scrollable
