### PR TITLE
feat(voice): support Inworld TTS-2 Flash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8052,7 +8052,7 @@
             "license": "MIT",
             "dependencies": {
                 "@aituber-onair/chat": "^0.54.0",
-                "@aituber-onair/voice": "^0.20.0"
+                "@aituber-onair/voice": "^0.21.0"
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -8971,7 +8971,7 @@
         },
         "packages/voice": {
             "name": "@aituber-onair/voice",
-            "version": "0.20.0",
+            "version": "0.21.0",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@aituber-onair/chat": "^0.54.0",
-    "@aituber-onair/voice": "^0.20.0"
+    "@aituber-onair/voice": "^0.21.0"
   },
   "peerDependencies": {
     "@pixiv/three-vrm": "^1.0.9"

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.21.0
+
+### Minor Changes
+
+- Add `inworld-tts-2-flash` as an explicit model option using the existing
+  non-streaming Inworld REST speech endpoint. Keep `inworld-tts-2` as the default.
+- Export `InworldModel` with TTS-2 model suggestions while preserving custom
+  model strings and runtime model switching.
+- Omit delivery mode for Flash and disable its control in the React example.
+- Replace deprecated TTS 1.5 example choices with TTS-2 Flash and update the
+  English and Japanese usage documentation.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -313,9 +313,19 @@ the Inworld Basic Base64 authorization value. Do not expose Basic credentials
 in browser-side code; use a backend proxy or Inworld JWT authentication for
 browser apps.
 
-Inworld On-Demand starts free and is suitable for development. For cost
-savings, use TTS 1.5 Mini when minimizing cost; use TTS-2 or 1.5 Max when
-prioritizing quality.
+The current TTS-2 models are `inworld-tts-2` (the default, for quality)
+and `inworld-tts-2-flash` (an explicit option for lower latency and cost).
+Set `inworldModel: 'inworld-tts-2-flash'` to use Flash, or switch at runtime
+with `voiceService.updateOptions({ inworldModel: 'inworld-tts-2-flash' })`.
+Both use the same REST endpoint and voice-list configuration. This engine
+waits for the complete audio response, so provider streaming latency figures
+do not describe its playback latency.
+
+`inworldDeliveryMode` is supported only by TTS-2 and is omitted for Flash.
+Earlier model IDs remain accepted as strings for compatibility, but deprecated
+TTS 1.5 models are no longer offered in the React model selector.
+See the [model catalog](https://docs.inworld.ai/tts/tts-models) and
+[speech API reference](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech).
 
 ### Gradium
 Gradium one-shot REST TTS support using direct `fetch` calls. This engine uses

--- a/packages/voice/README_ja.md
+++ b/packages/voice/README_ja.md
@@ -305,9 +305,18 @@ Base64 認証値を指定します。Basic 認証情報をブラウザ側コー�
 ください。ブラウザアプリではバックエンドプロキシまたは Inworld の JWT 認証を
 使用してください。
 
-Inworld の On-Demand は無料で開始でき、開発用途に適しています。コストを
-抑える場合は TTS 1.5 Mini、品質を優先する場合は TTS-2 または 1.5 Max の
-利用が推奨されます。
+現行の TTS-2 系では、品質重視の `inworld-tts-2` が既定値で、低遅延・低コスト向けの
+`inworld-tts-2-flash` を明示的に選択できます。
+`inworldModel: 'inworld-tts-2-flash'` を指定するか、実行中に
+`voiceService.updateOptions({ inworldModel: 'inworld-tts-2-flash' })` で切り替えます。
+両モデルとも同じ REST エンドポイントと話者一覧を利用します。このエンジンは音声全体の
+受信後に再生するため、プロバイダーのストリーミング遅延値は再生開始までの時間とは異なります。
+
+`inworldDeliveryMode` は通常の TTS-2 専用で、Flash には送信しません。
+従来のモデルIDは互換性のため文字列として指定できますが、非推奨の TTS 1.5 系は
+React サンプルの選択肢から外しています。
+[モデル一覧](https://docs.inworld.ai/tts/tts-models)と
+[音声API仕様](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech)を参照してください。
 
 ### Gradium
 Gradium の one-shot REST TTS を SDK なしの直接 `fetch` で利用する

--- a/packages/voice/examples/react-basic/README.md
+++ b/packages/voice/examples/react-basic/README.md
@@ -171,6 +171,10 @@ The built files will be in the `dist/` directory and can be deployed to any stat
 ```
 
 #### Inworld TTS
+Select `inworld-tts-2` (default) for quality or `inworld-tts-2-flash` for lower
+latency and cost. Delivery Mode is available only for TTS-2. Both models use
+the same non-streaming REST endpoint and selectable voice list.
+
 ```bash
 # Default endpoint: https://api.inworld.ai/tts/v1/voice
 # Use the Basic Base64 authorization value from Inworld as the API key.

--- a/packages/voice/examples/react-basic/package-lock.json
+++ b/packages/voice/examples/react-basic/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@aituber-onair/voice",
-      "version": "0.17.0",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/packages/voice/examples/react-basic/src/App.tsx
+++ b/packages/voice/examples/react-basic/src/App.tsx
@@ -1021,7 +1021,10 @@ function App() {
           options.inworldLanguage = inworldLanguage.trim();
         }
 
-        if (inworldDeliveryMode !== 'default') {
+        if (
+          inworldModel === 'inworld-tts-2' &&
+          inworldDeliveryMode !== 'default'
+        ) {
           options.inworldDeliveryMode =
             inworldDeliveryMode as InworldDeliveryMode;
         }

--- a/packages/voice/examples/react-basic/src/components/EngineParameters.tsx
+++ b/packages/voice/examples/react-basic/src/components/EngineParameters.tsx
@@ -826,7 +826,7 @@ export function EngineParameters({
         <CollapsibleCard
           className="parameter-card openai-card"
           title="Inworld パラメータ"
-          description="Inworld TTS の非ストリーミング REST API 向け設定です。voiceId は上部の Speaker に入力します。"
+          description="Inworld TTS の非ストリーミング REST API 向け設定です。話者は上部の Speaker で選択します。"
         >
           <div className="parameter-section">
             <div className="parameter-section__title">モデル・出力</div>
@@ -931,6 +931,7 @@ export function EngineParameters({
                 <label htmlFor="inworldDeliveryMode">Delivery Mode</label>
                 <select
                   id="inworldDeliveryMode"
+                  disabled={inworld.model.value !== 'inworld-tts-2'}
                   value={inworld.deliveryMode.value}
                   onChange={(e) =>
                     inworld.deliveryMode.onChange(
@@ -947,6 +948,9 @@ export function EngineParameters({
                     ),
                   )}
                 </select>
+                <small>
+                  Delivery Mode は TTS-2 専用です。Flash では使用しません。
+                </small>
               </div>
             </div>
           </div>

--- a/packages/voice/examples/react-basic/src/constants.ts
+++ b/packages/voice/examples/react-basic/src/constants.ts
@@ -329,8 +329,7 @@ export const ELEVENLABS_OUTPUT_FORMATS: Record<string, string> = {
 
 export const INWORLD_MODELS: Record<string, string> = {
   'inworld-tts-2': 'TTS-2 — highest quality for expressive speech',
-  'inworld-tts-1.5-mini': 'TTS 1.5 Mini — cost-efficient',
-  'inworld-tts-1.5-max': 'TTS 1.5 Max — high quality',
+  'inworld-tts-2-flash': 'TTS-2 Flash — lower latency and cost',
 };
 
 export const INWORLD_AUDIO_ENCODINGS: Record<InworldAudioEncoding, string> = {

--- a/packages/voice/examples/react-irodori-mlx/package-lock.json
+++ b/packages/voice/examples/react-irodori-mlx/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../..": {
       "name": "@aituber-onair/voice",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-onair/voice",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Voice synthesis library for AITuber OnAir",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/voice/src/engines/InworldEngine.ts
+++ b/packages/voice/src/engines/InworldEngine.ts
@@ -3,6 +3,11 @@ import { Talk } from '../types/voice';
 import { decodeBase64ToArrayBuffer, fetchWithTimeout } from './internal/utils';
 import { VoiceEngine } from './VoiceEngine';
 
+export type InworldModel =
+  | 'inworld-tts-2'
+  | 'inworld-tts-2-flash'
+  | (string & {});
+
 export type InworldAudioEncoding =
   | 'MP3'
   | 'OGG_OPUS'
@@ -24,7 +29,7 @@ interface InworldSynthesizeSpeechResponse {
  */
 export class InworldEngine implements VoiceEngine {
   private apiEndpoint: string = INWORLD_TTS_API_URL;
-  private model: string = 'inworld-tts-2';
+  private model: InworldModel = 'inworld-tts-2';
   private audioEncoding: InworldAudioEncoding = 'MP3';
   private sampleRateHertz: number = 48000;
   private bitRate?: number;
@@ -44,7 +49,7 @@ export class InworldEngine implements VoiceEngine {
   /**
    * Set Inworld TTS model ID.
    */
-  setModel(model?: string): void {
+  setModel(model?: InworldModel): void {
     const trimmed = model?.trim();
     this.model = trimmed || 'inworld-tts-2';
   }
@@ -196,7 +201,10 @@ export class InworldEngine implements VoiceEngine {
     if (this.language !== undefined) {
       body.language = this.language;
     }
-    if (this.deliveryMode !== undefined) {
+    if (
+      this.deliveryMode !== undefined &&
+      this.model !== 'inworld-tts-2-flash'
+    ) {
       body.deliveryMode = this.deliveryMode;
     }
     if (this.temperature !== undefined) {

--- a/packages/voice/src/engines/index.ts
+++ b/packages/voice/src/engines/index.ts
@@ -45,6 +45,7 @@ export {
 export {
   InworldEngine,
   type InworldAudioEncoding,
+  type InworldModel,
   type InworldDeliveryMode,
 } from './InworldEngine';
 export {

--- a/packages/voice/src/services/VoiceService.ts
+++ b/packages/voice/src/services/VoiceService.ts
@@ -16,6 +16,7 @@ import type { GeminiTtsModel } from '../engines';
 import type { GradiumOutputFormat } from '../engines/GradiumEngine';
 import type {
   InworldAudioEncoding,
+  InworldModel,
   InworldDeliveryMode,
 } from '../engines/InworldEngine';
 import type { UnrealSpeechCodec } from '../engines/UnrealSpeechEngine';
@@ -250,7 +251,7 @@ export interface InworldVoiceServiceOptions extends VoiceServiceCommonOptions {
   /** Custom Inworld TTS endpoint URL */
   inworldApiUrl?: string;
   /** Inworld TTS model ID */
-  inworldModel?: string;
+  inworldModel?: InworldModel;
   /** Inworld output audio encoding (default: MP3) */
   inworldAudioEncoding?: InworldAudioEncoding;
   /** Inworld output sample rate in hertz (default: 48000) */

--- a/packages/voice/tests/InworldEngine.test.ts
+++ b/packages/voice/tests/InworldEngine.test.ts
@@ -114,6 +114,52 @@ describe('InworldEngine', () => {
     }
   });
 
+  it('should switch to Flash through the REST endpoint and decode audio', async () => {
+    const engine = new InworldEngine();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ audioContent: btoa('audio') }),
+    });
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      engine.setDeliveryMode('CREATIVE');
+      engine.setModel('inworld-tts-2-flash');
+      engine.setLanguage('ja-JP');
+      const audio = await engine.fetchAudio(
+        { message: 'こんにちは', style: 'neutral' },
+        'Ashley',
+        'test-key',
+      );
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.inworld.ai/tts/v1/voice');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Basic test-key');
+      expect(JSON.parse(init.body)).toEqual({
+        text: 'こんにちは',
+        voiceId: 'Ashley',
+        modelId: 'inworld-tts-2-flash',
+        audioConfig: { audioEncoding: 'MP3', sampleRateHertz: 48000 },
+        language: 'ja-JP',
+      });
+      expect(Array.from(new Uint8Array(audio))).toEqual([
+        97, 117, 100, 105, 111,
+      ]);
+
+      engine.setModel('inworld-tts-2');
+      await engine.fetchAudio(
+        { message: 'hello', style: 'neutral' },
+        'Ashley',
+        'test-key',
+      );
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body).deliveryMode).toBe(
+        'CREATIVE',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should apply defaults in the request body', async () => {
     const engine = new InworldEngine();
     const fetchMock = vi.fn().mockResolvedValue({

--- a/packages/voice/tests/VoiceEngineAdapter.test.ts
+++ b/packages/voice/tests/VoiceEngineAdapter.test.ts
@@ -1556,7 +1556,7 @@ describe('VoiceEngineAdapter', () => {
       const adapter = new VoiceEngineAdapter(options);
       adapter.updateOptions({
         inworldApiUrl: 'https://example.com/tts/v1/voice',
-        inworldModel: 'inworld-tts-1.5-mini',
+        inworldModel: 'inworld-tts-2-flash',
         inworldAudioEncoding: 'LINEAR16',
         inworldSampleRateHertz: 24000,
         inworldBitRate: 96000,
@@ -1571,7 +1571,7 @@ describe('VoiceEngineAdapter', () => {
       expect(mockEngine.setApiEndpoint).toHaveBeenCalledWith(
         'https://example.com/tts/v1/voice',
       );
-      expect(mockEngine.setModel).toHaveBeenCalledWith('inworld-tts-1.5-mini');
+      expect(mockEngine.setModel).toHaveBeenCalledWith('inworld-tts-2-flash');
       expect(mockEngine.setAudioEncoding).toHaveBeenCalledWith('LINEAR16');
       expect(mockEngine.setSampleRateHertz).toHaveBeenCalledWith(24000);
       expect(mockEngine.setBitRate).toHaveBeenCalledWith(96000);


### PR DESCRIPTION
## Summary
Add `inworld-tts-2-flash` as an explicit option in the Voice package and its React example, while keeping `inworld-tts-2` as the default.

- Export an autocomplete-friendly `InworldModel` type while preserving custom model strings.
- Omit the unsupported delivery mode when using Flash, and disable that control in the example. Switching back to TTS-2 restores the control.
- Replace deprecated TTS 1.5 example choices with Flash and update the English/Japanese documentation.
- Cover the REST request, audio decoding, model switching, and adapter option updates.

## Compatibility
Uses the existing non-streaming `POST /tts/v1/voice` endpoint and voice selection flow. Provider model availability and request/response compatibility were checked against the [model catalog](https://docs.inworld.ai/tts/tts-models) and [speech API reference](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech).

Prepare `@aituber-onair/voice` 0.21.0 with a changelog entry and refreshed root and Voice example lockfiles. Update Core's Voice dependency range to `^0.21.0` for workspace consistency; Core's version and example features remain unchanged. Conversation APIs are outside this change.

## Validation
- Regenerated the root lockfile with `npm install --package-lock-only` and verified `npm ci`.
- Repository-wide checks in order: `npm run fmt`, `npm run lint`, `npm run test`, `npm run build`.
- Voice suite: 38 test files / 352 tests passed.
- Voice React example: `npm run build` passed.
- Browser verification: Flash is selectable, Delivery Mode is disabled for Flash and re-enabled when switching back to TTS-2.
- Public release scan and contextual disclosure review: no findings. Local TODOs and screenshots are Git-ignored.

Live provider audio generation, playback quality, and latency were not tested because no API credential was supplied.
