### PR TITLE
fix(voice): remove artificial Irodori generation limits

### DIFF
--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -603,6 +603,7 @@ const voiceService = new VoiceService({
   openAiSpeed: 1.15,
   openAiCompatibleModel: 'your-model-id',
   openAiCompatibleSpeed: 1.1,
+  openAiCompatibleTimeoutMs: 300_000, // Optional; default: 30_000 ms; 0 disables the timeout
   unrealSpeechBitrate: '192k',
   unrealSpeechSpeed: 0,
   unrealSpeechPitch: 1,
@@ -640,6 +641,7 @@ const voiceService = new VoiceService({
   - Optional voice: `speaker`
   - `openAiCompatibleModel`
   - `openAiCompatibleSpeed`
+  - `openAiCompatibleTimeoutMs`
 
 - **xAI TTS**
   - `xaiLanguage`

--- a/packages/voice/README_ja.md
+++ b/packages/voice/README_ja.md
@@ -597,6 +597,7 @@ const voiceService = new VoiceService({
   openAiSpeed: 1.1,
   openAiCompatibleModel: 'your-model-id',
   openAiCompatibleSpeed: 1.1,
+  openAiCompatibleTimeoutMs: 300_000, // Optional; default: 30_000 ms; 0 disables the timeout
   unrealSpeechBitrate: '192k',
   unrealSpeechSpeed: 0,
   unrealSpeechPitch: 1,
@@ -638,6 +639,7 @@ const voiceService = new VoiceService({
   - 任意の voice: `speaker`
   - `openAiCompatibleModel`
   - `openAiCompatibleSpeed`
+  - `openAiCompatibleTimeoutMs`
 
 - **xAI TTS**
   - `xaiLanguage`

--- a/packages/voice/examples/react-irodori-mlx/README.md
+++ b/packages/voice/examples/react-irodori-mlx/README.md
@@ -1,7 +1,7 @@
 # Irodori Local Voice (Apple Silicon / MLX)
 
 A standalone React + TypeScript sample using `@aituber-onair/voice` to generate
-and play short speech using the bundled `sample-speaker` reference or an audio
+and play speech using the bundled `sample-speaker` reference or an audio
 file uploaded by the user.
 
 Browser → `VoiceEngineAdapter` → loopback OpenAI-compatible API → persistent
@@ -126,33 +126,37 @@ not stop. Occupied ports cause a clear failure; existing services are never kill
 API initialization is allowed up to 180 seconds. Logs are replaced on each launch
 in `.local/api.log` and `.local/frontend.log`.
 
-## Limits and error handling
+## Generation and error handling
 
-- One short sentence, at most 40 Unicode code points. This is a conservative input
-  limit, not a guarantee of sub-30-second generation on every Mac.
-- `cfg_guidance_mode="alternating"`, six Sway steps (`sway_coeff=-1`),
-  `max_seconds=6`, `max_ref_seconds=5`, non-streaming generation.
-- v3 dynamically predicts sequence length; setting `sequence_length` alone
-  does not constrain it. The sample wraps the model's public `generate_latents`
-  method to inspect its returned frame count **before silence trimming**.
-  Reaching the six-second frame cap produces HTTP 422 rather than playing a
-  possibly truncated sentence. This conservative check may reject an exact fit.
-  It cannot prove correct pronunciation or semantic completion below the cap.
+- The sample imposes no character-count, audio-duration or generation-wait limit.
+  There is no generation configuration JSON. Longer speech requires more time
+  and memory; successful generation depends on the model and Mac.
+- Irodori's duration predictor determines the output length. MLX-Audio requires
+  a finite numeric duration bound (infinity fails during integer conversion),
+  so the sample uses the platform sample-index range instead of its default
+  30-second clamp. This is a numeric representation ceiling, not a practical
+  speech-duration restriction.
+- Inputs beyond the model's own token capacity return 422 before inference,
+  because upstream would otherwise silently truncate them. This is checked with
+  the pinned tokenizer and model configuration, not an arbitrary character count.
+- Non-streaming generation uses alternating guidance, six Sway steps and the
+  first five seconds of reference audio.
 - The API accepts finite `speed` values from 0.5 to 2.0 (default 1.0), and maps
   them to Irodori `duration_scale=1/speed`. Values below 1 make speech slower;
   values above 1 make it faster. The UI slider moves in steps of 0.5. Unsupported values
   are rejected with 422, never silently clamped. This adjusts predicted generation
   duration rather than resampling playback, so it is not an exact audio-speed
   multiplier and pronunciation/naturalness can vary. Very short speech can hit
-  Irodori's 0.5-second minimum (rounded to audio frames). Slower speech is still
-  subject to the six-second cap; shorten the sentence or increase speed if rejected.
+  Irodori's 0.5-second minimum (rounded to audio frames).
 - Only one GPU request is admitted; no waiting inference queue. Concurrent
   requests get 429. The HTTP server also limits concurrent connections to 16
-  and speech JSON to 4 KiB (audio uploads to 10 MiB).
-- The API responds with 504 after 25 seconds, leaving margin before the voice
-  package's 30-second fetch timeout. Native GPU work cannot be safely cancelled
-  mid-call; the busy lock remains held until it finishes. This is a response
-  deadline, not a hard wall-clock GPU limit. Shorten input and wait before retrying.
+  (audio uploads remain limited to 10 MiB).
+- The API waits for generation to finish. The browser sets
+  `openAiCompatibleTimeoutMs: 0` to disable the voice package's timeout;
+  other consumers retain the 30-second default unless they opt out.
+  Failed generation returns an error. If native code or the OS terminates the
+  process (for example under memory pressure), the browser sees a connection
+  failure instead of a structured API response. Restart the sample in that case.
 - Empty/invalid input, unsupported model/speed/format and invalid audio: 422;
   unknown voice: 404; unavailable model: 503; generation failure: 500.
 - WAV validation rejects empty, non-finite or near-silent data (RMS < 0.0001).
@@ -244,13 +248,13 @@ npm test
 ```
 
 Tests cover HTTP validation/CORS, bounded requests, serialization, reference
-containment, duration caps and busy admission after timeouts. They use a fake
+containment, model token overflow and busy admission after disconnects/timeouts. They use a fake
 runtime for API tests; those tests do **not** establish audible MLX compatibility.
 Live validation must separately use a provided reference, generate through the
 browser, observe playback, inspect PCM duration/RMS/peak and retain screenshots
 and logs under `.local`. Voice similarity and pronunciation require listening.
 
-The library's public API is unchanged. This example uses the repository-local
+The library adds optional `openAiCompatibleTimeoutMs`; existing defaults are unchanged. This example uses the repository-local
 voice package just like `react-basic`; no version bump or new provider is needed.
 
 ## Implementation sources

--- a/packages/voice/examples/react-irodori-mlx/server/app.py
+++ b/packages/voice/examples/react-irodori-mlx/server/app.py
@@ -12,14 +12,14 @@ from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from server.audio import load_voices, register_reference
-from server.runtime import DurationLimitError, Runtime
-from server.settings import MODEL_ID, MAX_CHARACTERS, ALLOWED_ORIGINS, REQUEST_SECONDS, ROOT, DEFAULT_REFERENCE, MAX_UPLOAD_BYTES
+from server.runtime import Runtime
+from server.settings import MODEL_ID, ALLOWED_ORIGINS, ROOT, DEFAULT_REFERENCE, MAX_UPLOAD_BYTES
 
 
 class Speech(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
     model: Literal[MODEL_ID]
-    input: str = Field(min_length=1, max_length=MAX_CHARACTERS)
+    input: str = Field(min_length=1)
     voice: str = Field(min_length=1, max_length=64)
     speed: float = Field(default=1.0, ge=0.5, le=2.0, allow_inf_nan=False)
     response_format: Literal["wav"] = "wav"
@@ -33,7 +33,7 @@ class Speech(BaseModel):
         return value
 
 
-def create_app(runtime_factory=Runtime, local=ROOT / ".local", timeout=REQUEST_SECONDS):
+def create_app(runtime_factory=Runtime, local=ROOT / ".local", timeout=None):
     state = {"runtime": None, "error": None, "busy": False, "uploading": False, "voices": {}}
     pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="irodori-gpu")
 
@@ -123,8 +123,8 @@ def create_app(runtime_factory=Runtime, local=ROOT / ".local", timeout=REQUEST_S
             audio = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
             return Response(audio, media_type="audio/wav")
         except TimeoutError:
-            raise HTTPException(504, "Generation exceeded 25 seconds. GPU remains busy until work finishes.")
-        except (DurationLimitError, ValueError) as exc:
+            raise HTTPException(504, "Generation timed out. GPU remains busy until work finishes.")
+        except ValueError as exc:
             logging.warning("Speech rejected: %s", exc)
             raise HTTPException(422, str(exc))
         except Exception:
@@ -150,11 +150,9 @@ def create_app(runtime_factory=Runtime, local=ROOT / ".local", timeout=REQUEST_S
                 if event["type"] == "http.disconnect":
                     return
                 total += len(event.get("body", b""))
-                limit = MAX_UPLOAD_BYTES if scope["path"].startswith("/voices/") else 4096
-                if total > limit:
-                    detail = ("Audio file exceeds 10 MiB. Automatic trimming happens after upload."
-                              if limit == MAX_UPLOAD_BYTES else "Speech JSON exceeds 4 KiB.")
-                    return await JSONResponse({"detail": detail}, 413)(scope, receive, send)
+                limit = MAX_UPLOAD_BYTES if scope["path"].startswith("/voices/") else None
+                if limit is not None and total > limit:
+                    return await JSONResponse({"detail": "Audio file exceeds 10 MiB. Automatic trimming happens after upload."}, 413)(scope, receive, send)
                 chunks.append(event.get("body", b""))
                 if not event.get("more_body", False):
                     break

--- a/packages/voice/examples/react-irodori-mlx/server/runtime.py
+++ b/packages/voice/examples/react-irodori-mlx/server/runtime.py
@@ -1,27 +1,19 @@
 """The single persistent MLX model is used only on the dedicated GPU thread."""
 import json
-import math
+import sys
 import time
 
 import numpy as np
 
 from server.audio import read_reference, wav_bytes
-from server.settings import MODEL_DIR, MODEL_REVISION, TOKENIZER_REVISION, MAX_SECONDS, REF_SECONDS
+from server.settings import MODEL_DIR, MODEL_REVISION, TOKENIZER_REVISION, REF_SECONDS
 
 
-class DurationLimitError(ValueError):
-    pass
-
-
-def guard_duration(generate_latents, max_frames):
-    # Observe the PUBLIC latent API before generate() trims trailing silence.
-    # Output duration alone cannot reveal a cap hidden by silence trimming.
-    def guarded(*args, **kwargs):
-        latent, frames = generate_latents(*args, **kwargs)
-        if frames >= max_frames:
-            raise DurationLimitError("Predicted speech reached the duration limit. Shorten the text or increase the speed.")
-        return latent, frames
-    return guarded
+def validate_text_tokens(tokenizer, text, config):
+    # Match upstream tokenization, but reject its silent truncation.
+    tokens = tokenizer.encode(text, add_special_tokens=False)
+    if len(tokens) + int(config.dit.text_add_bos) > config.max_text_length:
+        raise ValueError("Input exceeds the model's token capacity. Split the text into smaller passages.")
 
 
 class Runtime:
@@ -42,19 +34,24 @@ class Runtime:
         self.model = load(MODEL_DIR)
         if self.model.dacvae is None or not self.model.config.dit.use_duration_predictor:
             raise RuntimeError("Expected the pinned Irodori v3 model with bundled DACVAE.")
-        max_frames = math.floor(MAX_SECONDS * self.model.sample_rate / self.model.config.audio_downsample_factor)
-        self.model.generate_latents = guard_duration(self.model.generate_latents, max_frames)
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+        self.normalize_text = normalize_text
+        from transformers import AutoTokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(MODEL_DIR / "tokenizer", local_files_only=True)
 
     def synthesize(self, text, voice, reference, speed=1.0):
         import mlx.core as mx
 
+        validate_text_tokens(self.tokenizer, self.normalize_text(text).strip(), self.model.config)
         start = time.monotonic()
         audio, reference_metrics = read_reference(reference, self.model.sample_rate)
         print(json.dumps({"event": "reference", "voice": voice, **reference_metrics}), flush=True)
         try:
+            # Upstream floors max_seconds to integer frames, so infinity is invalid.
+            # Use the platform sample-index range, not an application duration cap.
             results = list(self.model.generate(
                 text=text, ref_audio=mx.array(audio), stream=False,
-                cfg_guidance_mode="alternating", max_seconds=MAX_SECONDS,
+                cfg_guidance_mode="alternating", max_seconds=sys.maxsize / self.model.sample_rate,
                 max_ref_seconds=REF_SECONDS, num_steps=6,
                 t_schedule_mode="sway", sway_coeff=-1.0,
                 duration_scale=1.0 / speed,

--- a/packages/voice/examples/react-irodori-mlx/server/settings.py
+++ b/packages/voice/examples/react-irodori-mlx/server/settings.py
@@ -6,11 +6,8 @@ MODEL_REVISION = "43b5d5539d8f07da46c7cd58d9f0ebed50ec1cc9"
 TOKENIZER_ID = "llm-jp/llm-jp-3-150m"
 TOKENIZER_REVISION = "b112feef602fff752e4dac4c30af6a2c2fa41c7a"
 MODEL_DIR = ROOT / ".cache" / "model"
-MAX_CHARACTERS = 40
-MAX_SECONDS = 6.0
 REF_SECONDS = 5.0
 MIN_REF_SECONDS = 1.0
-REQUEST_SECONDS = 25.0
 ALLOWED_ORIGINS = ["http://127.0.0.1:5173", "http://localhost:5173"]
 
 DEFAULT_REFERENCE = ROOT / "samples" / "sample-speaker.wav"

--- a/packages/voice/examples/react-irodori-mlx/src/main.tsx
+++ b/packages/voice/examples/react-irodori-mlx/src/main.tsx
@@ -116,6 +116,7 @@ function App() {
         openAiCompatibleApiUrl: `${API}/v1/audio/speech`,
         openAiCompatibleModel: MODEL,
         openAiCompatibleSpeed: speed,
+        openAiCompatibleTimeoutMs: 0,
         speaker,
         onPlay: async (buffer) => {
           const decoded = await player.decodeAudioData(buffer.slice(0));
@@ -141,7 +142,7 @@ function App() {
     } catch (cause) {
       setPhase('エラー');
       setError(
-        `${cause instanceof Error ? cause.message : String(cause)} 文章を短くするか、話速を上げて再試行してください。APIの詳細は .local/api.log を確認してください。`,
+        `${cause instanceof Error ? cause.message : String(cause)} APIの詳細は .local/api.log を確認してください。`,
       );
     } finally {
       setActive(false);
@@ -153,7 +154,7 @@ function App() {
       <p className="eyebrow">AITUBER ONAIR / VOICE EXAMPLE</p>
       <h1>Irodori Local Voice</h1>
       <p className="intro">
-        自分で用意した参照音声を使い、Mac上で短い文章を読み上げます。
+        自分で用意した参照音声を使い、Mac上で文章を読み上げます。
       </p>
       <output className="status" aria-live="polite">
         <span className={ready ? 'dot ready' : 'dot'} />
@@ -249,21 +250,20 @@ function App() {
         <span>2.0</span>
       </div>
       <p className="hint">
-        遅くすると音声が長くなります。6秒の上限に達した場合は、文章を短くするか話速を上げてください。
+        遅くすると音声が長くなります。生成にかかる時間は文章とPCによって変わります。
       </p>
       <label htmlFor="text">
-        読み上げテキスト <span>{Array.from(text).length} / 40</span>
+        読み上げテキスト <span>{Array.from(text).length} 文字</span>
       </label>
       <textarea
         id="text"
         rows={4}
-        maxLength={40}
         value={text}
         onChange={(event) => setText(event.target.value)}
         disabled={active}
       />
       <p className="hint">
-        まずは「こんにちは。」から。短い1文・生成音声6秒未満。
+        生成が完了するまでお待ちください。失敗した場合はエラーを表示します。
       </p>
       <button
         type="button"

--- a/packages/voice/examples/react-irodori-mlx/tests/test_api.py
+++ b/packages/voice/examples/react-irodori-mlx/tests/test_api.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from server.app import create_app
 from server.audio import load_voices, read_reference, validate_audio, wav_bytes
-from server.runtime import DurationLimitError, guard_duration
+from server.runtime import validate_text_tokens
 from server.settings import MODEL_ID, ALLOWED_ORIGINS
 
 BODY = {"model": MODEL_ID, "input": "こんにちは。", "voice": "sample-speaker", "speed": 1.0}
@@ -49,13 +49,12 @@ def test_contract(local, origin):
         assert response.headers["content-type"] == "audio/wav"
         assert response.headers["access-control-allow-origin"] == origin
         assert client.get("/voices").json() == {"voices": ["sample-speaker"]}
-        for change in ({"input": " "}, {"input": "!"}, {"input": "a" * 41},
+        for change in ({"input": " "}, {"input": "!"},
                        {"model": "other"}, {"speed": 0.49}, {"speed": 2.01}, {"speed": "1"},
                        {"response_format": "mp3"}, {"ref_audio": "/tmp/other.wav"}):
             assert client.post("/v1/audio/speech", json={**BODY, **change}).status_code == 422
         assert client.post("/v1/audio/speech", json={**BODY, "voice": "../other"}).status_code == 404
         assert client.post("/v1/audio/speech", json=BODY, headers={"Origin": "https://example.com"}).status_code == 403
-        assert client.post("/v1/audio/speech", content=b"x" * 4097).status_code == 413
         preflight = client.options("/v1/audio/speech", headers={"Origin": origin,
                                    "Access-Control-Request-Method": "POST", "Access-Control-Request-Headers": "content-type"})
         assert preflight.status_code == 200
@@ -125,25 +124,6 @@ def test_reference_boundaries(local):
         read_reference(local / "references/short.wav")
 
 
-def test_wav_normalization():
-    audio = np.sin(np.arange(48000) * 0.03).astype(np.float32) * 2
-    payload, metrics = wav_bytes(audio, 48000)
-    assert payload[:4] == b"RIFF" and payload[8:12] == b"WAVE"
-    decoded, rate = sf.read(io.BytesIO(payload))
-    assert rate == 48000 and len(decoded) == 48000
-    assert 0.97 < max(abs(decoded)) < 0.981
-    assert metrics["gain"] < 1
-
-
-def test_cap_detected_before_silence_trimming():
-    safe = guard_duration(lambda: ("latent", 149), 150)
-    assert safe() == ("latent", 149)
-    for frames in (150, 151):
-        guarded = guard_duration(lambda: ("latent", frames), 150)
-        with pytest.raises(DurationLimitError):
-            guarded()
-
-
 @pytest.mark.parametrize("speed", [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, None])
 def test_speed_reaches_runtime(local, speed):
     received = []
@@ -184,11 +164,13 @@ def test_runtime_maps_speed_to_generation(monkeypatch, speed, scale):
         recorded.update(kwargs)
         yield SimpleNamespace(audio=reference, sample_rate=48000, peak_memory_usage=0)
     runtime = module.Runtime.__new__(module.Runtime)
-    runtime.model = SimpleNamespace(sample_rate=48000, generate=generate)
+    runtime.model = SimpleNamespace(sample_rate=48000, generate=generate, config=SimpleNamespace(max_text_length=512, dit=SimpleNamespace(text_add_bos=True)))
+    runtime.tokenizer = SimpleNamespace(encode=lambda *a, **kw: [1])
+    runtime.normalize_text = lambda text: text
     assert runtime.synthesize("hello", "sample-speaker", "unused", speed) == b"wav"
     assert recorded["duration_scale"] == scale
     assert recorded["ref_audio"] is reference
-    assert recorded["max_seconds"] == 6.0
+    assert recorded["max_seconds"] == sys.maxsize / 48000
     assert recorded["stream"] is False
 
 
@@ -265,3 +247,30 @@ def test_upload_registration_is_serialized(local, monkeypatch):
         assert client.post('/voices/second', content=payload).status_code == 201
     mapping = load_voices(local)
     assert 'first' in mapping and 'second' in mapping
+
+
+
+def test_wav_normalization():
+    audio = np.sin(np.arange(48000) * 0.03).astype(np.float32) * 2
+    payload, metrics = wav_bytes(audio, 48000)
+    assert payload[:4] == b"RIFF" and payload[8:12] == b"WAVE"
+    decoded, rate = sf.read(io.BytesIO(payload))
+    assert rate == 48000 and len(decoded) == 48000
+    assert 0.97 < max(abs(decoded)) < 0.981
+    assert metrics["gain"] < 1
+
+
+
+def test_no_sample_text_limit(local):
+    with TestClient(create_app(FakeRuntime, local)) as client:
+        ready(client)
+        assert client.post('/v1/audio/speech', json={**BODY, 'input': 'あ' * 10000}).status_code == 200
+
+
+def test_model_token_overflow_is_rejected():
+    from types import SimpleNamespace
+    tokenizer = SimpleNamespace(encode=lambda text, **kwargs: list(text))
+    config = SimpleNamespace(max_text_length=4, dit=SimpleNamespace(text_add_bos=True))
+    validate_text_tokens(tokenizer, 'abc', config)
+    with pytest.raises(ValueError, match='token capacity'):
+        validate_text_tokens(tokenizer, 'abcd', config)

--- a/packages/voice/src/engines/OpenAiCompatibleEngine.ts
+++ b/packages/voice/src/engines/OpenAiCompatibleEngine.ts
@@ -10,6 +10,21 @@ export class OpenAiCompatibleEngine implements VoiceEngine {
   private apiUrl: string = OPENAI_COMPATIBLE_TTS_API_URL;
   private speed: number = 1.0;
   private model: string = '';
+  private timeoutMs = 30_000;
+
+  /** Set a request timeout (0 disables the timeout) in milliseconds (default: 30000). */
+  setTimeout(timeoutMs: number): void {
+    if (
+      !Number.isFinite(timeoutMs) ||
+      timeoutMs < 0 ||
+      timeoutMs > 2_147_483_647
+    ) {
+      throw new RangeError(
+        'OpenAI-compatible timeout must be between 0 and 2147483647 milliseconds',
+      );
+    }
+    this.timeoutMs = timeoutMs;
+  }
 
   /**
    * Set custom OpenAI-compatible speech endpoint
@@ -66,11 +81,16 @@ export class OpenAiCompatibleEngine implements VoiceEngine {
       requestBody.voice = trimmedSpeaker;
     }
 
-    const response = await fetchWithTimeout(this.apiUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(requestBody),
-    });
+    const fetchAudio = this.timeoutMs === 0 ? fetch : fetchWithTimeout;
+    const response = await fetchAudio(
+      this.apiUrl,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestBody),
+      },
+      this.timeoutMs,
+    );
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => '');

--- a/packages/voice/src/services/VoiceService.ts
+++ b/packages/voice/src/services/VoiceService.ts
@@ -310,6 +310,8 @@ export interface OpenAiCompatibleVoiceServiceOptions
   openAiCompatibleModel?: string;
   /** OpenAI-compatible speaking speed (0.25-4.0, default: 1.0) */
   openAiCompatibleSpeed?: number;
+  /** Request timeout in milliseconds (default: 30000; 0 disables). */
+  openAiCompatibleTimeoutMs?: number;
 }
 
 export interface AivisSpeechVoiceServiceOptions

--- a/packages/voice/src/services/internal/engineHandlers/openaiCompatible.ts
+++ b/packages/voice/src/services/internal/engineHandlers/openaiCompatible.ts
@@ -10,6 +10,7 @@ const allowedUpdateKeys = [
   'openAiCompatibleApiUrl',
   'openAiCompatibleModel',
   'openAiCompatibleSpeed',
+  'openAiCompatibleTimeoutMs',
 ] as const;
 
 export const openAiCompatibleEngineHandler: EngineHandler<OpenAiCompatibleVoiceServiceOptions> =
@@ -21,6 +22,12 @@ export const openAiCompatibleEngineHandler: EngineHandler<OpenAiCompatibleVoiceS
     ) {
       const compatibleEngine = engine as OpenAiCompatibleConfigurableEngine;
 
+      if (
+        options.openAiCompatibleTimeoutMs !== undefined &&
+        compatibleEngine.setTimeout
+      ) {
+        compatibleEngine.setTimeout(options.openAiCompatibleTimeoutMs);
+      }
       if (options.openAiCompatibleApiUrl && compatibleEngine.setApiEndpoint) {
         compatibleEngine.setApiEndpoint(options.openAiCompatibleApiUrl);
       }

--- a/packages/voice/src/services/internal/engineHandlers/types.ts
+++ b/packages/voice/src/services/internal/engineHandlers/types.ts
@@ -179,6 +179,7 @@ export interface GeminiTtsConfigurableEngine extends VoiceEngine {
 }
 
 export interface OpenAiCompatibleConfigurableEngine extends VoiceEngine {
+  setTimeout?(value: number): void;
   setApiEndpoint?(value: string): void;
   setModel?(value: string): void;
   setSpeed?(value?: number): void;

--- a/packages/voice/tests/EngineHandlers.test.ts
+++ b/packages/voice/tests/EngineHandlers.test.ts
@@ -294,16 +294,19 @@ const cases: HandlerCase[] = [
       openAiCompatibleApiUrl: 'http://localhost:8000/v1/audio/speech',
       openAiCompatibleModel: 'local-tts',
       openAiCompatibleSpeed: 1.1,
+      openAiCompatibleTimeoutMs: 90_000,
     },
     allowedUpdateKeys: [
       'openAiCompatibleApiUrl',
       'openAiCompatibleModel',
       'openAiCompatibleSpeed',
+      'openAiCompatibleTimeoutMs',
     ],
     expectedCalls: {
       setApiEndpoint: ['http://localhost:8000/v1/audio/speech'],
       setModel: ['local-tts'],
       setSpeed: [1.1],
+      setTimeout: [90_000],
     },
   },
   {

--- a/packages/voice/tests/OpenAiCompatibleEngine.test.ts
+++ b/packages/voice/tests/OpenAiCompatibleEngine.test.ts
@@ -116,3 +116,73 @@ describe('OpenAiCompatibleEngine', () => {
     expect(engine.getTestMessage()).toBe('OpenAI互換TTSを使用します');
   });
 });
+
+describe('OpenAI-compatible request timeout', () => {
+  it('waits beyond the default deadline when configured', async () => {
+    vi.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    let signal: AbortSignal | undefined;
+    globalThis.fetch = vi.fn((_url, init) => {
+      signal = init?.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    }) as typeof fetch;
+    try {
+      const engine = new OpenAiCompatibleEngine();
+      engine.setModel('sample-model');
+      engine.setTimeout(90_000);
+      const request = engine.fetchAudio(
+        { message: 'Hello', style: 'neutral' },
+        'sample-speaker',
+      );
+      const rejected = expect(request).rejects.toThrow('Network error');
+      await vi.advanceTimersByTimeAsync(30_001);
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await rejected;
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+    'rejects invalid timeout %s',
+    (value) => {
+      expect(() => new OpenAiCompatibleEngine().setTimeout(value)).toThrow(
+        RangeError,
+      );
+    },
+  );
+});
+
+it('disables the deadline when timeout is zero', async () => {
+  vi.useFakeTimers();
+  const original = globalThis.fetch;
+  let finish!: (response: Response) => void;
+  const mock = vi.fn(
+    () =>
+      new Promise<Response>((resolve) => {
+        finish = resolve;
+      }),
+  );
+  globalThis.fetch = mock;
+  try {
+    const engine = new OpenAiCompatibleEngine();
+    engine.setModel('sample-model');
+    engine.setTimeout(0);
+    const audio = engine.fetchAudio(
+      { message: 'Hello', style: 'neutral' },
+      'sample-speaker',
+    );
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(vi.getTimerCount()).toBe(0);
+    finish(new Response(new Uint8Array([1, 2, 3])));
+    expect((await audio).byteLength).toBe(3);
+  } finally {
+    globalThis.fetch = original;
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Summary

Remove the Irodori example's 40-character input limit, six-second audio cap and 25-second generation deadline. Users can submit text and wait for generation without configuring a limits JSON file.

- Let Irodori predict speech duration without the upstream default 30-second clamp. MLX-Audio requires a finite numeric bound, so use the platform sample-index range rather than an application duration limit.
- Reject input beyond the model's actual token capacity with HTTP 422 instead of allowing upstream tokenization to silently truncate it.
- Add optional `openAiCompatibleTimeoutMs` to the voice adapter. The example uses `0` to disable the request timeout; existing consumers keep the 30-second default.
- Remove the UI's length restrictions and update documentation. Retain serialized GPU admission, reference upload validation and WAV validation.

## Validation

- Repository checks passed in order: `npm run fmt`, `npm run lint`, `npm run test`, `npm run build`.
- Voice package: 351 tests passed; example: 28 Python tests and one Node process test passed, plus its TypeScript/Vite build.
- Live Apple Silicon browser verification: 131 characters at speed 0.5 produced 45.84 seconds of audio and reached playback completion. Generation took 7.86 seconds; saved peak was 0.98 and no near-clipping samples were detected. Screenshots and metrics remain in the ignored local verification directory.
- An oversized model input returned HTTP 422 without silent truncation. Fake-timer tests verify disabled and configurable client deadlines.
- Public-release diff audit found no disclosure issues. No private references, logs, screenshots, caches or model weights are included.

## Runtime behavior

Generation depends on available memory and the model's capabilities. Recoverable failures return API errors; native-process termination can surface as a connection failure. Without a generation deadline, stalled native work requires stopping the sample. Voice similarity and pronunciation were not evaluated by listening.

No package version changes are included.
